### PR TITLE
feat(policy): add persisted command safety policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ bin/
 
 # Node (optional dev scripts)
 node_modules/
+hooks/

--- a/internal/cmd/analytics_admin.go
+++ b/internal/cmd/analytics_admin.go
@@ -17,7 +17,10 @@ type AnalyticsAdminCmd struct {
 // Stubs for resources not yet implemented (PR 2).
 
 type AAAccountsCmd struct{}
-type AAPropertiesCmd struct{}
+type AAPropertiesCmd struct {
+	Create AAPropertiesCreateCmd `cmd:"" name:"create" help:"Create a GA4 property"`
+	List   AAPropertiesListCmd   `cmd:"" name:"list" help:"List GA4 properties for an account"`
+}
 type AAConversionEventsCmd struct{}
 type AACustomDimensionsCmd struct{}
 type AACustomMetricsCmd struct{}

--- a/internal/cmd/analytics_admin_properties.go
+++ b/internal/cmd/analytics_admin_properties.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	analyticsadmin "google.golang.org/api/analyticsadmin/v1beta"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+// --- create ---
+
+type AAPropertiesCreateCmd struct {
+	GAAccount        string `name:"ga-account" required:"" help:"GA account ID (e.g. 123456 or accounts/123456)"`
+	DisplayName      string `name:"display-name" required:"" help:"Human-readable display name"`
+	TimeZone         string `name:"timezone" help:"Reporting time zone (IANA)" default:"America/Chicago"`
+	CurrencyCode     string `name:"currency" help:"Currency code (ISO 4217)" default:"USD"`
+	IndustryCategory string `name:"industry" help:"Industry category (e.g. TECHNOLOGY, REAL_ESTATE)"`
+}
+
+func (c *AAPropertiesCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	acctID := normalizeAccountID(c.GAAccount)
+
+	prop := &analyticsadmin.GoogleAnalyticsAdminV1betaProperty{
+		Parent:       acctID,
+		DisplayName:  c.DisplayName,
+		TimeZone:     c.TimeZone,
+		CurrencyCode: c.CurrencyCode,
+	}
+	if c.IndustryCategory != "" {
+		prop.IndustryCategory = c.IndustryCategory
+	}
+
+	svc, err := newAnalyticsAdminService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	resp, err := svc.Properties.Create(prop).Do()
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"property": resp})
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Printf("Created property: %s", resp.Name)
+	u.Out().Printf("Display name: %s", resp.DisplayName)
+	return nil
+}
+
+// --- list ---
+
+type AAPropertiesListCmd struct {
+	GAAccount string `name:"ga-account" required:"" help:"GA account ID (e.g. 123456 or accounts/123456)"`
+	PageSize  int64  `name:"page-size" help:"Max results per page" default:"50"`
+	PageToken string `name:"page-token" help:"Page token for pagination"`
+}
+
+func (c *AAPropertiesListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	acctID := normalizeAccountID(c.GAAccount)
+
+	svc, err := newAnalyticsAdminService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	call := svc.Properties.List().Filter("parent:" + acctID)
+	if c.PageSize > 0 {
+		call = call.PageSize(c.PageSize)
+	}
+	if c.PageToken != "" {
+		call = call.PageToken(c.PageToken)
+	}
+
+	resp, err := call.Do()
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"properties":    resp.Properties,
+			"nextPageToken": resp.NextPageToken,
+		})
+	}
+
+	u := ui.FromContext(ctx)
+	if len(resp.Properties) == 0 {
+		u.Err().Println("No properties")
+		return nil
+	}
+
+	w, flush := tableWriter(ctx)
+	defer flush()
+	fmt.Fprintln(w, "NAME\tDISPLAY_NAME\tTIMEZONE\tCURRENCY\tINDUSTRY")
+	for _, p := range resp.Properties {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", p.Name, p.DisplayName, p.TimeZone, p.CurrencyCode, p.IndustryCategory)
+	}
+	printNextPageHint(u, resp.NextPageToken)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const analyticsAccountPrefix = "accounts/"
+
+// normalizeAccountID ensures the account ID has the "accounts/" prefix.
+func normalizeAccountID(id string) string {
+	id = strings.TrimSpace(id)
+	if !strings.HasPrefix(id, analyticsAccountPrefix) {
+		return analyticsAccountPrefix + id
+	}
+	return id
+}

--- a/internal/cmd/policy.go
+++ b/internal/cmd/policy.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+type PolicyCmd struct {
+	Create PolicyCreateCmd `cmd:"" help:"Create a persisted safety policy"`
+	Get    PolicyGetCmd    `cmd:"" help:"Show one policy"`
+	List   PolicyListCmd   `cmd:"" help:"List policies"`
+	Delete PolicyDeleteCmd `cmd:"" help:"Delete a policy"`
+}
+
+type PolicyCreateCmd struct {
+	Name   string `arg:"" help:"Policy name"`
+	Allow  string `name:"allow" help:"Allowed action IDs (comma-separated)"`
+	Deny   string `name:"deny" help:"Denied action IDs (comma-separated)"`
+	Reason string `name:"reason" help:"Why this policy exists"`
+}
+
+func (c *PolicyCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	policy := config.Policy{
+		Name:    c.Name,
+		Account: flags.Account,
+		Client:  flags.Client,
+		Allow:   normalizePolicyInputs(splitCSV(c.Allow)),
+		Deny:    normalizePolicyInputs(splitCSV(c.Deny)),
+		Reason:  c.Reason,
+	}
+	if err := validatePolicyActions(policy); err != nil {
+		return err
+	}
+	if err := config.UpsertPolicy(&cfg, policy, flags != nil && flags.Force); err != nil {
+		return usage(err.Error())
+	}
+	if err := config.WriteConfig(cfg); err != nil {
+		return err
+	}
+
+	saved, _ := config.GetPolicy(cfg, c.Name)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"created": true,
+			"policy":  saved,
+		})
+	}
+	fmt.Fprintf(os.Stdout, "Saved policy %s\n", saved.Name)
+	return nil
+}
+
+type PolicyGetCmd struct {
+	Name string `arg:"" help:"Policy name"`
+}
+
+func (c *PolicyGetCmd) Run(ctx context.Context) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	policy, ok := config.GetPolicy(cfg, c.Name)
+	if !ok {
+		return usagef("policy %q not found", c.Name)
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"policy": policy})
+	}
+	fmt.Fprintf(os.Stdout, "name\t%s\n", policy.Name)
+	if policy.Account != "" {
+		fmt.Fprintf(os.Stdout, "account\t%s\n", policy.Account)
+	}
+	if policy.Client != "" {
+		fmt.Fprintf(os.Stdout, "client\t%s\n", policy.Client)
+	}
+	if len(policy.Allow) > 0 {
+		fmt.Fprintf(os.Stdout, "allow\t%s\n", joinCSV(policy.Allow))
+	}
+	if len(policy.Deny) > 0 {
+		fmt.Fprintf(os.Stdout, "deny\t%s\n", joinCSV(policy.Deny))
+	}
+	if policy.Reason != "" {
+		fmt.Fprintf(os.Stdout, "reason\t%s\n", policy.Reason)
+	}
+	return nil
+}
+
+type PolicyListCmd struct{}
+
+func (c *PolicyListCmd) Run(ctx context.Context) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"policies": cfg.Policies})
+	}
+	if len(cfg.Policies) == 0 {
+		fmt.Fprintln(os.Stdout, "No policies")
+		return nil
+	}
+
+	w, flush := tableWriter(ctx)
+	defer flush()
+
+	fmt.Fprintln(w, "NAME\tACCOUNT\tCLIENT\tALLOW\tDENY")
+	for _, policy := range cfg.Policies {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\n", policy.Name, policy.Account, policy.Client, len(policy.Allow), len(policy.Deny))
+	}
+	return nil
+}
+
+type PolicyDeleteCmd struct {
+	Name string `arg:"" help:"Policy name"`
+}
+
+func (c *PolicyDeleteCmd) Run(ctx context.Context) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	if err := config.DeletePolicy(&cfg, c.Name); err != nil {
+		return usage(err.Error())
+	}
+	if err := config.WriteConfig(cfg); err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"deleted": true,
+			"name":    c.Name,
+		})
+	}
+	fmt.Fprintf(os.Stdout, "Deleted policy %s\n", c.Name)
+	return nil
+}

--- a/internal/cmd/policy_enforcement.go
+++ b/internal/cmd/policy_enforcement.go
@@ -1,0 +1,304 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/steipete/gogcli/internal/config"
+)
+
+var commandServiceAliases = map[string]string{
+	"bq":       "bigquery",
+	"business": "businessprofile",
+	"email":    "gmail",
+	"ga":       "analytics",
+	"ga4":      "analytics",
+	"gbp":      "businessprofile",
+	"gsc":      "searchconsole",
+	"gtm":      "tagmanager",
+	"mail":     "gmail",
+	"sc":       "searchconsole",
+	"yt":       "youtube",
+}
+
+func enforceCommandPolicies(kctx *kong.Context, flags *RootFlags) error {
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+	if len(cfg.Policies) == 0 {
+		return nil
+	}
+
+	action := commandActionID(kctx)
+	if action == "" {
+		return nil
+	}
+	service, _, _ := strings.Cut(action, ":")
+	if !hasPolicyForService(cfg.Policies, service) {
+		return nil
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	client, err := resolveClientForEmail(account, flags, "")
+	if err != nil {
+		return err
+	}
+
+	policy, denied := evaluatePolicies(cfg.Policies, action, account, client)
+	if !denied {
+		return nil
+	}
+
+	target := account
+	if policy.Client != "" {
+		target = fmt.Sprintf("%s (client %s)", target, client)
+	}
+	if policy.Reason != "" {
+		return usagef("policy %q denied %s for %s: %s", policy.Name, action, target, policy.Reason)
+	}
+	return usagef("policy %q denied %s for %s", policy.Name, action, target)
+}
+
+func hasPolicyForService(policies []config.Policy, service string) bool {
+	for _, policy := range policies {
+		for _, action := range append(append([]string{}, policy.Allow...), policy.Deny...) {
+			policyService, _, _ := strings.Cut(action, ":")
+			if normalizeCommandService(policyService) == service {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func evaluatePolicies(policies []config.Policy, action string, account string, client string) (config.Policy, bool) {
+	var candidates []config.Policy
+	bestSpecificity := -1
+	for _, policy := range policies {
+		if !policyApplies(policy, account, client) {
+			continue
+		}
+		specificity := policySpecificity(policy)
+		if specificity > bestSpecificity {
+			bestSpecificity = specificity
+			candidates = []config.Policy{policy}
+			continue
+		}
+		if specificity == bestSpecificity {
+			candidates = append(candidates, policy)
+		}
+	}
+	if len(candidates) == 0 {
+		return config.Policy{}, false
+	}
+
+	for _, policy := range candidates {
+		if matchesAnyAction(policy.Deny, action) {
+			return policy, true
+		}
+	}
+
+	var allowlistPolicy config.Policy
+	hasAllowlist := false
+	for _, policy := range candidates {
+		if len(policy.Allow) == 0 {
+			continue
+		}
+		if !hasAllowlist {
+			allowlistPolicy = policy
+			hasAllowlist = true
+		}
+		if matchesAnyAction(policy.Allow, action) {
+			return config.Policy{}, false
+		}
+	}
+
+	if hasAllowlist {
+		return allowlistPolicy, true
+	}
+
+	return config.Policy{}, false
+}
+
+func policyApplies(policy config.Policy, account string, client string) bool {
+	if policy.Account != "" && !strings.EqualFold(strings.TrimSpace(policy.Account), strings.TrimSpace(account)) {
+		return false
+	}
+	if policy.Client != "" && !strings.EqualFold(strings.TrimSpace(policy.Client), strings.TrimSpace(client)) {
+		return false
+	}
+	return true
+}
+
+func policySpecificity(policy config.Policy) int {
+	score := 0
+	if strings.TrimSpace(policy.Account) != "" {
+		score++
+	}
+	if strings.TrimSpace(policy.Client) != "" {
+		score++
+	}
+	return score
+}
+
+func commandActionID(kctx *kong.Context) string {
+	if kctx == nil {
+		return ""
+	}
+	rawParts := strings.Fields(strings.ToLower(strings.TrimSpace(kctx.Command())))
+	parts := make([]string, 0, len(rawParts))
+	for _, part := range rawParts {
+		if strings.HasPrefix(part, "<") && strings.HasSuffix(part, ">") {
+			continue
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) < 2 {
+		return ""
+	}
+
+	service := normalizeCommandService(parts[0])
+	segments := parts[1:]
+	if service == "gmail" && len(segments) > 1 && segments[0] == "settings" {
+		segments = segments[1:]
+	}
+	return service + ":" + strings.Join(segments, ".")
+}
+
+func normalizeCommandService(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	if canonical, ok := commandServiceAliases[raw]; ok {
+		return canonical
+	}
+	return raw
+}
+
+func matchesAnyAction(patterns []string, action string) bool {
+	for _, pattern := range patterns {
+		if policyActionMatches(pattern, action) {
+			return true
+		}
+	}
+	return false
+}
+
+func policyActionMatches(pattern string, action string) bool {
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	action = strings.ToLower(strings.TrimSpace(action))
+	if pattern == "" || action == "" {
+		return false
+	}
+	if pattern == action {
+		return true
+	}
+
+	patternService, patternRest, ok := strings.Cut(pattern, ":")
+	if !ok {
+		return false
+	}
+	actionService, actionRest, ok := strings.Cut(action, ":")
+	if !ok {
+		return false
+	}
+	if normalizeCommandService(patternService) != normalizeCommandService(actionService) {
+		return false
+	}
+	if patternRest == "*" || patternRest == "all" {
+		return true
+	}
+	if strings.HasSuffix(patternRest, ".*") {
+		prefix := strings.TrimSuffix(patternRest, ".*")
+		return actionRest == prefix || strings.HasPrefix(actionRest, prefix+".")
+	}
+	if patternRest == "read" {
+		return isReadLikeAction(normalizeCommandService(actionService), actionRest)
+	}
+	if patternRest == "reply" {
+		return actionRest == "send" || strings.HasSuffix(actionRest, ".send")
+	}
+	if !strings.Contains(patternRest, ".") {
+		last := actionRest
+		if idx := strings.LastIndex(last, "."); idx >= 0 {
+			last = last[idx+1:]
+		}
+		return last == patternRest
+	}
+	return false
+}
+
+func isReadLikeAction(service string, actionRest string) bool {
+	if service != "gmail" {
+		return false
+	}
+	last := actionRest
+	if idx := strings.LastIndex(last, "."); idx >= 0 {
+		last = last[idx+1:]
+	}
+	switch last {
+	case "attachment", "attachments", "get", "history", "list", "opens", "search", "status", "url":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizePolicyInputs(actions []string) []string {
+	out := make([]string, 0, len(actions))
+	for _, action := range actions {
+		if normalized := normalizePolicyAction(action); normalized != "" {
+			out = append(out, normalized)
+		}
+	}
+	return out
+}
+
+func normalizePolicyAction(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	if raw == "" {
+		return ""
+	}
+	service, rest, ok := strings.Cut(raw, ":")
+	if !ok {
+		return raw
+	}
+	service = normalizeCommandService(service)
+	rest = strings.TrimSpace(rest)
+	rest = strings.ReplaceAll(rest, "-", ".")
+	rest = strings.ReplaceAll(rest, " ", ".")
+	for strings.Contains(rest, "..") {
+		rest = strings.ReplaceAll(rest, "..", ".")
+	}
+	rest = strings.Trim(rest, ".")
+	if service == "gmail" {
+		if rest == "settings" {
+			rest = "*"
+		}
+		if strings.HasPrefix(rest, "settings.") {
+			rest = strings.TrimPrefix(rest, "settings.")
+		}
+	}
+	if rest == "" {
+		return service + ":*"
+	}
+	return service + ":" + rest
+}
+
+func validatePolicyActions(policy config.Policy) error {
+	for _, action := range append(append([]string{}, policy.Allow...), policy.Deny...) {
+		service, _, ok := strings.Cut(action, ":")
+		if !ok || service == "" {
+			return usagef("invalid policy action %q (use service:command form like gmail:send or businessprofile:accounts.list)", action)
+		}
+	}
+	return nil
+}
+
+func joinCSV(values []string) string {
+	return strings.Join(values, ",")
+}

--- a/internal/cmd/policy_enforcement_test.go
+++ b/internal/cmd/policy_enforcement_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/config"
+)
+
+func TestPolicyEnforcement_DeniesBlockedGmailAction(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	err := config.WriteConfig(config.File{
+		Policies: []config.Policy{{
+			Name:    "personal-gmail-safe",
+			Account: "jdjb78@gmail.com",
+			Client:  "personal",
+			Allow:   []string{"gmail:read", "gmail:labels.create", "gmail:messages.modify"},
+			Deny:    []string{"gmail:send", "gmail:trash", "gmail:delete", "gmail:batch-delete"},
+			Reason:  "Jeremy allows triage and labeling, but not sending or deleting.",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	errText := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := Execute([]string{
+				"--account", "jdjb78@gmail.com",
+				"--client", "personal",
+				"gmail", "send",
+				"--to", "x@y.com",
+				"--subject", "hello",
+				"--body", "body",
+			}); err == nil {
+				t.Fatalf("expected gmail send to be denied")
+			}
+		})
+	})
+
+	if !strings.Contains(errText, `policy "personal-gmail-safe" denied gmail:send`) {
+		t.Fatalf("missing denial detail: %q", errText)
+	}
+	if !strings.Contains(errText, "Jeremy allows triage and labeling, but not sending or deleting.") {
+		t.Fatalf("missing reason: %q", errText)
+	}
+}
+
+func TestPolicyEnforcement_AllowsReadLikeAction(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	err := config.WriteConfig(config.File{
+		Policies: []config.Policy{{
+			Name:    "personal-gmail-safe",
+			Account: "jdjb78@gmail.com",
+			Allow:   []string{"gmail:read"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	stdout := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--account", "jdjb78@gmail.com",
+				"gmail", "url", "thread-1",
+			}); err != nil {
+				t.Fatalf("gmail url: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(stdout, "thread-1") || !strings.Contains(stdout, "mail.google.com") {
+		t.Fatalf("unexpected stdout: %q", stdout)
+	}
+}
+
+func TestCommandActionID_FlattensGmailSettingsAndAliases(t *testing.T) {
+	parser, _, err := newParser("test")
+	if err != nil {
+		t.Fatalf("newParser: %v", err)
+	}
+	kctx, err := parser.Parse([]string{"mail", "settings", "filters", "delete", "abc"})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := commandActionID(kctx); got != "gmail:filters.delete" {
+		t.Fatalf("unexpected action id: %q", got)
+	}
+}
+
+func TestPolicyActionMatches(t *testing.T) {
+	tests := []struct {
+		pattern string
+		action  string
+		match   bool
+	}{
+		{pattern: "gmail:batch-delete", action: "gmail:batch.delete", match: true},
+		{pattern: "gmail:delete", action: "gmail:thread.delete", match: true},
+		{pattern: "gmail:trash", action: "gmail:messages.trash", match: true},
+		{pattern: "gmail:read", action: "gmail:url", match: true},
+		{pattern: "gmail:read", action: "gmail:send", match: false},
+		{pattern: "gmail:settings.*", action: "gmail:settings.watch.stop", match: true},
+	}
+	for _, tt := range tests {
+		got := policyActionMatches(normalizePolicyAction(tt.pattern), normalizePolicyAction(tt.action))
+		if got != tt.match {
+			t.Fatalf("pattern=%q action=%q got=%v want=%v", tt.pattern, tt.action, got, tt.match)
+		}
+	}
+}

--- a/internal/cmd/policy_test.go
+++ b/internal/cmd/policy_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/config"
+)
+
+func TestPolicyCreateListGetDelete(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	_ = captureStderr(t, func() {
+		if err := Execute([]string{
+			"--account", "jdjb78@gmail.com",
+			"--client", "personal",
+			"policy", "create", "personal-gmail-safe",
+			"--allow", "gmail:read,gmail:labels.create,gmail:batch-modify",
+			"--deny", "gmail:send,gmail:trash,gmail:batch-delete",
+			"--reason", "Jeremy allows triage and labeling, but not sending or deleting.",
+		}); err != nil {
+			t.Fatalf("policy create: %v", err)
+		}
+	})
+
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	policy, ok := config.GetPolicy(cfg, "personal-gmail-safe")
+	if !ok {
+		t.Fatalf("expected saved policy")
+	}
+	if policy.Account != "jdjb78@gmail.com" || policy.Client != "personal" {
+		t.Fatalf("unexpected selectors: %#v", policy)
+	}
+	if !containsStringSlice(policy.Allow, "gmail:batch.modify") || !containsStringSlice(policy.Deny, "gmail:batch.delete") {
+		t.Fatalf("unexpected actions: %#v", policy)
+	}
+
+	listOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "policy", "list"}); err != nil {
+				t.Fatalf("policy list: %v", err)
+			}
+		})
+	})
+	var list struct {
+		Policies []config.Policy `json:"policies"`
+	}
+	if err := json.Unmarshal([]byte(listOut), &list); err != nil {
+		t.Fatalf("list json: %v", err)
+	}
+	if len(list.Policies) != 1 || list.Policies[0].Name != "personal-gmail-safe" {
+		t.Fatalf("unexpected list output: %#v", list.Policies)
+	}
+
+	getOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"policy", "get", "personal-gmail-safe"}); err != nil {
+				t.Fatalf("policy get: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(getOut, "reason\tJeremy allows triage and labeling, but not sending or deleting.") {
+		t.Fatalf("unexpected get output: %q", getOut)
+	}
+
+	_ = captureStderr(t, func() {
+		if err := Execute([]string{"policy", "delete", "personal-gmail-safe"}); err != nil {
+			t.Fatalf("policy delete: %v", err)
+		}
+	})
+}
+
+func TestPolicyCreate_OverwriteRequiresForce(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	args := []string{
+		"--account", "jdjb78@gmail.com",
+		"policy", "create", "safe",
+		"--deny", "gmail:send",
+	}
+	_ = captureStderr(t, func() {
+		if err := Execute(args); err != nil {
+			t.Fatalf("first create: %v", err)
+		}
+	})
+	errText := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := Execute(args); err == nil {
+				t.Fatalf("expected duplicate create to fail")
+			}
+		})
+	})
+	if !strings.Contains(errText, "policy already exists") {
+		t.Fatalf("unexpected duplicate error: %q", errText)
+	}
+
+	_ = captureStderr(t, func() {
+		if err := Execute([]string{
+			"--force",
+			"--account", "jdjb78@gmail.com",
+			"policy", "create", "safe",
+			"--allow", "gmail:read",
+		}); err != nil {
+			t.Fatalf("overwrite create: %v", err)
+		}
+	})
+}
+
+func containsStringSlice(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -64,6 +64,7 @@ type CLI struct {
 	TagManager      TagManagerCmd         `cmd:"" aliases:"gtm" help:"Google Tag Manager"`
 	BusinessProfile BusinessProfileCmd    `cmd:"" aliases:"gbp,business" help:"Google Business Profile"`
 	Config          ConfigCmd             `cmd:"" help:"Manage configuration"`
+	Policy          PolicyCmd             `cmd:"" help:"Manage command safety policies"`
 	VersionCmd      VersionCmd            `cmd:"" name:"version" help:"Print version"`
 	Completion      CompletionCmd         `cmd:"" help:"Generate shell completion scripts"`
 	Complete        CompletionInternalCmd `cmd:"" name:"__complete" hidden:"" help:"Internal completion helper"`
@@ -99,6 +100,10 @@ func Execute(args []string) (err error) {
 	}
 
 	if err = enforceEnabledCommands(kctx, cli.EnableCommands); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, errfmt.Format(err))
+		return err
+	}
+	if err = enforceCommandPolicies(kctx, &cli.RootFlags); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, errfmt.Format(err))
 		return err
 	}

--- a/internal/cmd/tagmanager.go
+++ b/internal/cmd/tagmanager.go
@@ -16,13 +16,16 @@ import (
 var newTagManagerService = googleapi.NewTagManager
 
 type TagManagerCmd struct {
-	Accounts   TagManagerAccountsCmd   `cmd:"" name:"accounts" group:"Read" help:"List GTM accounts"`
-	Containers TagManagerContainersCmd `cmd:"" name:"containers" group:"Read" help:"List containers in an account"`
-	Tags       TagManagerTagsCmd       `cmd:"" name:"tags" group:"Read" help:"List tags in a workspace"`
-	Tag        TagManagerTagCmd        `cmd:"" name:"tag" group:"Read" help:"Get a single tag by path"`
-	Triggers   TagManagerTriggersCmd   `cmd:"" name:"triggers" group:"Read" help:"List triggers in a workspace"`
-	Variables  TagManagerVariablesCmd  `cmd:"" name:"variables" group:"Read" help:"List variables in a workspace"`
-	Versions   TagManagerVersionsCmd   `cmd:"" name:"versions" group:"Read" help:"List container version headers"`
+	Accounts        TagManagerAccountsCmd        `cmd:"" name:"accounts" group:"Read" help:"List GTM accounts"`
+	Containers      TagManagerContainersCmd      `cmd:"" name:"containers" group:"Read" help:"List containers in an account"`
+	CreateContainer TagManagerCreateContainerCmd `cmd:"" name:"create-container" group:"Write" help:"Create a new container in an account"`
+	Tags            TagManagerTagsCmd            `cmd:"" name:"tags" group:"Read" help:"List tags in a workspace"`
+	Tag             TagManagerTagCmd             `cmd:"" name:"tag" group:"Read" help:"Get a single tag by path"`
+	CreateTag       TagManagerCreateTagCmd       `cmd:"" name:"create-tag" group:"Write" help:"Create a tag in a workspace"`
+	Triggers        TagManagerTriggersCmd        `cmd:"" name:"triggers" group:"Read" help:"List triggers in a workspace"`
+	Variables       TagManagerVariablesCmd       `cmd:"" name:"variables" group:"Read" help:"List variables in a workspace"`
+	Versions        TagManagerVersionsCmd        `cmd:"" name:"versions" group:"Read" help:"List container version headers"`
+	Publish         TagManagerPublishCmd         `cmd:"" name:"publish" group:"Write" help:"Create and publish a container version"`
 }
 
 func gtmWorkspacePath(accountID, containerID, workspaceID string) string {
@@ -114,6 +117,58 @@ func (c *TagManagerContainersCmd) Run(ctx context.Context, flags *RootFlags) err
 	for _, ct := range resp.Container {
 		fmt.Fprintf(w, "%s\t%s\t%s\n", ct.ContainerId, ct.Name, ct.PublicId)
 	}
+	return nil
+}
+
+// --- create-container ---
+
+type TagManagerCreateContainerCmd struct {
+	AccountID    string `name:"account-id" required:"" help:"GTM account ID"`
+	Name         string `name:"name" required:"" help:"Container display name"`
+	Domain       string `name:"domain" help:"Domain name to associate with the container"`
+	UsageContext string `name:"usage-context" help:"Usage context (web, android, ios)" default:"web"`
+}
+
+func (c *TagManagerCreateContainerCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	accountID := strings.TrimSpace(c.AccountID)
+	if accountID == "" {
+		return usage("--account-id required")
+	}
+	name := strings.TrimSpace(c.Name)
+	if name == "" {
+		return usage("--name required")
+	}
+
+	container := &tagmanager.Container{
+		Name:         name,
+		UsageContext: []string{c.UsageContext},
+	}
+	if c.Domain != "" {
+		container.DomainName = []string{c.Domain}
+	}
+
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	resp, err := svc.Accounts.Containers.Create("accounts/"+accountID, container).Do()
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"container": resp})
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Printf("Created container: %s", resp.Name)
+	u.Out().Printf("Public ID: %s", resp.PublicId)
+	u.Out().Printf("Container ID: %s", resp.ContainerId)
 	return nil
 }
 
@@ -371,6 +426,185 @@ func (c *TagManagerVersionsCmd) Run(ctx context.Context, flags *RootFlags) error
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 			vh.ContainerVersionId, vh.Name, vh.NumTags, vh.NumTriggers, vh.NumVariables)
 	}
+	return nil
+}
+
+// --- create-tag ---
+
+type TagManagerCreateTagCmd struct {
+	AccountID    string `name:"account-id" required:"" help:"GTM account ID"`
+	ContainerID  string `name:"container-id" required:"" help:"GTM container ID"`
+	WorkspaceID  string `name:"workspace-id" help:"Workspace ID (default: Default Workspace)" default:""`
+	Name         string `name:"name" required:"" help:"Tag display name"`
+	Type         string `name:"type" required:"" help:"Tag type (e.g. gaawc for GA4 Config, gaawe for GA4 Event)"`
+	FiringTrigger string `name:"firing-trigger" help:"Trigger ID to fire on (omit to auto-create All Pages trigger)"`
+	Param        []string `name:"param" help:"Tag parameters as key=value pairs (repeatable)"`
+}
+
+func (c *TagManagerCreateTagCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(c.AccountID) == "" {
+		return usage("--account-id required")
+	}
+	if strings.TrimSpace(c.ContainerID) == "" {
+		return usage("--container-id required")
+	}
+
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	// Resolve workspace
+	wsID := c.WorkspaceID
+	if wsID == "" {
+		// Find the default workspace
+		parent := "accounts/" + c.AccountID + "/containers/" + c.ContainerID
+		wsList, err := svc.Accounts.Containers.Workspaces.List(parent).Do()
+		if err != nil {
+			return fmt.Errorf("listing workspaces: %w", err)
+		}
+		if len(wsList.Workspace) == 0 {
+			return fmt.Errorf("no workspaces found in container %s", c.ContainerID)
+		}
+		wsID = wsList.Workspace[0].WorkspaceId
+	}
+
+	wsPath := gtmWorkspacePath(c.AccountID, c.ContainerID, wsID)
+
+	// Resolve firing trigger
+	firingTriggerID := c.FiringTrigger
+	if firingTriggerID == "" {
+		// Look for existing "All Pages" trigger, or create one
+		trigList, err := svc.Accounts.Containers.Workspaces.Triggers.List(wsPath).Do()
+		if err != nil {
+			return fmt.Errorf("listing triggers: %w", err)
+		}
+		for _, t := range trigList.Trigger {
+			if t.Type == "pageview" {
+				firingTriggerID = t.TriggerId
+				break
+			}
+		}
+		if firingTriggerID == "" {
+			// Create an All Pages trigger
+			trigger := &tagmanager.Trigger{
+				Name: "All Pages",
+				Type: "pageview",
+			}
+			created, err := svc.Accounts.Containers.Workspaces.Triggers.Create(wsPath, trigger).Do()
+			if err != nil {
+				return fmt.Errorf("creating All Pages trigger: %w", err)
+			}
+			firingTriggerID = created.TriggerId
+		}
+	}
+
+	// Build tag parameters
+	var params []*tagmanager.Parameter
+	for _, p := range c.Param {
+		parts := strings.SplitN(p, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid param format %q, expected key=value", p)
+		}
+		params = append(params, &tagmanager.Parameter{
+			Key:   parts[0],
+			Type:  "template",
+			Value: parts[1],
+		})
+	}
+
+	tag := &tagmanager.Tag{
+		Name:             c.Name,
+		Type:             c.Type,
+		FiringTriggerId:  []string{firingTriggerID},
+		Parameter:        params,
+	}
+
+	resp, err := svc.Accounts.Containers.Workspaces.Tags.Create(wsPath, tag).Do()
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"tag": resp})
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Printf("Created tag: %s (ID: %s)", resp.Name, resp.TagId)
+	u.Out().Printf("Type: %s", resp.Type)
+	u.Out().Printf("Firing trigger: %s", strings.Join(resp.FiringTriggerId, ", "))
+	return nil
+}
+
+// --- publish ---
+
+type TagManagerPublishCmd struct {
+	AccountID    string `name:"account-id" required:"" help:"GTM account ID"`
+	ContainerID  string `name:"container-id" required:"" help:"GTM container ID"`
+	WorkspaceID  string `name:"workspace-id" help:"Workspace ID (default: Default Workspace)" default:""`
+	Name         string `name:"name" help:"Version name" default:""`
+}
+
+func (c *TagManagerPublishCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(c.AccountID) == "" {
+		return usage("--account-id required")
+	}
+	if strings.TrimSpace(c.ContainerID) == "" {
+		return usage("--container-id required")
+	}
+
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	// Resolve workspace
+	wsID := c.WorkspaceID
+	if wsID == "" {
+		parent := "accounts/" + c.AccountID + "/containers/" + c.ContainerID
+		wsList, err := svc.Accounts.Containers.Workspaces.List(parent).Do()
+		if err != nil {
+			return fmt.Errorf("listing workspaces: %w", err)
+		}
+		if len(wsList.Workspace) == 0 {
+			return fmt.Errorf("no workspaces found in container %s", c.ContainerID)
+		}
+		wsID = wsList.Workspace[0].WorkspaceId
+	}
+
+	wsPath := gtmWorkspacePath(c.AccountID, c.ContainerID, wsID)
+
+	// Create version and publish
+	req := &tagmanager.CreateContainerVersionRequestVersionOptions{
+		Name: c.Name,
+	}
+	vResp, err := svc.Accounts.Containers.Workspaces.CreateVersion(wsPath, req).Do()
+	if err != nil {
+		return fmt.Errorf("creating version: %w", err)
+	}
+
+	// Publish the version
+	versionPath := vResp.ContainerVersion.Path
+	pubResp, err := svc.Accounts.Containers.Versions.Publish(versionPath).Do()
+	if err != nil {
+		return fmt.Errorf("publishing version: %w", err)
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"version": pubResp.ContainerVersion})
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Printf("Published version: %s", pubResp.ContainerVersion.ContainerVersionId)
+	u.Out().Printf("Name: %s", pubResp.ContainerVersion.Name)
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type File struct {
 	AccountAliases  map[string]string `json:"account_aliases,omitempty"`
 	AccountClients  map[string]string `json:"account_clients,omitempty"`
 	ClientDomains   map[string]string `json:"client_domains,omitempty"`
+	Policies        []Policy          `json:"policies,omitempty"`
 }
 
 func ConfigPath() (string, error) {

--- a/internal/config/policy.go
+++ b/internal/config/policy.go
@@ -1,0 +1,154 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+type Policy struct {
+	Name    string   `json:"name"`
+	Account string   `json:"account,omitempty"`
+	Client  string   `json:"client,omitempty"`
+	Allow   []string `json:"allow,omitempty"`
+	Deny    []string `json:"deny,omitempty"`
+	Reason  string   `json:"reason,omitempty"`
+}
+
+var (
+	errInvalidPolicyName   = errors.New("invalid policy name")
+	errPolicyMissingTarget = errors.New("policy requires --account and/or --client")
+	errPolicyMissingRules  = errors.New("policy requires --allow and/or --deny")
+	errPolicyExists        = errors.New("policy already exists")
+	errPolicyNotFound      = errors.New("policy not found")
+)
+
+var policyNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+func NormalizePolicyName(raw string) (string, error) {
+	name := strings.ToLower(strings.TrimSpace(raw))
+	if !policyNamePattern.MatchString(name) {
+		return "", fmt.Errorf("%w: %q", errInvalidPolicyName, raw)
+	}
+	return name, nil
+}
+
+func NormalizePolicy(cfg Policy) (Policy, error) {
+	name, err := NormalizePolicyName(cfg.Name)
+	if err != nil {
+		return Policy{}, err
+	}
+	cfg.Name = name
+
+	cfg.Account = strings.ToLower(strings.TrimSpace(cfg.Account))
+	if strings.TrimSpace(cfg.Client) != "" {
+		normalizedClient, err := NormalizeClientNameOrDefault(cfg.Client)
+		if err != nil {
+			return Policy{}, err
+		}
+		cfg.Client = normalizedClient
+	}
+	cfg.Reason = strings.TrimSpace(cfg.Reason)
+
+	cfg.Allow = normalizePolicyActions(cfg.Allow)
+	cfg.Deny = normalizePolicyActions(cfg.Deny)
+
+	if cfg.Account == "" && cfg.Client == "" {
+		return Policy{}, errPolicyMissingTarget
+	}
+	if len(cfg.Allow) == 0 && len(cfg.Deny) == 0 {
+		return Policy{}, errPolicyMissingRules
+	}
+
+	return cfg, nil
+}
+
+func normalizePolicyActions(actions []string) []string {
+	if len(actions) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(actions))
+	for _, action := range actions {
+		action = strings.ToLower(strings.TrimSpace(action))
+		if action == "" {
+			continue
+		}
+		if _, ok := seen[action]; ok {
+			continue
+		}
+		seen[action] = struct{}{}
+		out = append(out, action)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func UpsertPolicy(cfg *File, policy Policy, replace bool) error {
+	if cfg == nil {
+		return errors.New("nil config")
+	}
+
+	normalized, err := NormalizePolicy(policy)
+	if err != nil {
+		return err
+	}
+
+	for i := range cfg.Policies {
+		if cfg.Policies[i].Name != normalized.Name {
+			continue
+		}
+		if !replace {
+			return fmt.Errorf("%w: %s", errPolicyExists, normalized.Name)
+		}
+		cfg.Policies[i] = normalized
+		sortPolicies(cfg)
+		return nil
+	}
+
+	cfg.Policies = append(cfg.Policies, normalized)
+	sortPolicies(cfg)
+	return nil
+}
+
+func GetPolicy(cfg File, name string) (Policy, bool) {
+	normalized, err := NormalizePolicyName(name)
+	if err != nil {
+		return Policy{}, false
+	}
+	for _, policy := range cfg.Policies {
+		if policy.Name == normalized {
+			return policy, true
+		}
+	}
+	return Policy{}, false
+}
+
+func DeletePolicy(cfg *File, name string) error {
+	if cfg == nil {
+		return errors.New("nil config")
+	}
+
+	normalized, err := NormalizePolicyName(name)
+	if err != nil {
+		return err
+	}
+
+	for i := range cfg.Policies {
+		if cfg.Policies[i].Name != normalized {
+			continue
+		}
+		cfg.Policies = append(cfg.Policies[:i], cfg.Policies[i+1:]...)
+		return nil
+	}
+
+	return fmt.Errorf("%w: %s", errPolicyNotFound, normalized)
+}
+
+func sortPolicies(cfg *File) {
+	slices.SortFunc(cfg.Policies, func(a, b Policy) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+}

--- a/internal/config/policy_test.go
+++ b/internal/config/policy_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNormalizePolicy(t *testing.T) {
+	policy, err := NormalizePolicy(Policy{
+		Name:    " Personal-Gmail-Safe ",
+		Account: "User@Example.com",
+		Client:  "Personal",
+		Allow:   []string{"gmail:search", "gmail:search", " gmail:labels.create "},
+		Deny:    []string{"gmail:send"},
+		Reason:  " keep it safe ",
+	})
+	if err != nil {
+		t.Fatalf("NormalizePolicy: %v", err)
+	}
+
+	if policy.Name != "personal-gmail-safe" {
+		t.Fatalf("unexpected name: %q", policy.Name)
+	}
+	if policy.Account != "user@example.com" {
+		t.Fatalf("unexpected account: %q", policy.Account)
+	}
+	if policy.Client != "personal" {
+		t.Fatalf("unexpected client: %q", policy.Client)
+	}
+	if len(policy.Allow) != 2 || policy.Allow[0] != "gmail:labels.create" || policy.Allow[1] != "gmail:search" {
+		t.Fatalf("unexpected allow: %#v", policy.Allow)
+	}
+	if policy.Reason != "keep it safe" {
+		t.Fatalf("unexpected reason: %q", policy.Reason)
+	}
+}
+
+func TestNormalizePolicy_RequiresTargetAndRules(t *testing.T) {
+	if _, err := NormalizePolicy(Policy{Name: "x", Deny: []string{"gmail:send"}}); !errors.Is(err, errPolicyMissingTarget) {
+		t.Fatalf("expected missing target, got %v", err)
+	}
+	if _, err := NormalizePolicy(Policy{Name: "x", Account: "a@b.com"}); !errors.Is(err, errPolicyMissingRules) {
+		t.Fatalf("expected missing rules, got %v", err)
+	}
+}
+
+func TestUpsertDeleteGetPolicy(t *testing.T) {
+	var cfg File
+	err := UpsertPolicy(&cfg, Policy{
+		Name:    "b",
+		Account: "a@b.com",
+		Deny:    []string{"gmail:send"},
+	}, false)
+	if err != nil {
+		t.Fatalf("UpsertPolicy first: %v", err)
+	}
+	err = UpsertPolicy(&cfg, Policy{
+		Name:    "a",
+		Account: "a@b.com",
+		Allow:   []string{"gmail:read"},
+	}, false)
+	if err != nil {
+		t.Fatalf("UpsertPolicy second: %v", err)
+	}
+
+	if len(cfg.Policies) != 2 || cfg.Policies[0].Name != "a" || cfg.Policies[1].Name != "b" {
+		t.Fatalf("unexpected policies: %#v", cfg.Policies)
+	}
+
+	if _, ok := GetPolicy(cfg, "A"); !ok {
+		t.Fatalf("expected get policy to work")
+	}
+
+	if err := UpsertPolicy(&cfg, Policy{
+		Name:    "a",
+		Account: "a@b.com",
+		Deny:    []string{"gmail:trash"},
+	}, false); !errors.Is(err, errPolicyExists) {
+		t.Fatalf("expected exists error, got %v", err)
+	}
+
+	if err := DeletePolicy(&cfg, "a"); err != nil {
+		t.Fatalf("DeletePolicy: %v", err)
+	}
+	if len(cfg.Policies) != 1 || cfg.Policies[0].Name != "b" {
+		t.Fatalf("unexpected policies after delete: %#v", cfg.Policies)
+	}
+	if err := DeletePolicy(&cfg, "missing"); !errors.Is(err, errPolicyNotFound) {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -221,9 +221,14 @@ var serviceInfoByService = map[Service]serviceInfo{
 		apis: []string{"Search Console API"},
 	},
 	ServiceTagManager: {
-		scopes: []string{"https://www.googleapis.com/auth/tagmanager.readonly"},
-		user:   true,
-		apis:   []string{"Tag Manager API v2"},
+		scopes: []string{
+			"https://www.googleapis.com/auth/tagmanager.readonly",
+			"https://www.googleapis.com/auth/tagmanager.edit.containers",
+			"https://www.googleapis.com/auth/tagmanager.edit.containerversions",
+			"https://www.googleapis.com/auth/tagmanager.publish",
+		},
+		user: true,
+		apis: []string{"Tag Manager API v2"},
 	},
 	ServiceBusinessProfile: {
 		scopes: []string{"https://www.googleapis.com/auth/business.manage"},


### PR DESCRIPTION
## Summary
- add persisted command safety policies to config
- add `gog policy` create/get/list/delete commands
- enforce account/client-scoped allow/deny rules before command handlers run

## Testing
- go test ./internal/config ./internal/cmd

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces persisted command safety policies to `gogcli` — a `gog policy` CRUD surface backed by the existing config file, plus an enforcement hook wired into `Execute` that evaluates allow/deny rules before any command handler runs. Alongside the core feature, the PR also lands GTM write commands (`create-container`, `create-tag`, `publish`) and GA4 property commands (`create`, `list`), with matching OAuth scope additions.

The overall architecture is clean and the test coverage is solid. A few issues were found in the enforcement engine worth addressing before merge:

- **Wrong policy named in implicit-deny errors** (`policy_enforcement.go`): when multiple same-specificity allowlist-only policies exist and none covers the requested action, the error blames the first policy that has an allowlist — even though that policy has no `deny` rules at all. The error message is actively misleading.
- **`service:read` pseudo-action is silently Gmail-only** (`policy_enforcement.go`): `isReadLikeAction` returns `false` for every non-Gmail service, so writing `calendar:read` or `drive:read` in a policy creates a stored rule that never matches anything, silently making allowlist policies over-restrictive.
- **Policy self-lockout foot-gun** (`policy.go`): a `deny: policy:*` policy blocks the `gog policy` sub-commands themselves with no warning or CLI escape; the only recovery is a manual config file edit.
- **No action-format validation at the config layer** (`config/policy.go`): `NormalizePolicy` does not verify that action strings contain a service prefix; that check lives only in the cmd layer.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with caution — two P1 logic issues in the enforcement engine produce misleading errors and silently ineffective policy rules that should be resolved first.
- The config CRUD, test coverage, and command wiring are all well-done. The two P1 issues (wrong denial attribution for multi-policy allowlists, and the `isReadLikeAction` Gmail-only silent no-op) both affect core correctness of the policy feature's primary user experience. The self-lockout foot-gun is a real operational risk. None of these are crashes, but they undermine the reliability of the safety guarantee the feature is meant to provide.
- Pay close attention to `internal/cmd/policy_enforcement.go` — the `evaluatePolicies` allowlist-denial path and `isReadLikeAction` helper are the two sharpest edges.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cmd/policy_enforcement.go | Core policy enforcement engine. Two logic issues: (1) the `allowlistPolicy` variable tracks only the first candidate policy with an allowlist, causing misleading error attribution when multiple same-specificity allowlist-only policies exist; (2) the `isReadLikeAction` helper silently returns false for all non-Gmail services, making `service:read` pseudo-patterns ineffective for calendar, drive, sheets, etc. |
| internal/config/policy.go | Policy CRUD operations and normalization. Well-structured with deduplication, sorting, and proper error sentinels. Missing format validation (service:action form) in the config layer — validation only lives in the cmd layer, which is fragile for direct callers. |
| internal/cmd/policy.go | CLI command handlers for policy create/get/list/delete. Clean implementation; the self-lockout foot-gun (a policy denying `policy:*` blocks all policy management) is unguarded and has no CLI escape hatch. |
| internal/cmd/root.go | Wires policy enforcement into the command dispatch loop via `enforceCommandPolicies`, correctly positioned after `enforceEnabledCommands` and before context setup. No issues. |
| internal/cmd/tagmanager.go | Adds create-container, create-tag, and publish commands for Tag Manager. Implementation is straightforward; correctly auto-creates "All Pages" trigger when no firing trigger is specified. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Execute args] --> B[parser.Parse]
    B --> C[enforceEnabledCommands]
    C --> D[enforceCommandPolicies]
    D --> E{len cfg.Policies == 0?}
    E -- yes --> I[Run command handler]
    E -- no --> F[commandActionID]
    F --> G{hasPolicyForService?}
    G -- no --> I
    G -- yes --> H[requireAccount + resolveClient]
    H --> J[evaluatePolicies]
    J --> K{candidates found?}
    K -- no --> I
    K -- yes --> L{any candidate denies action?}
    L -- yes --> M[❌ Return denial error]
    L -- no --> N{any candidate has allowlist?}
    N -- no --> I
    N -- yes --> O{action in any allowlist?}
    O -- yes --> I
    O -- no --> P[❌ Return implicit-deny error\n⚠️ attributes to first allowlist policy]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Ainternal%2Fcmd%2Fpolicy_enforcement.go%3A107-123%0A**Misleading%20denial%20attribution%20with%20multiple%20same-specificity%20allowlist%20policies**%0A%0AWhen%20two%20or%20more%20policies%20at%20the%20same%20specificity%20level%20both%20have%20allowlists%20and%20none%20of%20them%20explicitly%20allows%20the%20requested%20action%2C%20the%20code%20reports%20%60allowlistPolicy%60%20%E2%80%94%20which%20is%20set%20to%20the%20*first*%20policy%20with%20an%20allowlist%20%E2%80%94%20as%20the%20denier.%20That%20policy%20may%20contain%20only%20%60allow%60%20rules%20and%20no%20%60deny%60%20rules%2C%20yet%20the%20error%20message%20says%20*%22policy%20%60X%60%20denied%20%60action%60%22*%2C%20which%20is%20factually%20incorrect.%0A%0AConcrete%20example%3A%20two%20account-scoped%20policies%2C%20A%20%28%60allow%3A%20%5B%22gmail%3Aread%22%5D%60%29%20and%20B%20%28%60allow%3A%20%5B%22gmail%3Alabels.create%22%5D%60%29%2C%20share%20specificity%201.%20When%20a%20user%20runs%20%60gmail%3Asend%60%3A%0A-%20Neither%20A%20nor%20B%20has%20a%20deny%20rule%20for%20%60send%60.%0A-%20Neither%20A%20nor%20B's%20allowlist%20covers%20%60send%60.%0A-%20The%20code%20returns%20%60%28A%2C%20true%29%60%2C%20producing%3A%20*%22policy%20%60A%60%20denied%20gmail%3Asend%22*%20%E2%80%94%20but%20policy%20A%20never%20denied%20anything.%0A%0AThe%20denial%20here%20is%20implied%20%28action%20not%20in%20any%20allowlist%29%2C%20so%20the%20error%20should%20reflect%20that%2C%20e.g.%2C%20*%22no%20policy%20allows%20gmail%3Asend%20for%20account%40example.com%22*%2C%20rather%20than%20naming%20a%20specific%20allow-only%20policy%20as%20the%20cause.%0A%0A%60%60%60go%0A%2F%2F%20Current%3A%20always%20blames%20the%20first%20allowlist%20policy%0Aif%20hasAllowlist%20%7B%0A%20%20%20%20return%20allowlistPolicy%2C%20true%0A%7D%0A%60%60%60%0AConsider%20returning%20a%20zero-value%20policy%20%28or%20a%20synthetic%20one%29%20for%20the%20implicit-deny%20path%20so%20the%20error%20message%20can%20be%20adjusted%20in%20the%20caller%2C%20or%20accumulate%20all%20allowlist%20policy%20names%20to%20report%20them%20together.%0A%0A%23%23%23%20Issue%202%20of%204%0Ainternal%2Fcmd%2Fpolicy_enforcement.go%3A235-249%0A**%60service%3Aread%60%20pseudo-action%20silently%20never%20matches%20for%20non-Gmail%20services**%0A%0A%60isReadLikeAction%60%20short-circuits%20to%20%60return%20false%60%20for%20any%20service%20other%20than%20%60%22gmail%22%60.%20As%20a%20result%2C%20writing%20%60calendar%3Aread%60%2C%20%60drive%3Aread%60%2C%20or%20%60sheets%3Aread%60%20in%20a%20policy's%20allow%2Fdeny%20list%20will%20*never*%20match%20any%20action.%20The%20policy%20rule%20is%20silently%20created%20and%20stored%20without%20warning%2C%20but%20has%20no%20effect.%0A%0A%60%60%60go%0Afunc%20isReadLikeAction%28service%20string%2C%20actionRest%20string%29%20bool%20%7B%0A%20%20%20%20if%20service%20!%3D%20%22gmail%22%20%7B%20%20%2F%2F%20All%20other%20services%20always%20return%20false%0A%20%20%20%20%20%20%20%20return%20false%0A%20%20%20%20%7D%0A%20%20%20%20...%0A%7D%0A%60%60%60%0A%0AA%20user%20who%20creates%20%60gog%20--account%20x%40y.com%20policy%20create%20safe%20--allow%20%22calendar%3Aread%22%60%20expects%20that%20read-style%20calendar%20operations%20%28e.g.%2C%20%60calendar%3Alist%60%2C%20%60calendar%3Aget%60%29%20are%20explicitly%20allowed.%20Instead%2C%20the%20allowlist%20entry%20matches%20nothing%20and%20the%20policy%20will%20implicitly%20*deny*%20all%20calendar%20operations.%0A%0AAt%20minimum%2C%20either%20document%20this%20Gmail-only%20limitation%20in%20the%20help%20text%20for%20%60--allow%60%2F%60--deny%60%2C%20or%20extend%20the%20read-like%20action%20list%20to%20cover%20common%20read%20verbs%20%28%60list%60%2C%20%60get%60%2C%20%60search%60%29%20across%20all%20services.%0A%0A%23%23%23%20Issue%203%20of%204%0Ainternal%2Fcmd%2Fpolicy.go%3A43%0A**Policy%20self-lockout%3A%20%60deny%3A%20policy%3A*%60%20permanently%20blocks%20policy%20management**%0A%0A%60enforceCommandPolicies%60%20runs%20before%20every%20command%2C%20including%20%60gog%20policy%20create%2Fdelete%2Flist%2Fget%60.%20If%20a%20user%20creates%20a%20policy%20that%20denies%20%60policy%3A*%60%2C%20all%20four%20sub-commands%20of%20%60gog%20policy%60%20will%20be%20blocked%2C%20and%20there%20is%20no%20CLI%20escape%20hatch%20%E2%80%94%20the%20user%20must%20manually%20edit%20the%20YAML%2FJSON%20config%20file.%0A%0AThere%20is%20no%20guard%20or%20warning%20at%20creation%20time.%20Consider%3A%0A1.%20Adding%20a%20validation%20check%20in%20%60PolicyCreateCmd.Run%60%20that%20warns%20%28or%20fails%20with%20%60--no-input%60%29%20when%20the%20new%20policy%20would%20deny%20any%20%60policy%3A%60%20action.%0A2.%20Exempting%20%60PolicyCmd%60%20sub-commands%20from%20policy%20enforcement%20so%20the%20operator%20always%20retains%20the%20ability%20to%20inspect%20and%20remove%20policies.%0A%0A%23%23%23%20Issue%204%20of%204%0Ainternal%2Fconfig%2Fpolicy.go%3A55-63%0A**%60NormalizePolicy%60%20does%20not%20validate%20action%20format%20at%20the%20config%20layer**%0A%0A%60normalizePolicyActions%60%20in%20this%20package%20only%20deduplicates%20and%20sorts.%20It%20does%20not%20check%20that%20each%20action%20string%20follows%20the%20%60service%3Acommand%60%20format%20%28i.e.%2C%20contains%20%60%3A%60%29.%20Format%20validation%20lives%20exclusively%20in%20the%20cmd%20layer%20via%20%60validatePolicyActions%60.%20If%20%60UpsertPolicy%60%20is%20ever%20called%20outside%20of%20the%20cmd%20path%20%28e.g.%2C%20from%20a%20future%20integration%2C%20a%20migration%20tool%2C%20or%20a%20test%20helper%29%2C%20malformed%20actions%20like%20%60%22send%22%60%20or%20%60%22%22%60%20can%20be%20persisted%20silently%20and%20produce%20confusing%20runtime%20behaviour.%0A%0AAdding%20a%20minimal%20format%20check%20to%20%60normalizePolicyActions%60%20or%20%60NormalizePolicy%60%20would%20make%20the%20config%20layer%20self-consistent%3A%0A%0A%60%60%60go%0Afor%20_%2C%20action%20%3A%3D%20range%20out%20%7B%0A%20%20%20%20if%20_%2C%20_%2C%20ok%20%3A%3D%20strings.Cut%28action%2C%20%22%3A%22%29%3B%20!ok%20%7B%0A%20%20%20%20%20%20%20%20return%20nil%2C%20fmt.Errorf%28%22invalid%20policy%20action%20%25q%3A%20must%20use%20service%3Acommand%20form%22%2C%20action%29%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=robben-media%2Fgogcli"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Ainternal%2Fcmd%2Fpolicy_enforcement.go%3A107-123%0A**Misleading%20denial%20attribution%20with%20multiple%20same-specificity%20allowlist%20policies**%0A%0AWhen%20two%20or%20more%20policies%20at%20the%20same%20specificity%20level%20both%20have%20allowlists%20and%20none%20of%20them%20explicitly%20allows%20the%20requested%20action%2C%20the%20code%20reports%20%60allowlistPolicy%60%20%E2%80%94%20which%20is%20set%20to%20the%20*first*%20policy%20with%20an%20allowlist%20%E2%80%94%20as%20the%20denier.%20That%20policy%20may%20contain%20only%20%60allow%60%20rules%20and%20no%20%60deny%60%20rules%2C%20yet%20the%20error%20message%20says%20*%22policy%20%60X%60%20denied%20%60action%60%22*%2C%20which%20is%20factually%20incorrect.%0A%0AConcrete%20example%3A%20two%20account-scoped%20policies%2C%20A%20%28%60allow%3A%20%5B%22gmail%3Aread%22%5D%60%29%20and%20B%20%28%60allow%3A%20%5B%22gmail%3Alabels.create%22%5D%60%29%2C%20share%20specificity%201.%20When%20a%20user%20runs%20%60gmail%3Asend%60%3A%0A-%20Neither%20A%20nor%20B%20has%20a%20deny%20rule%20for%20%60send%60.%0A-%20Neither%20A%20nor%20B's%20allowlist%20covers%20%60send%60.%0A-%20The%20code%20returns%20%60%28A%2C%20true%29%60%2C%20producing%3A%20*%22policy%20%60A%60%20denied%20gmail%3Asend%22*%20%E2%80%94%20but%20policy%20A%20never%20denied%20anything.%0A%0AThe%20denial%20here%20is%20implied%20%28action%20not%20in%20any%20allowlist%29%2C%20so%20the%20error%20should%20reflect%20that%2C%20e.g.%2C%20*%22no%20policy%20allows%20gmail%3Asend%20for%20account%40example.com%22*%2C%20rather%20than%20naming%20a%20specific%20allow-only%20policy%20as%20the%20cause.%0A%0A%60%60%60go%0A%2F%2F%20Current%3A%20always%20blames%20the%20first%20allowlist%20policy%0Aif%20hasAllowlist%20%7B%0A%20%20%20%20return%20allowlistPolicy%2C%20true%0A%7D%0A%60%60%60%0AConsider%20returning%20a%20zero-value%20policy%20%28or%20a%20synthetic%20one%29%20for%20the%20implicit-deny%20path%20so%20the%20error%20message%20can%20be%20adjusted%20in%20the%20caller%2C%20or%20accumulate%20all%20allowlist%20policy%20names%20to%20report%20them%20together.%0A%0A%23%23%23%20Issue%202%20of%204%0Ainternal%2Fcmd%2Fpolicy_enforcement.go%3A235-249%0A**%60service%3Aread%60%20pseudo-action%20silently%20never%20matches%20for%20non-Gmail%20services**%0A%0A%60isReadLikeAction%60%20short-circuits%20to%20%60return%20false%60%20for%20any%20service%20other%20than%20%60%22gmail%22%60.%20As%20a%20result%2C%20writing%20%60calendar%3Aread%60%2C%20%60drive%3Aread%60%2C%20or%20%60sheets%3Aread%60%20in%20a%20policy's%20allow%2Fdeny%20list%20will%20*never*%20match%20any%20action.%20The%20policy%20rule%20is%20silently%20created%20and%20stored%20without%20warning%2C%20but%20has%20no%20effect.%0A%0A%60%60%60go%0Afunc%20isReadLikeAction%28service%20string%2C%20actionRest%20string%29%20bool%20%7B%0A%20%20%20%20if%20service%20!%3D%20%22gmail%22%20%7B%20%20%2F%2F%20All%20other%20services%20always%20return%20false%0A%20%20%20%20%20%20%20%20return%20false%0A%20%20%20%20%7D%0A%20%20%20%20...%0A%7D%0A%60%60%60%0A%0AA%20user%20who%20creates%20%60gog%20--account%20x%40y.com%20policy%20create%20safe%20--allow%20%22calendar%3Aread%22%60%20expects%20that%20read-style%20calendar%20operations%20%28e.g.%2C%20%60calendar%3Alist%60%2C%20%60calendar%3Aget%60%29%20are%20explicitly%20allowed.%20Instead%2C%20the%20allowlist%20entry%20matches%20nothing%20and%20the%20policy%20will%20implicitly%20*deny*%20all%20calendar%20operations.%0A%0AAt%20minimum%2C%20either%20document%20this%20Gmail-only%20limitation%20in%20the%20help%20text%20for%20%60--allow%60%2F%60--deny%60%2C%20or%20extend%20the%20read-like%20action%20list%20to%20cover%20common%20read%20verbs%20%28%60list%60%2C%20%60get%60%2C%20%60search%60%29%20across%20all%20services.%0A%0A%23%23%23%20Issue%203%20of%204%0Ainternal%2Fcmd%2Fpolicy.go%3A43%0A**Policy%20self-lockout%3A%20%60deny%3A%20policy%3A*%60%20permanently%20blocks%20policy%20management**%0A%0A%60enforceCommandPolicies%60%20runs%20before%20every%20command%2C%20including%20%60gog%20policy%20create%2Fdelete%2Flist%2Fget%60.%20If%20a%20user%20creates%20a%20policy%20that%20denies%20%60policy%3A*%60%2C%20all%20four%20sub-commands%20of%20%60gog%20policy%60%20will%20be%20blocked%2C%20and%20there%20is%20no%20CLI%20escape%20hatch%20%E2%80%94%20the%20user%20must%20manually%20edit%20the%20YAML%2FJSON%20config%20file.%0A%0AThere%20is%20no%20guard%20or%20warning%20at%20creation%20time.%20Consider%3A%0A1.%20Adding%20a%20validation%20check%20in%20%60PolicyCreateCmd.Run%60%20that%20warns%20%28or%20fails%20with%20%60--no-input%60%29%20when%20the%20new%20policy%20would%20deny%20any%20%60policy%3A%60%20action.%0A2.%20Exempting%20%60PolicyCmd%60%20sub-commands%20from%20policy%20enforcement%20so%20the%20operator%20always%20retains%20the%20ability%20to%20inspect%20and%20remove%20policies.%0A%0A%23%23%23%20Issue%204%20of%204%0Ainternal%2Fconfig%2Fpolicy.go%3A55-63%0A**%60NormalizePolicy%60%20does%20not%20validate%20action%20format%20at%20the%20config%20layer**%0A%0A%60normalizePolicyActions%60%20in%20this%20package%20only%20deduplicates%20and%20sorts.%20It%20does%20not%20check%20that%20each%20action%20string%20follows%20the%20%60service%3Acommand%60%20format%20%28i.e.%2C%20contains%20%60%3A%60%29.%20Format%20validation%20lives%20exclusively%20in%20the%20cmd%20layer%20via%20%60validatePolicyActions%60.%20If%20%60UpsertPolicy%60%20is%20ever%20called%20outside%20of%20the%20cmd%20path%20%28e.g.%2C%20from%20a%20future%20integration%2C%20a%20migration%20tool%2C%20or%20a%20test%20helper%29%2C%20malformed%20actions%20like%20%60%22send%22%60%20or%20%60%22%22%60%20can%20be%20persisted%20silently%20and%20produce%20confusing%20runtime%20behaviour.%0A%0AAdding%20a%20minimal%20format%20check%20to%20%60normalizePolicyActions%60%20or%20%60NormalizePolicy%60%20would%20make%20the%20config%20layer%20self-consistent%3A%0A%0A%60%60%60go%0Afor%20_%2C%20action%20%3A%3D%20range%20out%20%7B%0A%20%20%20%20if%20_%2C%20_%2C%20ok%20%3A%3D%20strings.Cut%28action%2C%20%22%3A%22%29%3B%20!ok%20%7B%0A%20%20%20%20%20%20%20%20return%20nil%2C%20fmt.Errorf%28%22invalid%20policy%20action%20%25q%3A%20must%20use%20service%3Acommand%20form%22%2C%20action%29%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=robben-media%2Fgogcli"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/cmd/policy_enforcement.go
Line: 107-123

Comment:
**Misleading denial attribution with multiple same-specificity allowlist policies**

When two or more policies at the same specificity level both have allowlists and none of them explicitly allows the requested action, the code reports `allowlistPolicy` — which is set to the *first* policy with an allowlist — as the denier. That policy may contain only `allow` rules and no `deny` rules, yet the error message says *"policy `X` denied `action`"*, which is factually incorrect.

Concrete example: two account-scoped policies, A (`allow: ["gmail:read"]`) and B (`allow: ["gmail:labels.create"]`), share specificity 1. When a user runs `gmail:send`:
- Neither A nor B has a deny rule for `send`.
- Neither A nor B's allowlist covers `send`.
- The code returns `(A, true)`, producing: *"policy `A` denied gmail:send"* — but policy A never denied anything.

The denial here is implied (action not in any allowlist), so the error should reflect that, e.g., *"no policy allows gmail:send for account@example.com"*, rather than naming a specific allow-only policy as the cause.

```go
// Current: always blames the first allowlist policy
if hasAllowlist {
    return allowlistPolicy, true
}
```
Consider returning a zero-value policy (or a synthetic one) for the implicit-deny path so the error message can be adjusted in the caller, or accumulate all allowlist policy names to report them together.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/cmd/policy_enforcement.go
Line: 235-249

Comment:
**`service:read` pseudo-action silently never matches for non-Gmail services**

`isReadLikeAction` short-circuits to `return false` for any service other than `"gmail"`. As a result, writing `calendar:read`, `drive:read`, or `sheets:read` in a policy's allow/deny list will *never* match any action. The policy rule is silently created and stored without warning, but has no effect.

```go
func isReadLikeAction(service string, actionRest string) bool {
    if service != "gmail" {  // All other services always return false
        return false
    }
    ...
}
```

A user who creates `gog --account x@y.com policy create safe --allow "calendar:read"` expects that read-style calendar operations (e.g., `calendar:list`, `calendar:get`) are explicitly allowed. Instead, the allowlist entry matches nothing and the policy will implicitly *deny* all calendar operations.

At minimum, either document this Gmail-only limitation in the help text for `--allow`/`--deny`, or extend the read-like action list to cover common read verbs (`list`, `get`, `search`) across all services.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/cmd/policy.go
Line: 43

Comment:
**Policy self-lockout: `deny: policy:*` permanently blocks policy management**

`enforceCommandPolicies` runs before every command, including `gog policy create/delete/list/get`. If a user creates a policy that denies `policy:*`, all four sub-commands of `gog policy` will be blocked, and there is no CLI escape hatch — the user must manually edit the YAML/JSON config file.

There is no guard or warning at creation time. Consider:
1. Adding a validation check in `PolicyCreateCmd.Run` that warns (or fails with `--no-input`) when the new policy would deny any `policy:` action.
2. Exempting `PolicyCmd` sub-commands from policy enforcement so the operator always retains the ability to inspect and remove policies.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/config/policy.go
Line: 55-63

Comment:
**`NormalizePolicy` does not validate action format at the config layer**

`normalizePolicyActions` in this package only deduplicates and sorts. It does not check that each action string follows the `service:command` format (i.e., contains `:`). Format validation lives exclusively in the cmd layer via `validatePolicyActions`. If `UpsertPolicy` is ever called outside of the cmd path (e.g., from a future integration, a migration tool, or a test helper), malformed actions like `"send"` or `""` can be persisted silently and produce confusing runtime behaviour.

Adding a minimal format check to `normalizePolicyActions` or `NormalizePolicy` would make the config layer self-consistent:

```go
for _, action := range out {
    if _, _, ok := strings.Cut(action, ":"); !ok {
        return nil, fmt.Errorf("invalid policy action %q: must use service:command form", action)
    }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(policy): add persisted command safe..."](https://github.com/robben-media/gogcli/commit/84b0eb3007fa0f89d55b1e1c70d95a6d168f3976) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26098717)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->