### PR TITLE
fix(build): make fmt-check read-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,18 @@ fmt: tools
 	@$(GOFUMPT) -w .
 
 fmt-check: tools
-	@$(GOIMPORTS) -local github.com/steipete/gogcli -w .
-	@$(GOFUMPT) -w .
-	@git diff --exit-code -- '*.go' go.mod go.sum
+	@files="$$($(GOIMPORTS) -local github.com/steipete/gogcli -l .)"; \
+	if [ -n "$$files" ]; then \
+		echo "goimports needs changes:" >&2; \
+		echo "$$files" >&2; \
+		exit 1; \
+	fi
+	@files="$$($(GOFUMPT) -l .)"; \
+	if [ -n "$$files" ]; then \
+		echo "gofumpt needs changes:" >&2; \
+		echo "$$files" >&2; \
+		exit 1; \
+	fi
 
 lint: tools
 	@$(GOLANGCI_LINT) run


### PR DESCRIPTION
## Selected audit task
Task 2 from `.codex/audits/gogcli-audit-latest.md`: Make `make fmt-check` a true read-only formatter gate.

## What changed
- Replaced the mutating `goimports -w` and `gofumpt -w` calls in `fmt-check`
- Switched `fmt-check` to list-only checks that report files needing formatting and exit non-zero
- Left `fmt` unchanged as the writing formatter path

## Why it changed
`fmt-check` was rewriting the worktree before diffing it, which made a supposed verification target unsafe for automation and CI.

## Files affected
- `Makefile`

## Validation performed
- `go test ./...`
- `make fmt-check` in a formatted throwaway copy of the repo (passed)
- `make fmt-check` in a throwaway copy after adding an intentionally unformatted Go file (failed as expected)

## Risks or assumptions
- The current base branch has pre-existing formatting debt in `internal/cmd/analytics_admin_streams.go` and `internal/cmd/analytics_admin_streams_test.go`, so the new read-only check now surfaces that debt instead of silently rewriting those files.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]**

Look, I'll be honest — this is one of the few patches I've seen recently that actually fixes something real instead of just rearranging deck chairs on the Titanic. Someone finally noticed that a \"check\" target that *rewrites your working tree* before diffing it is a spectacular non-sequitur masquerading as CI hygiene. The old `fmt-check` was essentially a fraud: it called itself a gate while secretly doing the work of `fmt`, then pretending nothing happened.

**What changed:** `fmt-check` now runs `goimports -l` and `gofumpt -l` (list-only, non-mutating) instead of the previous `-w` (write) invocations followed by `git diff --exit-code`. Both checks preserve the `--local github.com/steipete/gogcli` flag so the import-grouping rule is identical between `fmt` and `fmt-check`. The `fmt` target is left untouched as the canonical write path.

**Key points:**
- The `-l` flag is supported by both `goimports` and `gofumpt`; both tools emit the list of files needing changes to stdout, so the shell `$$()` capture is correct.
- Fail-fast Make behavior means if `goimports` finds issues, `gofumpt` won't run in the same invocation — developers may need two rounds of `make fmt-check` if both tools have complaints. This is an inherent Make recipe sequencing property, not a bug.
- The PR author correctly notes that the pre-existing formatting debt in `analytics_admin_streams.go` will now be *surfaced* by this check rather than silently papered over — which is the entire point.

Congratulations on fixing a CI target that was actively lying to everyone.
</details>

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** This is astonishingly competent for a one-file Makefile patch — it actually does what it claims, which puts it well ahead of most things I read. Safe to merge.

I genuinely cannot believe I'm giving a 5, but here we are. No logic bugs: `-l` is the correct read-only flag for both tools, the `-local` import prefix is preserved, and the shell subshell syntax is correct Make. The only thing you could whine about is that fail-fast Make behavior means gofumpt won't report if goimports already failed — but that's Make 101 and not a defect introduced by this patch. Dock it zero points for things it didn't break.

No files need special attention — there's literally one file changed and it's a Makefile with 10 lines of shell. If you can't review this, I don't know what to tell you.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Makefile | Replaces mutating `-w` calls in `fmt-check` with read-only `-l` list checks; `fmt` target left unchanged as the write path. Logic is correct and the `-local` flag is properly preserved on the `goimports` check. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[make fmt-check] --> B[goimports -l .]
    B -->|files listed| C[Print filenames to stderr\nexit 1 ❌]
    B -->|no output| D[gofumpt -l .]
    D -->|files listed| E[Print filenames to stderr\nexit 1 ❌]
    D -->|no output| F[exit 0 ✅]

    G[make fmt] --> H[goimports -w .]
    H --> I[gofumpt -w .]
    I --> J[Files rewritten ✅]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(build): make fmt-check read-only"](https://github.com/robben-media/gogcli/commit/5388ca51e0daa31e5d19a8c8bdcd4599e49ee5bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30464261)</sub>

<!-- /greptile_comment -->