### PR TITLE
fix(cli): honor json for global version

### DIFF
--- a/internal/cmd/execute_version_exitcodes_test.go
+++ b/internal/cmd/execute_version_exitcodes_test.go
@@ -57,6 +57,34 @@ func TestExecute_VersionCommand_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_VersionFlag_JSON(t *testing.T) {
+	origV, origC, origD := version, commit, date
+	t.Cleanup(func() {
+		version = origV
+		commit = origC
+		date = origD
+	})
+	version = "1.2.3"
+	commit = "abc123"
+	date = "2025-12-26T00:00:00Z"
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--version", "--json"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if parsed["version"] != "1.2.3" || parsed["commit"] != "abc123" || parsed["date"] != "2025-12-26T00:00:00Z" {
+		t.Fatalf("unexpected json: %#v", parsed)
+	}
+}
+
 func TestExecute_ExitCodes(t *testing.T) {
 	err := Execute([]string{"--nope"})
 	if err == nil {

--- a/internal/cmd/execute_version_exitcodes_test.go
+++ b/internal/cmd/execute_version_exitcodes_test.go
@@ -85,6 +85,50 @@ func TestExecute_VersionFlag_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_VersionFlag_StopsAtSeparator(t *testing.T) {
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			err := Execute([]string{"--", "--version"})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if ExitCode(err) != 2 {
+				t.Fatalf("expected exit code 2, got %d (err=%v)", ExitCode(err), err)
+			}
+		})
+	})
+	if out != "" {
+		t.Fatalf("expected no version output, got %q", out)
+	}
+}
+
+func TestExecute_VersionFlag_ModeStopsAtSeparator(t *testing.T) {
+	origV, origC, origD := version, commit, date
+	t.Cleanup(func() {
+		version = origV
+		commit = origC
+		date = origD
+	})
+	version = "1.2.3"
+	commit = "abc123"
+	date = ""
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--version", "--", "--json"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if strings.HasPrefix(strings.TrimSpace(out), "{") {
+		t.Fatalf("expected text output, got JSON: %q", out)
+	}
+	if !strings.Contains(out, "1.2.3") {
+		t.Fatalf("unexpected out=%q", out)
+	}
+}
+
 func TestExecute_ExitCodes(t *testing.T) {
 	err := Execute([]string{"--nope"})
 	if err == nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/alecthomas/kong"
@@ -256,6 +257,9 @@ func newUsageError(err error) error {
 
 func hasVersionFlag(args []string) bool {
 	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
 		if arg == "--version" {
 			return true
 		}
@@ -269,6 +273,9 @@ func outputModeFromVersionArgs(args []string) (outfmt.Mode, error) {
 	plainOut := envMode.Plain
 
 	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
 		switch {
 		case arg == "--json":
 			jsonOut = true
@@ -293,12 +300,5 @@ func outputModeFromVersionArgs(args []string) (outfmt.Mode, error) {
 }
 
 func parseFlagBool(value string) (bool, error) {
-	switch strings.TrimSpace(value) {
-	case "1", "t", "T", "true", "TRUE", "True":
-		return true, nil
-	case "0", "f", "F", "false", "FALSE", "False":
-		return false, nil
-	default:
-		return false, fmt.Errorf("invalid bool value %q", value)
-	}
+	return strconv.ParseBool(strings.TrimSpace(value))
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/alecthomas/kong"
 
@@ -32,6 +33,7 @@ type RootFlags struct {
 	EnableCommands string `help:"Comma-separated list of enabled top-level commands (restricts CLI)" default:"${enabled_commands}"`
 	JSON           bool   `help:"Output JSON to stdout (best for scripting)" default:"${json}"`
 	Plain          bool   `help:"Output stable, parseable text to stdout (TSV; no colors)" default:"${plain}"`
+	Version        bool   `help:"Print version and exit"`
 	Force          bool   `help:"Skip confirmations for destructive commands"`
 	NoInput        bool   `help:"Never prompt; fail instead (useful for CI)"`
 	Verbose        bool   `help:"Enable verbose logging"`
@@ -39,8 +41,6 @@ type RootFlags struct {
 
 type CLI struct {
 	RootFlags `embed:""`
-
-	Version kong.VersionFlag `help:"Print version and exit"`
 
 	Auth            AuthCmd               `cmd:"" help:"Auth and credentials"`
 	Groups          GroupsCmd             `cmd:"" help:"Google Groups"`
@@ -76,6 +76,15 @@ func Execute(args []string) (err error) {
 	parser, cli, err := newParser(helpDescription())
 	if err != nil {
 		return err
+	}
+
+	if hasVersionFlag(args) {
+		mode, err := outputModeFromVersionArgs(args)
+		if err != nil {
+			return newUsageError(err)
+		}
+		ctx := outfmt.WithMode(context.Background(), mode)
+		return (&VersionCmd{}).Run(ctx)
 	}
 
 	defer func() {
@@ -243,4 +252,53 @@ func newUsageError(err error) error {
 		return nil
 	}
 	return &ExitError{Code: 2, Err: err}
+}
+
+func hasVersionFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--version" {
+			return true
+		}
+	}
+	return false
+}
+
+func outputModeFromVersionArgs(args []string) (outfmt.Mode, error) {
+	envMode := outfmt.FromEnv()
+	jsonOut := envMode.JSON
+	plainOut := envMode.Plain
+
+	for _, arg := range args {
+		switch {
+		case arg == "--json":
+			jsonOut = true
+		case arg == "--plain":
+			plainOut = true
+		case strings.HasPrefix(arg, "--json="):
+			v, err := parseFlagBool(strings.TrimPrefix(arg, "--json="))
+			if err != nil {
+				return outfmt.Mode{}, err
+			}
+			jsonOut = v
+		case strings.HasPrefix(arg, "--plain="):
+			v, err := parseFlagBool(strings.TrimPrefix(arg, "--plain="))
+			if err != nil {
+				return outfmt.Mode{}, err
+			}
+			plainOut = v
+		}
+	}
+
+	return outfmt.FromFlags(jsonOut, plainOut)
+}
+
+func parseFlagBool(value string) (bool, error) {
+	switch strings.TrimSpace(value) {
+	case "1", "t", "T", "true", "TRUE", "True":
+		return true, nil
+	case "0", "f", "F", "false", "FALSE", "False":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid bool value %q", value)
+	}
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -80,9 +80,9 @@ func Execute(args []string) (err error) {
 	}
 
 	if hasVersionFlag(args) {
-		mode, err := outputModeFromVersionArgs(args)
-		if err != nil {
-			return newUsageError(err)
+		mode, innerErr := outputModeFromVersionArgs(args)
+		if innerErr != nil {
+			return newUsageError(innerErr)
 		}
 		ctx := outfmt.WithMode(context.Background(), mode)
 		return (&VersionCmd{}).Run(ctx)


### PR DESCRIPTION
Selected audit task
- Task 2: Unify global `--version` with structured output modes.

What changed
- Replaced the Kong `VersionFlag` parse-time exit with a normal root `--version` flag plus a narrow pre-parse version path.
- Reused the existing `VersionCmd` renderer so `gog --version --json` matches `gog version --json`.
- Added regression coverage for `gog --version --json`.

Why it changed
- The audit found that `gog --version --json` returned plain text because the previous version flag exited before output mode resolution.

Files affected
- `internal/cmd/root.go`
- `internal/cmd/execute_version_exitcodes_test.go`

Validation performed
- `go test ./internal/cmd -run 'TestExecute_Version|TestExecute_ExitCodes' -count=1`\n- `go run ./cmd/gog --version --json`\n- `go run ./cmd/gog version --json`\n- `go run ./cmd/gog --version`\n- `go test ./...`\n\nRisks or assumptions\n- Scope is limited to global version output handling. Command behavior and the existing `version` subcommand JSON shape are preserved.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]**

Oh great, someone noticed that `gog --version --json` produced plain text because the version flag bailed before output mode resolution — congratulations on finding a bug that should never have shipped. This PR removes the `kong.VersionFlag` parse-time escape hatch and replaces it with a narrow pre-parse intercept in `Execute` that reads `--json`/`--plain` from args before handing off to `VersionCmd.Run`, making `gog --version --json` produce identical output to `gog version --json`. Previous review findings (`--` separator not respected, reinvented `strconv.ParseBool`) are addressed with regression tests added for both.

**Key changes:**
- `kong.VersionFlag` removed; replaced with `Version bool` in `RootFlags` to keep the flag registered with Kong
- `hasVersionFlag` and `outputModeFromVersionArgs` scan args pre-parse, both stopping at `--`
- `parseFlagBool` now delegates to `strconv.ParseBool` (previous finding resolved)
- Three new regression tests: `--version --json` JSON output, `-- --version` separator, `--version -- --json` mode-separator

**Residual issues:**
- `hasVersionFlag` only matches the bare `--version` token; `--version=true` (valid Kong bool syntax) bypasses the intercept path entirely and falls into normal parse, where `cli.Version` is set but never acted upon — a silent regression
- The `\"version\"` key in `kong.Vars` is now dead code — it was used by the old `kong.VersionFlag` for help-text interpolation but the new `Version bool` field doesn't reference `${version}`

I'd say this is almost good enough to merge, but leaving a half-broken `--version=true` path lying around is exactly the kind of thing that makes me lose faith in humanity.
</details>


<h3>Confidence Score: 4/5</h3>

**[Linus Torvalds Mode]** You fixed the obvious bug and addressed the previous review findings — barely passing the bar a first-year intern should clear without being told. Safe to merge if you squint, but `--version=true` silently misbehaving is the kind of sloppy edge case that keeps reviewers awake at night.

This patch is basically fine and the prior P1 issues are gone. But the residual `--version=true` bypass is a genuine behavior regression from the old `kong.VersionFlag` that handled all boolean forms — it's not hypothetical, it's just an unlikely usage you didn't test for. Score stays at 4 because of that unfixed gap and the stale `"version"` var still cluttering `kong.Vars`. Fix those two P2s and this is mergeable without drama.

The only place that needs eyeballs is `internal/cmd/root.go` — specifically `hasVersionFlag` (line 258) and the `"version"` key in `kong.Vars` (line 204). The test file is fine.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/cmd/root.go | Replaces kong.VersionFlag with a plain bool + pre-parse interception path. -- separator and strconv.ParseBool previously flagged issues are fixed; two minor residual issues: --version=true bypasses the intercept, and the now-unused "version" kong.Vars key remains. |
| internal/cmd/execute_version_exitcodes_test.go | Adds three new regression tests: JSON flag output, -- separator stops version detection, and -- separator stops mode flag pickup. Coverage is thorough for the expected usage, though --version=true form is not tested. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Execute(args)"] --> B["newParser + helpDescription()"]
    B --> C{"hasVersionFlag(args)?"}
    C -- "scans until '--'\nmatches '--version'" --> D["outputModeFromVersionArgs(args)"]
    D -- "scans until '--'\nhonors --json / --plain" --> E["outfmt.WithMode(ctx, mode)"]
    E --> F["VersionCmd.Run(ctx)"]
    F -- "IsJSON(ctx)?" --> G["WriteJSON(stdout, {version,commit,date})"]
    F -- "else" --> H["fmt.Fprintln(stdout, VersionString())"]
    C -- false --> I["parser.Parse(args)"]
    I -- error --> J["wrapParseError → ExitError{Code:2}"]
    I -- ok --> K["enforceEnabledCommands\nenforceCommandPolicies"]
    K --> L["outfmt.FromFlags(cli.JSON, cli.Plain)"]
    L --> M["kctx.Run()"]
    C -- "--version=true\nnot intercepted" --> I
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/cmd/root.go`, line 201-204 ([link](https://github.com/robben-media/gogcli/blob/3a48660f1a4701cc401ae90cd8ac453a1955652e/internal/cmd/root.go#L201-L204)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead `"version"` var in `kong.Vars`**

   You left the lights on in a room you demolished. Charming.

   The `"version": VersionString()` entry in `kong.Vars` was only ever consumed by the now-removed `kong.VersionFlag` as its display value. No field in `RootFlags` or any help tag references `${version}` anymore, so this is dead code that misleadingly implies the variable is still used.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/cmd/root.go
   Line: 201-204

   Comment:
   **Dead `"version"` var in `kong.Vars`**

   You left the lights on in a room you demolished. Charming.

   The `"version": VersionString()` entry in `kong.Vars` was only ever consumed by the now-removed `kong.VersionFlag` as its display value. No field in `RootFlags` or any help tag references `${version}` anymore, so this is dead code that misleadingly implies the variable is still used.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robben-media%2Fgogcli%22%20on%20the%20existing%20branch%20%22ai-improvement%2Fversion-json-global%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ai-improvement%2Fversion-json-global%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fcmd%2Froot.go%0ALine%3A%20201-204%0A%0AComment%3A%0A**Dead%20%60%22version%22%60%20var%20in%20%60kong.Vars%60**%0A%0AYou%20left%20the%20lights%20on%20in%20a%20room%20you%20demolished.%20Charming.%0A%0AThe%20%60%22version%22%3A%20VersionString%28%29%60%20entry%20in%20%60kong.Vars%60%20was%20only%20ever%20consumed%20by%20the%20now-removed%20%60kong.VersionFlag%60%20as%20its%20display%20value.%20No%20field%20in%20%60RootFlags%60%20or%20any%20help%20tag%20references%20%60%24%7Bversion%7D%60%20anymore%2C%20so%20this%20is%20dead%20code%20that%20misleadingly%20implies%20the%20variable%20is%20still%20used.%0A%0A%60%60%60suggestion%0A%09%09%22json%22%3A%20%20boolString%28envMode.JSON%29%2C%0A%09%09%22plain%22%3A%20boolString%28envMode.Plain%29%2C%0A%09%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fcmd%2Froot.go%0ALine%3A%20201-204%0A%0AComment%3A%0A**Dead%20%60%22version%22%60%20var%20in%20%60kong.Vars%60**%0A%0AYou%20left%20the%20lights%20on%20in%20a%20room%20you%20demolished.%20Charming.%0A%0AThe%20%60%22version%22%3A%20VersionString%28%29%60%20entry%20in%20%60kong.Vars%60%20was%20only%20ever%20consumed%20by%20the%20now-removed%20%60kong.VersionFlag%60%20as%20its%20display%20value.%20No%20field%20in%20%60RootFlags%60%20or%20any%20help%20tag%20references%20%60%24%7Bversion%7D%60%20anymore%2C%20so%20this%20is%20dead%20code%20that%20misleadingly%20implies%20the%20variable%20is%20still%20used.%0A%0A%60%60%60suggestion%0A%09%09%22json%22%3A%20%20boolString%28envMode.JSON%29%2C%0A%09%09%22plain%22%3A%20boolString%28envMode.Plain%29%2C%0A%09%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=robben-media%2Fgogcli&pr=21&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robben-media%2Fgogcli%22%20on%20the%20existing%20branch%20%22ai-improvement%2Fversion-json-global%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ai-improvement%2Fversion-json-global%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ainternal%2Fcmd%2Froot.go%3A258-268%0A**%60--version%3Dtrue%60%20bypasses%20pre-parse%20path**%0A%0ADid%20you%20even%20test%20this%20with%20a%20single%20extra%20character%3F%20Congratulations%20on%20building%20a%20version%20flag%20that%20only%20works%20if%20you%20spell%20it%20exactly%20right.%0A%0A%60hasVersionFlag%60%20matches%20only%20the%20bare%20token%20%60%22--version%22%60.%20Kong%20accepts%20%60--version%3Dtrue%60%20as%20valid%20bool-flag%20syntax%2C%20so%20%60gog%20--version%3Dtrue%60%20falls%20through%20to%20%60parser.Parse%60%2C%20sets%20%60cli.Version%20%3D%20true%60%2C%20and%20then%20%60kctx.Run%60%20fails%20with%20a%20%22no%20command%20selected%22%20error%20%E2%80%94%20a%20silent%20regression%20from%20%60kong.VersionFlag%60%2C%20which%20handled%20both%20forms.%0A%0AAdd%20a%20check%20for%20%60--version%3Dtrue%60%20%28and%20optionally%20%60--version%3D1%60%2C%20etc.%29%20or%20use%20%60strings.HasPrefix%28arg%2C%20%22--version%3D%22%29%60%20alongside%20the%20existing%20equality%20check.%0A%0A%60%60%60suggestion%0Afunc%20hasVersionFlag%28args%20%5B%5Dstring%29%20bool%20%7B%0A%09for%20_%2C%20arg%20%3A%3D%20range%20args%20%7B%0A%09%09if%20arg%20%3D%3D%20%22--%22%20%7B%0A%09%09%09return%20false%0A%09%09%7D%0A%09%09if%20arg%20%3D%3D%20%22--version%22%20%7C%7C%20strings.HasPrefix%28arg%2C%20%22--version%3D%22%29%20%7B%0A%09%09%09return%20true%0A%09%09%7D%0A%09%7D%0A%09return%20false%0A%7D%0A%60%60%60%0A%0AShip%20it%20if%20you%20want%2C%20but%20don't%20come%20crying%20when%20automation%20breaks.%0A%0A%23%23%23%20Issue%202%20of%202%0Ainternal%2Fcmd%2Froot.go%3A204%0A**Stale%20%60%22version%22%60%20key%20in%20%60kong.Vars%60**%0A%0AYou%20ripped%20out%20%60kong.VersionFlag%60%20and%20forgot%20to%20clean%20up%20after%20yourself%20%E2%80%94%20the%20digital%20equivalent%20of%20leaving%20your%20dishes%20in%20the%20sink.%20This%20is%20the%20kind%20of%20housekeeping%20that%20separates%20engineers%20from%20people%20who%20just%20push%20stuff.%0A%0A%60%22version%22%3A%20VersionString%28%29%60%20was%20injected%20specifically%20for%20%60kong.VersionFlag%60%20to%20embed%20in%20its%20help%20text%20via%20%60%24%7Bversion%7D%60.%20The%20new%20%60Version%20bool%60%20field%20uses%20no%20%60%24%7Bversion%7D%60%20interpolation%2C%20so%20the%20var%20is%20dead%20weight%20computed%20on%20every%20%60Execute%60%20call.%0A%0ARemove%20the%20%60%22version%22%60%20entry%20from%20%60kong.Vars%60%20to%20avoid%20the%20wasted%20%60VersionString%28%29%60%20call%20and%20the%20misleading%20key.%0A%0AYou%20managed%20to%20delete%20the%20flag%20but%20not%20its%20footprint.%20Well%20done.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ainternal%2Fcmd%2Froot.go%3A258-268%0A**%60--version%3Dtrue%60%20bypasses%20pre-parse%20path**%0A%0ADid%20you%20even%20test%20this%20with%20a%20single%20extra%20character%3F%20Congratulations%20on%20building%20a%20version%20flag%20that%20only%20works%20if%20you%20spell%20it%20exactly%20right.%0A%0A%60hasVersionFlag%60%20matches%20only%20the%20bare%20token%20%60%22--version%22%60.%20Kong%20accepts%20%60--version%3Dtrue%60%20as%20valid%20bool-flag%20syntax%2C%20so%20%60gog%20--version%3Dtrue%60%20falls%20through%20to%20%60parser.Parse%60%2C%20sets%20%60cli.Version%20%3D%20true%60%2C%20and%20then%20%60kctx.Run%60%20fails%20with%20a%20%22no%20command%20selected%22%20error%20%E2%80%94%20a%20silent%20regression%20from%20%60kong.VersionFlag%60%2C%20which%20handled%20both%20forms.%0A%0AAdd%20a%20check%20for%20%60--version%3Dtrue%60%20%28and%20optionally%20%60--version%3D1%60%2C%20etc.%29%20or%20use%20%60strings.HasPrefix%28arg%2C%20%22--version%3D%22%29%60%20alongside%20the%20existing%20equality%20check.%0A%0A%60%60%60suggestion%0Afunc%20hasVersionFlag%28args%20%5B%5Dstring%29%20bool%20%7B%0A%09for%20_%2C%20arg%20%3A%3D%20range%20args%20%7B%0A%09%09if%20arg%20%3D%3D%20%22--%22%20%7B%0A%09%09%09return%20false%0A%09%09%7D%0A%09%09if%20arg%20%3D%3D%20%22--version%22%20%7C%7C%20strings.HasPrefix%28arg%2C%20%22--version%3D%22%29%20%7B%0A%09%09%09return%20true%0A%09%09%7D%0A%09%7D%0A%09return%20false%0A%7D%0A%60%60%60%0A%0AShip%20it%20if%20you%20want%2C%20but%20don't%20come%20crying%20when%20automation%20breaks.%0A%0A%23%23%23%20Issue%202%20of%202%0Ainternal%2Fcmd%2Froot.go%3A204%0A**Stale%20%60%22version%22%60%20key%20in%20%60kong.Vars%60**%0A%0AYou%20ripped%20out%20%60kong.VersionFlag%60%20and%20forgot%20to%20clean%20up%20after%20yourself%20%E2%80%94%20the%20digital%20equivalent%20of%20leaving%20your%20dishes%20in%20the%20sink.%20This%20is%20the%20kind%20of%20housekeeping%20that%20separates%20engineers%20from%20people%20who%20just%20push%20stuff.%0A%0A%60%22version%22%3A%20VersionString%28%29%60%20was%20injected%20specifically%20for%20%60kong.VersionFlag%60%20to%20embed%20in%20its%20help%20text%20via%20%60%24%7Bversion%7D%60.%20The%20new%20%60Version%20bool%60%20field%20uses%20no%20%60%24%7Bversion%7D%60%20interpolation%2C%20so%20the%20var%20is%20dead%20weight%20computed%20on%20every%20%60Execute%60%20call.%0A%0ARemove%20the%20%60%22version%22%60%20entry%20from%20%60kong.Vars%60%20to%20avoid%20the%20wasted%20%60VersionString%28%29%60%20call%20and%20the%20misleading%20key.%0A%0AYou%20managed%20to%20delete%20the%20flag%20but%20not%20its%20footprint.%20Well%20done.%0A%0A&repo=robben-media%2Fgogcli&pr=21&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/cmd/root.go:258-268
**`--version=true` bypasses pre-parse path**

Did you even test this with a single extra character? Congratulations on building a version flag that only works if you spell it exactly right.

`hasVersionFlag` matches only the bare token `"--version"`. Kong accepts `--version=true` as valid bool-flag syntax, so `gog --version=true` falls through to `parser.Parse`, sets `cli.Version = true`, and then `kctx.Run` fails with a "no command selected" error — a silent regression from `kong.VersionFlag`, which handled both forms.

Add a check for `--version=true` (and optionally `--version=1`, etc.) or use `strings.HasPrefix(arg, "--version=")` alongside the existing equality check.

```suggestion
func hasVersionFlag(args []string) bool {
	for _, arg := range args {
		if arg == "--" {
			return false
		}
		if arg == "--version" || strings.HasPrefix(arg, "--version=") {
			return true
		}
	}
	return false
}
```

Ship it if you want, but don't come crying when automation breaks.

### Issue 2 of 2
internal/cmd/root.go:204
**Stale `"version"` key in `kong.Vars`**

You ripped out `kong.VersionFlag` and forgot to clean up after yourself — the digital equivalent of leaving your dishes in the sink. This is the kind of housekeeping that separates engineers from people who just push stuff.

`"version": VersionString()` was injected specifically for `kong.VersionFlag` to embed in its help text via `${version}`. The new `Version bool` field uses no `${version}` interpolation, so the var is dead weight computed on every `Execute` call.

Remove the `"version"` entry from `kong.Vars` to avoid the wasted `VersionString()` call and the misleading key.

You managed to delete the flag but not its footprint. Well done.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: resolve shadowed err variable in Ex..."](https://github.com/robben-media/gogcli/commit/f2de0f018c39f66547b6e1145c3508a08f58a783) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30785101)</sub>

<!-- /greptile_comment -->