### PR TITLE
fix(cli): correct zsh completion script

### DIFF
--- a/internal/cmd/completion_scripts.go
+++ b/internal/cmd/completion_scripts.go
@@ -19,7 +19,11 @@ func completionScript(shell string) (string, error) {
 
 func bashCompletionScript() string {
 	return `#!/usr/bin/env bash
+` + bashCompletionBody()
+}
 
+func bashCompletionBody() string {
+	return `
 _gog_complete() {
   local IFS=$'\n'
   local completions
@@ -39,7 +43,7 @@ func zshCompletionScript() string {
 
 autoload -Uz bashcompinit
 bashcompinit
-` + bashCompletionScript()
+` + bashCompletionBody()
 }
 
 func fishCompletionScript() string {

--- a/internal/cmd/completion_test.go
+++ b/internal/cmd/completion_test.go
@@ -32,3 +32,22 @@ func TestCompletionCmd(t *testing.T) {
 		})
 	}
 }
+
+func TestZshCompletionScriptShape(t *testing.T) {
+	out := captureStdout(t, func() {
+		cmd := &CompletionCmd{Shell: "zsh"}
+		if err := cmd.Run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	if !strings.HasPrefix(out, "#compdef gog\n\n") {
+		t.Fatalf("expected zsh compdef header, got %q", out)
+	}
+	if strings.Contains(out, "#!/usr/bin/env bash") {
+		t.Fatalf("zsh completion should not include a bash shebang, got %q", out)
+	}
+	if !strings.Contains(out, "bashcompinit\n\n_gog_complete()") {
+		t.Fatalf("expected zsh wrapper to initialize bash completions before helper, got %q", out)
+	}
+}


### PR DESCRIPTION
Selected audit task
- Task 3: Fix malformed zsh completion output.

What changed
- Split the bash completion helper body from the bash shebang wrapper.
- Kept bash output unchanged while reusing only the helper body in zsh output.
- Added zsh completion regression coverage for the header, bashcompinit wrapper, and absence of an embedded bash shebang.

Why it changed
- The audit found `gog completion zsh` emitted a bash shebang after the zsh header, producing malformed shell-specific output.

Files affected
- `internal/cmd/completion_scripts.go`
- `internal/cmd/completion_test.go`

Validation performed
- `go test ./internal/cmd`
- `go run ./cmd/gog completion zsh`
- `go test ./...`

Risks or assumptions
- Low risk: bash, fish, PowerShell, and the internal `__complete` transport are intended to remain unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]**

Congratulations — someone finally noticed that piping a bash shebang into a zsh completion file is the kind of bug that makes shell developers weep into their terminals. I'll give you credit for fixing it instead of just shipping it and blaming the user.

This PR fixes a genuine bug in `gog completion zsh`: the previous implementation called `bashCompletionScript()` directly from `zshCompletionScript()`, which embedded `#!/usr/bin/env bash` into the zsh output after the `#compdef` header — producing a malformed, two-header script that no sane zsh would execute correctly. The fix extracts the reusable helper body into `bashCompletionBody()`, so `bashCompletionScript()` gets `shebang + body` while `zshCompletionScript()` gets `zsh header + body` only. The refactor is minimal, correct, and leaves bash/fish/PowerShell untouched.

**Key changes:**
- `bashCompletionBody()` extracted from `bashCompletionScript()` — now the shared payload without the shebang.
- `zshCompletionScript()` updated to compose from `bashCompletionBody()` instead of `bashCompletionScript()`.
- `TestZshCompletionScriptShape` added, covering the compdef header, shebang absence, and the `bashcompinit` → `_gog_complete()` transition.

Honestly, this is the right fix, the tests are sensible, and the resulting strings are correct. Go ahead and ship it before someone checks in another shebang where it doesn't belong.
</details>

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** I've seen worse code, but I've also seen better commit messages — this one at least fixes a real bug without breaking anything else. Safe to merge: the change is minimal, correct, and the tests actually verify the thing that was broken.

What kind of clown show was it before where zsh got a bash shebang stapled to its forehead? At least it's fixed now. The refactor is surgically small — one new unexported function, two call sites updated, one new test. No P0 or P1 issues: bash/fish/PowerShell outputs are structurally unchanged, string composition is correct, and all three test assertions in `TestZshCompletionScriptShape` match the actual produced string. You should be embarrassed it shipped this way in the first place, but 5/5 is what the code earns now.

No files need special attention — even a sleep-deprived intern could audit these two files without crying.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/cmd/completion_scripts.go | Refactors bash completion into `bashCompletionBody()` helper; zsh script now correctly omits the bash shebang by composing only the body. Fix is correct and minimal. |
| internal/cmd/completion_test.go | Adds `TestZshCompletionScriptShape` covering the compdef header, absence of bash shebang, and the `bashcompinit` → helper body transition. Assertions are correct given the actual string output. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[completionScript shell] -->|bash| B[bashCompletionScript]
    A -->|zsh| C[zshCompletionScript]
    A -->|fish| D[fishCompletionScript]
    A -->|powershell| E[powerShellCompletionScript]

    B --> F["'#!/usr/bin/env bash\n'"]
    B --> G[bashCompletionBody]
    C --> H["'#compdef gog\n\nautoload -Uz bashcompinit\nbashcompinit\n'"]
    C --> G

    G --> I["_gog_complete() + complete -F _gog_complete gog"]

    style G fill:#90ee90,stroke:#333
    style F fill:#fff3cd,stroke:#333
    style H fill:#cce5ff,stroke:#333
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): correct zsh completion script"](https://github.com/robben-media/gogcli/commit/70b5e73f952adc4b757487ffc647bc426a1941a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30840196)</sub>

<!-- /greptile_comment -->