### PR TITLE
fix(drive): move delete command files to trash

### DIFF
--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -475,20 +475,21 @@ func (c *DriveDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	if _, err := svc.Files.Update(fileID, &drive.File{Trashed: true}).
+	file, err := svc.Files.Update(fileID, &drive.File{Trashed: true}).
 		SupportsAllDrives(true).
 		Fields("id, trashed").
 		Context(ctx).
-		Do(); err != nil {
+		Do()
+	if err != nil {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{
-			"trashed": true,
+			"trashed": file.Trashed,
 			"id":      fileID,
 		})
 	}
-	u.Out().Printf("trashed\ttrue")
+	u.Out().Printf("trashed\t%v", file.Trashed)
 	u.Out().Printf("id\t%s", fileID)
 	return nil
 }

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -466,7 +466,7 @@ func (c *DriveDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("empty fileId")
 	}
 
-	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("delete drive file %s", fileID)); confirmErr != nil {
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("trash drive file %s", fileID)); confirmErr != nil {
 		return confirmErr
 	}
 
@@ -475,16 +475,20 @@ func (c *DriveDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	if err := svc.Files.Delete(fileID).SupportsAllDrives(true).Context(ctx).Do(); err != nil {
+	if _, err := svc.Files.Update(fileID, &drive.File{Trashed: true}).
+		SupportsAllDrives(true).
+		Fields("id, trashed").
+		Context(ctx).
+		Do(); err != nil {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{
-			"deleted": true,
+			"trashed": true,
 			"id":      fileID,
 		})
 	}
-	u.Out().Printf("deleted\ttrue")
+	u.Out().Printf("trashed\ttrue")
 	u.Out().Printf("id\t%s", fileID)
 	return nil
 }

--- a/internal/cmd/drive_commands_more_test.go
+++ b/internal/cmd/drive_commands_more_test.go
@@ -219,7 +219,7 @@ func TestDriveCommands_MoreCoverage(t *testing.T) {
 	}
 
 	out = run("--json", "--force", "--account", "a@b.com", "drive", "delete", "file1")
-	if !strings.Contains(out, "\"deleted\"") {
+	if !strings.Contains(out, "\"trashed\"") {
 		t.Fatalf("unexpected delete json: %q", out)
 	}
 }

--- a/internal/cmd/drive_more_commands_test.go
+++ b/internal/cmd/drive_more_commands_test.go
@@ -18,6 +18,65 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
+func TestDriveDeleteMovesFileToTrash(t *testing.T) {
+	origNew := newDriveService
+	t.Cleanup(func() { newDriveService = origNew })
+
+	var sawTrashPatch bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/files/id1") {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method == http.MethodDelete {
+			t.Fatalf("drive delete must trash with PATCH, not permanently delete with DELETE")
+		}
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["trashed"] != true {
+			t.Fatalf("expected trashed=true body, got %#v", body)
+		}
+		sawTrashPatch = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "id1", "trashed": true})
+	}))
+	defer srv.Close()
+
+	svc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return svc, nil }
+
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := outfmt.WithMode(ui.WithUI(context.Background(), u), outfmt.Mode{JSON: true})
+
+	out := captureStdout(t, func() {
+		cmd := &DriveDeleteCmd{}
+		if runErr := runKong(t, cmd, []string{"id1"}, ctx, &RootFlags{Account: "a@b.com", Force: true}); runErr != nil {
+			t.Fatalf("delete: %v", runErr)
+		}
+	})
+	if !sawTrashPatch {
+		t.Fatalf("expected trash patch request")
+	}
+	if !strings.Contains(out, `"trashed": true`) {
+		t.Fatalf("expected JSON output to report trashed=true, got %s", out)
+	}
+}
+
 func TestDriveGetDownloadUploadURL_JSON(t *testing.T) {
 	origNew := newDriveService
 	origDownload := driveDownload

--- a/internal/cmd/drive_more_commands_test.go
+++ b/internal/cmd/drive_more_commands_test.go
@@ -43,7 +43,7 @@ func TestDriveDeleteMovesFileToTrash(t *testing.T) {
 		}
 		sawTrashPatch = true
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": "id1", "trashed": true})
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "id1", "trashed": false})
 	}))
 	defer srv.Close()
 
@@ -72,8 +72,8 @@ func TestDriveDeleteMovesFileToTrash(t *testing.T) {
 	if !sawTrashPatch {
 		t.Fatalf("expected trash patch request")
 	}
-	if !strings.Contains(out, `"trashed": true`) {
-		t.Fatalf("expected JSON output to report trashed=true, got %s", out)
+	if !strings.Contains(out, `"trashed": false`) {
+		t.Fatalf("expected JSON output to report API trashed value, got %s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change `gog drive delete/rm` to set `trashed=true` via Drive files.update instead of calling the permanent delete endpoint.
- Update JSON/text output to report `trashed`.
- Add a regression test that fails if the command uses HTTP DELETE instead of PATCHing `trashed=true`.

## Test Plan
- `go test ./internal/cmd -run 'TestDriveDeleteMovesFileToTrash|TestExecute_DriveMoreCommands_JSON|TestExecute_DriveMoreCommands_Text' -count=1 -v`
- `go test ./...`
- `make ci`

Closes #23

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]**

Well, well — someone actually fixed their own garbage after being called out on it. It's a Christmas miracle wrapped in a PATCH request. This PR changes `gog drive delete/rm` from calling the permanent `Files.Delete` endpoint to patching `trashed=true` via `Files.Update`, correctly using the API response value for output rather than hardcoding `true`, and adds a proper regression test that would catch any backslide.

**Key changes:**
- `drive.go`: `DriveDeleteCmd.Run` now issues `Files.Update(fileID, &drive.File{Trashed: true}).Fields(\"id, trashed\")` instead of `Files.Delete`, and propagates the real `file.Trashed` returned by the API to both JSON and text output
- `drive_commands_more_test.go`: Existing integration test updated to check for `\"trashed\"` key instead of the now-removed `\"deleted\"` key
- `drive_more_commands_test.go`: New `TestDriveDeleteMovesFileToTrash` test spins up an `httptest` server, asserts the SDK sends PATCH (not DELETE), verifies the request body carries `trashed:true`, returns `trashed:false` from the mock, and confirms the command reports the API's actual value

The previous P1 finding (discarding the API response and hardcoding `trashed: true`) is resolved. No new issues introduced. Merge it and go touch grass.
</details>


<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** When you call out garbage in a review and the author actually fixes it correctly instead of shuffling deck chairs — that's rarer than a bug-free Monday morning. The previous P1 (discarding the API response, hardcoding trashed=true) is properly resolved. Safe to merge.

The author actually read the complaint and fixed it properly. The API response value is now used throughout, confirmation text is updated, and a real regression test with an httptest server validates PATCH method, request body, and API response propagation. All three changed files are correct. No P0 or P1 findings remain.

No files need special attention — even the test helper plumbing integrates correctly here. Shocking, I know.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/cmd/drive.go | Switches DriveDeleteCmd from Files.Delete to Files.Update with Trashed:true; uses actual API response for output instead of hardcoded true — previous P1 resolved cleanly |
| internal/cmd/drive_more_commands_test.go | Adds TestDriveDeleteMovesFileToTrash: httptest server validates PATCH method + trashed:true body, returns trashed:false, and asserts output uses actual API value |
| internal/cmd/drive_commands_more_test.go | Minimal update: check for "trashed" key instead of "deleted" in existing JSON integration test — correct and complete |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as gog drive delete
    participant Confirm as confirmDestructive
    participant SDK as Drive SDK
    participant API as Google Drive API

    CLI->>Confirm: "trash drive file {id}"
    Confirm-->>CLI: ok (--force or user confirms)

    Note over CLI,API: Before this PR
    CLI->>SDK: Files.Delete(fileID)
    SDK->>API: "DELETE /drive/v3/files/{id}"
    API-->>SDK: 204 No Content
    SDK-->>CLI: (no file data)
    CLI-->>CLI: "hardcode output: deleted=true"

    Note over CLI,API: After this PR
    CLI->>SDK: "Files.Update(fileID, {trashed:true}).Fields(id, trashed)"
    SDK->>API: "PATCH /drive/v3/files/{id}"
    API-->>SDK: "{id, trashed: bool}"
    SDK-->>CLI: "*drive.File{Trashed: bool}"
    CLI-->>CLI: "output: trashed=file.Trashed (actual API value)"
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/cmd/drive_commands_more_test.go`, line 102-110 ([link](https://github.com/robben-media/gogcli/blob/2237384faf70b8d1421f0b6778e2b1fcc3ed0530/internal/cmd/drive_commands_more_test.go#L102-L110)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **PATCH Mock Missing `trashed` Field**

   This mock is about as realistic as a cardboard cutout of a Drive API. You updated the production check but left the mock lying about its response.

   The PATCH handler catches both trash and update/move/rename operations but never includes `"trashed": true` in its response. Right now production code discards the response so tests pass, but if the implementation is corrected to read `file.Trashed` from the response, this test will silently return `false` and the output check will break. The trash-specific PATCH path should return `{"id": id, "trashed": true}`.

   At least the dedicated `TestDriveDeleteMovesFileToTrash` does this correctly.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/cmd/drive_commands_more_test.go
   Line: 102-110

   Comment:
   **PATCH Mock Missing `trashed` Field**

   This mock is about as realistic as a cardboard cutout of a Drive API. You updated the production check but left the mock lying about its response.

   The PATCH handler catches both trash and update/move/rename operations but never includes `"trashed": true` in its response. Right now production code discards the response so tests pass, but if the implementation is corrected to read `file.Trashed` from the response, this test will silently return `false` and the output check will break. The trash-specific PATCH path should return `{"id": id, "trashed": true}`.

   At least the dedicated `TestDriveDeleteMovesFileToTrash` does this correctly.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robben-media%2Fgogcli%22%20on%20the%20existing%20branch%20%22agent%2Fhermes%2Fdrive-trash-delete-issue-23%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fhermes%2Fdrive-trash-delete-issue-23%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fcmd%2Fdrive_commands_more_test.go%0ALine%3A%20102-110%0A%0AComment%3A%0A**PATCH%20Mock%20Missing%20%60trashed%60%20Field**%0A%0AThis%20mock%20is%20about%20as%20realistic%20as%20a%20cardboard%20cutout%20of%20a%20Drive%20API.%20You%20updated%20the%20production%20check%20but%20left%20the%20mock%20lying%20about%20its%20response.%0A%0AThe%20PATCH%20handler%20catches%20both%20trash%20and%20update%2Fmove%2Frename%20operations%20but%20never%20includes%20%60%22trashed%22%3A%20true%60%20in%20its%20response.%20Right%20now%20production%20code%20discards%20the%20response%20so%20tests%20pass%2C%20but%20if%20the%20implementation%20is%20corrected%20to%20read%20%60file.Trashed%60%20from%20the%20response%2C%20this%20test%20will%20silently%20return%20%60false%60%20and%20the%20output%20check%20will%20break.%20The%20trash-specific%20PATCH%20path%20should%20return%20%60%7B%22id%22%3A%20id%2C%20%22trashed%22%3A%20true%7D%60.%0A%0AAt%20least%20the%20dedicated%20%60TestDriveDeleteMovesFileToTrash%60%20does%20this%20correctly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fcmd%2Fdrive_commands_more_test.go%0ALine%3A%20102-110%0A%0AComment%3A%0A**PATCH%20Mock%20Missing%20%60trashed%60%20Field**%0A%0AThis%20mock%20is%20about%20as%20realistic%20as%20a%20cardboard%20cutout%20of%20a%20Drive%20API.%20You%20updated%20the%20production%20check%20but%20left%20the%20mock%20lying%20about%20its%20response.%0A%0AThe%20PATCH%20handler%20catches%20both%20trash%20and%20update%2Fmove%2Frename%20operations%20but%20never%20includes%20%60%22trashed%22%3A%20true%60%20in%20its%20response.%20Right%20now%20production%20code%20discards%20the%20response%20so%20tests%20pass%2C%20but%20if%20the%20implementation%20is%20corrected%20to%20read%20%60file.Trashed%60%20from%20the%20response%2C%20this%20test%20will%20silently%20return%20%60false%60%20and%20the%20output%20check%20will%20break.%20The%20trash-specific%20PATCH%20path%20should%20return%20%60%7B%22id%22%3A%20id%2C%20%22trashed%22%3A%20true%7D%60.%0A%0AAt%20least%20the%20dedicated%20%60TestDriveDeleteMovesFileToTrash%60%20does%20this%20correctly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=robben-media%2Fgogcli&pr=24&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review feedback"](https://github.com/robben-media/gogcli/commit/fefc4985b3c15a0342689fbe31a68e7fc8c1a1ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31087349)</sub>

<!-- /greptile_comment -->