### PR TITLE
fix(cli): make plain config and policy output TSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- CLI: make `--plain config list` and `--plain policy list` emit stable TSV for scriptable output. (#26)
 - Calendar: fix recurrence rules with BYDAY parameter (e.g., `BYDAY=MO,TU,WE,TH,FR`). (#120)
 - Docs: improve create-with-parent failure errors to include created document ID and target parent when move fails.
 

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -144,7 +144,6 @@ func (c *ConfigListCmd) Run(ctx context.Context) error {
 
 	if outfmt.IsPlain(ctx) {
 		fmt.Fprintln(os.Stdout, "KEY\tVALUE")
-		fmt.Fprintf(os.Stdout, "path\t%s\n", path)
 		for _, key := range keys {
 			fmt.Fprintf(os.Stdout, "%s\t%s\n", key, config.GetValue(cfg, key))
 		}

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -142,6 +142,15 @@ func (c *ConfigListCmd) Run(ctx context.Context) error {
 		return outfmt.WriteJSON(os.Stdout, payload)
 	}
 
+	if outfmt.IsPlain(ctx) {
+		fmt.Fprintln(os.Stdout, "KEY\tVALUE")
+		fmt.Fprintf(os.Stdout, "path\t%s\n", path)
+		for _, key := range keys {
+			fmt.Fprintf(os.Stdout, "%s\t%s\n", key, config.GetValue(cfg, key))
+		}
+		return nil
+	}
+
 	fmt.Fprintf(os.Stdout, "Config file: %s\n", path)
 	for _, key := range keys {
 		value := config.GetValue(cfg, key)

--- a/internal/cmd/config_cmd_test.go
+++ b/internal/cmd/config_cmd_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steipete/gogcli/internal/config"
@@ -101,5 +102,34 @@ func TestConfigCmd_JSONEmptyValues(t *testing.T) {
 	}
 	if get.Value != "" {
 		t.Fatalf("expected empty value, got %q", get.Value)
+	}
+}
+
+func TestConfigList_PlainTSV(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := config.WriteConfig(config.File{
+		KeyringBackend:  "file",
+		DefaultTimezone: "UTC",
+	}); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "config", "list"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if strings.Contains(out, "Config file:") || strings.Contains(out, ": ") {
+		t.Fatalf("expected TSV plain output, got %q", out)
+	}
+	if !strings.Contains(out, "KEY\tVALUE\n") ||
+		!strings.Contains(out, "timezone\tUTC\n") ||
+		!strings.Contains(out, "keyring_backend\tfile\n") {
+		t.Fatalf("unexpected plain config output: %q", out)
 	}
 }

--- a/internal/cmd/config_cmd_test.go
+++ b/internal/cmd/config_cmd_test.go
@@ -124,8 +124,11 @@ func TestConfigList_PlainTSV(t *testing.T) {
 		})
 	})
 
-	if strings.Contains(out, "Config file:") || strings.Contains(out, ": ") {
+	if strings.Contains(out, "Config file:") {
 		t.Fatalf("expected TSV plain output, got %q", out)
+	}
+	if strings.Contains(out, "path\t") {
+		t.Fatalf("expected only settable config keys in plain output, got %q", out)
 	}
 	if !strings.Contains(out, "KEY\tVALUE\n") ||
 		!strings.Contains(out, "timezone\tUTC\n") ||

--- a/internal/cmd/policy.go
+++ b/internal/cmd/policy.go
@@ -106,7 +106,7 @@ func (c *PolicyListCmd) Run(ctx context.Context) error {
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"policies": cfg.Policies})
 	}
-	if len(cfg.Policies) == 0 {
+	if len(cfg.Policies) == 0 && !outfmt.IsPlain(ctx) {
 		fmt.Fprintln(os.Stdout, "No policies")
 		return nil
 	}

--- a/internal/cmd/policy_test.go
+++ b/internal/cmd/policy_test.go
@@ -75,6 +75,56 @@ func TestPolicyCreateListGetDelete(t *testing.T) {
 	})
 }
 
+func TestPolicyList_PlainTSV(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := config.WriteConfig(config.File{
+		Policies: []config.Policy{{
+			Name:    "safe",
+			Account: "jdjb78@gmail.com",
+			Client:  "personal",
+			Allow:   []string{"gmail:read", "gmail:labels.create"},
+			Deny:    []string{"gmail:send"},
+		}},
+	}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "policy", "list"}); err != nil {
+				t.Fatalf("policy list: %v", err)
+			}
+		})
+	})
+
+	if strings.Contains(out, "No policies") {
+		t.Fatalf("expected TSV plain output, got %q", out)
+	}
+	if !strings.Contains(out, "NAME\tACCOUNT\tCLIENT\tALLOW\tDENY\n") ||
+		!strings.Contains(out, "safe\tjdjb78@gmail.com\tpersonal\t2\t1\n") {
+		t.Fatalf("unexpected plain policy output: %q", out)
+	}
+}
+
+func TestPolicyList_PlainEmptyTSV(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "policy", "list"}); err != nil {
+				t.Fatalf("policy list: %v", err)
+			}
+		})
+	})
+
+	if out != "NAME\tACCOUNT\tCLIENT\tALLOW\tDENY\n" {
+		t.Fatalf("unexpected empty plain policy output: %q", out)
+	}
+}
+
 func TestPolicyCreate_OverwriteRequiresForce(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())


### PR DESCRIPTION
## Selected audit task

Task 4 from `.codex/audits/gogcli-audit-latest.md`: add explicit TSV plain-mode branches for `config` and `policy` list surfaces. The Top 3 audit tasks were already merged in PRs #20, #21, and #22, so this is the highest-priority remaining safe-to-automate task.

## What changed

- `gog --plain config list` now emits stable `KEY\tVALUE` TSV rows instead of human labels.
- `gog --plain policy list` now emits the TSV header in empty state instead of `No policies`.
- Added regression tests for config plain TSV, policy plain TSV with data, and policy plain TSV empty state.

## Why it changed

The root help documents `--plain` as stable parseable text. Human labels and sentinel strings made these surfaces harder to script reliably.

## Files affected

- `internal/cmd/config_cmd.go`
- `internal/cmd/config_cmd_test.go`
- `internal/cmd/policy.go`
- `internal/cmd/policy_test.go`

## Validation performed

- `go test ./internal/cmd -run 'Test(ConfigList_PlainTSV|PolicyList_Plain|PolicyCreateListGetDelete|PolicyCommandsBypassPolicyEnforcement)'`\n- `go test ./...`\n- `HOME=$(mktemp -d) XDG_CONFIG_HOME=$(mktemp -d) go run ./cmd/gog --plain config list`\n- `HOME=$(mktemp -d) XDG_CONFIG_HOME=$(mktemp -d) go run ./cmd/gog --plain policy list`\n\n## Risks or assumptions\n\n- This intentionally changes only `--plain` output for the selected list commands. Default human output and JSON output are preserved.\n- Empty policy plain output is represented as a header-only TSV table.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]**

Somebody finally figured out that `--plain` should mean "parseable text," not "surprise humans with labels." This is the rare PR that actually does what it says on the tin — adding explicit TSV branches to `config list` and `policy list` in plain mode, with tests to back it up.

- `config_cmd.go`: New `IsPlain` branch emits a `KEY\tVALUE` header followed by `key\tvalue` rows using raw `os.Stdout`, correctly skipping the `Config file:` metadata header and the non-settable `path` row (both previously-flagged issues now properly resolved).
- `policy.go`: The empty-policies guard is narrowed with `&& !outfmt.IsPlain(ctx)` so that plain mode falls through to `tableWriter` (which already returns `os.Stdout` unchanged in plain mode) and emits a header-only TSV instead of the human string `No policies`.
- Tests cover the non-empty TSV case, the empty header-only case, and the absence of human labels — test structure is clean and consistent with the rest of the test suite.
- CHANGELOG.md is updated accordingly.

Existing prior-review concerns (the `": "` false-positive and the read-only `path` metadata row) were properly addressed before this submission. Conditional and behavioral logic are correct for all three output modes (default, JSON, plain).
</details>

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** Shockingly, someone wrote a focused diff that actually solves a real problem without setting anything else on fire. Merge it — it's fine.

I had to read this three times looking for something to complain about and mostly came up empty. Logic for all three output modes (default, JSON, plain) is correct in both files; tableWriter correctly returns raw os.Stdout in plain mode so tabs flow through unmodified; the empty-policy sentinel guard is narrowed precisely; tests cover the non-empty case, the empty header-only case, and regression checks against human labels. Prior review findings were properly addressed before submission. Somebody managed to not break anything this time — barely noteworthy, but here we are.

No files require special attention — all five changed files are straightforward and correct.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/cmd/config_cmd.go | Adds an explicit plain-mode branch that emits TSV to os.Stdout directly, correctly preceding the human-label fallback and omitting the non-settable path row. |
| internal/cmd/policy.go | Narrows the empty-policy sentinel guard to non-plain mode only; plain mode now falls through to tableWriter for header-only TSV output on empty list. |
| internal/cmd/config_cmd_test.go | Adds TestConfigList_PlainTSV covering TSV header presence, absence of human labels, key/value correctness, and exclusion of path metadata row. |
| internal/cmd/policy_test.go | Adds TestPolicyList_PlainTSV and TestPolicyList_PlainEmptyTSV; the empty test uses strict equality which correctly validates the header-only output contract. |
| CHANGELOG.md | Adds a changelog entry for the plain-mode TSV fix under the Fixed section. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[gog --plain config list / policy list] --> B{IsJSON?}
    B -- yes --> C[Write JSON to stdout]
    B -- no --> D{IsPlain?}

    subgraph config list
        D -- yes --> E[fmt.Fprintln: KEY TAB VALUE header\nfmt.Fprintf: key TAB value per row]
        D -- no --> F[fmt.Fprintf: Config file: path\nfmt.Fprintf: key: value per row]
    end

    subgraph policy list
        D -- yes --> G{len policies == 0?}
        D -- no --> H{len policies == 0?}
        G -- yes --> I[tableWriter → os.Stdout\nWrite header only]
        G -- no --> J[tableWriter → os.Stdout\nWrite header + data rows]
        H -- yes --> K[Print: No policies]
        H -- no --> L[tableWriter → tabwriter\nWrite padded header + data rows]
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(changelog): note plain TSV fix"](https://github.com/robben-media/gogcli/commit/3ebb0f63518b575a1bd11f07b874a2190f63341a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32149619)</sub>

<!-- /greptile_comment -->