### PR TITLE
fix(cli): report pre-ui diagnostics

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -82,7 +82,7 @@ func Execute(args []string) (err error) {
 	if hasVersionFlag(args) {
 		mode, innerErr := outputModeFromVersionArgs(args)
 		if innerErr != nil {
-			return newUsageError(innerErr)
+			return reportPreUIError(newUsageError(innerErr))
 		}
 		ctx := outfmt.WithMode(context.Background(), mode)
 		return (&VersionCmd{}).Run(ctx)
@@ -128,7 +128,7 @@ func Execute(args []string) (err error) {
 
 	mode, err := outfmt.FromFlags(cli.JSON, cli.Plain)
 	if err != nil {
-		return newUsageError(err)
+		return reportPreUIError(newUsageError(err))
 	}
 
 	ctx := context.Background()
@@ -146,7 +146,7 @@ func Execute(args []string) (err error) {
 		Color:  uiColor,
 	})
 	if err != nil {
-		return err
+		return reportPreUIError(err)
 	}
 	ctx = ui.WithUI(ctx, u)
 
@@ -253,6 +253,14 @@ func newUsageError(err error) error {
 		return nil
 	}
 	return &ExitError{Code: 2, Err: err}
+}
+
+func reportPreUIError(err error) error {
+	if err == nil {
+		return nil
+	}
+	_, _ = fmt.Fprintln(os.Stderr, errfmt.Format(err))
+	return err
 }
 
 func hasVersionFlag(args []string) bool {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -87,6 +87,53 @@ func TestExecute_UnknownFlag(t *testing.T) {
 	}
 }
 
+func TestExecute_ConflictingOutputModesReportsStderr(t *testing.T) {
+	errText := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			err := Execute([]string{"--json", "--plain", "version"})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if ExitCode(err) != 2 {
+				t.Fatalf("expected exit code 2, got %d (err=%v)", ExitCode(err), err)
+			}
+		})
+	})
+	if !strings.Contains(errText, "invalid output mode") {
+		t.Fatalf("expected stderr diagnostic, got %q", errText)
+	}
+}
+
+func TestExecute_VersionConflictingOutputModesReportsStderr(t *testing.T) {
+	errText := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			err := Execute([]string{"--version", "--json", "--plain"})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if ExitCode(err) != 2 {
+				t.Fatalf("expected exit code 2, got %d (err=%v)", ExitCode(err), err)
+			}
+		})
+	})
+	if !strings.Contains(errText, "invalid output mode") {
+		t.Fatalf("expected stderr diagnostic, got %q", errText)
+	}
+}
+
+func TestExecute_InvalidColorReportsStderr(t *testing.T) {
+	errText := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := Execute([]string{"--color", "nope", "version"}); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	})
+	if !strings.Contains(errText, "invalid --color") {
+		t.Fatalf("expected stderr diagnostic, got %q", errText)
+	}
+}
+
 func TestNewUsageError(t *testing.T) {
 	if newUsageError(nil) != nil {
 		t.Fatalf("expected nil for nil error")


### PR DESCRIPTION
## Selected audit task
Pre-UI usage and initialization errors exit without a gog diagnostic.

## What changed
- Added a small pre-UI diagnostic helper that writes formatted errors to stderr before returning.
- Applied it to conflicting output mode handling, global version output-mode parsing, and invalid UI color setup.
- Added regression tests for all three pre-UI diagnostic paths.

## Why it changed
Scripts should receive an actionable gog diagnostic on stderr instead of only a non-zero exit when root initialization fails before the UI exists.

## Files affected
- internal/cmd/root.go
- internal/cmd/root_test.go

## Validation performed
- make fmt
- make fmt-check
- go test ./internal/cmd
- go test ./...

## Risks or assumptions
- Successful stdout output is unchanged.
- Existing exit code behavior is preserved for usage errors.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]**

Oh look, someone finally noticed that silently exiting with a non-zero code and leaving scripts completely in the dark is garbage behavior. Took a while, but here we are — a tiny, focused fix that actually makes the tool usable by anything that isn't a human staring at a terminal.

This PR wires up a `reportPreUIError` helper that writes a formatted diagnostic to stderr before returning, and applies it to the three places in `Execute` where the CLI can fail before the `UI` object exists: conflicting `--version` output-mode flags, conflicting global `--json`/`--plain` flags, and an invalid `--color` value. Three regression tests cover each path.

**Key changes:**
- New `reportPreUIError(err error) error` in `root.go`: nil-guards, calls `errfmt.Format`, writes to `os.Stderr`, returns the original error unchanged — no exit-code mutation, no double-printing.
- Three call sites updated: `outputModeFromVersionArgs` error path, `outfmt.FromFlags` error path, and `ui.New` error path.
- All three paths tested with `captureStderr` + substring assertions.

The change is consistent with the existing inline stderr-reporting pattern. Stdout output and all exit codes are preserved. Safe to merge.
</details>

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** Seven-line helper, three call-site changes — safe to merge.

No P0 or P1 findings. Implementation is correct, no double-printing, exit codes preserved, all paths tested.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/cmd/root.go | Adds reportPreUIError helper and applies it to three pre-UI error paths. |
| internal/cmd/root_test.go | Adds three regression tests covering all new diagnostic paths. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): report pre-ui diagnostics"](https://github.com/robben-media/gogcli/commit/c20a57f1b61161d30a798a78e528540a1df0e200) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36453302)</sub>

<!-- /greptile_comment -->