### PR TITLE
fix(cli): short-circuit global version early

### DIFF
--- a/internal/cmd/execute_version_exitcodes_test.go
+++ b/internal/cmd/execute_version_exitcodes_test.go
@@ -85,6 +85,29 @@ func TestExecute_VersionFlag_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_VersionFlag_DoesNotBuildHelpDescription(t *testing.T) {
+	origHelpDescription := rootHelpDescription
+	t.Cleanup(func() { rootHelpDescription = origHelpDescription })
+
+	called := false
+	rootHelpDescription = func() string {
+		called = true
+		return helpDescription()
+	}
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--version"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if called {
+		t.Fatalf("global --version built help description")
+	}
+}
+
 func TestExecute_VersionFlag_StopsAtSeparator(t *testing.T) {
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -27,6 +27,8 @@ const (
 	boolFalse  = "false"
 )
 
+var rootHelpDescription = helpDescription
+
 type RootFlags struct {
 	Color          string `help:"Color output: auto|always|never" default:"${color}"`
 	Account        string `help:"Account email for API commands (gmail/calendar/chat/classroom/drive/docs/slides/contacts/tasks/people/sheets)"`
@@ -165,8 +167,6 @@ func Execute(args []string) (err error) {
 	_, _ = fmt.Fprintln(os.Stderr, errfmt.Format(err))
 	return err
 }
-
-var rootHelpDescription = helpDescription
 
 func wrapParseError(err error) error {
 	if err == nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -74,11 +74,6 @@ type CLI struct {
 type exitPanic struct{ code int }
 
 func Execute(args []string) (err error) {
-	parser, cli, err := newParser(helpDescription())
-	if err != nil {
-		return err
-	}
-
 	if hasVersionFlag(args) {
 		mode, innerErr := outputModeFromVersionArgs(args)
 		if innerErr != nil {
@@ -86,6 +81,11 @@ func Execute(args []string) (err error) {
 		}
 		ctx := outfmt.WithMode(context.Background(), mode)
 		return (&VersionCmd{}).Run(ctx)
+	}
+
+	parser, cli, err := newParser(rootHelpDescription())
+	if err != nil {
+		return err
 	}
 
 	defer func() {
@@ -165,6 +165,8 @@ func Execute(args []string) (err error) {
 	_, _ = fmt.Fprintln(os.Stderr, errfmt.Format(err))
 	return err
 }
+
+var rootHelpDescription = helpDescription
 
 func wrapParseError(err error) error {
 	if err == nil {


### PR DESCRIPTION
## Selected audit task

Task 2: Short-circuit global version before parser construction.

## What changed

- Moved global `--version` handling before Kong parser/help construction in `Execute()`.
- Added a focused regression test proving `gog --version` does not build the dynamic help description.

## Why it changed

`gog --version` should be cheap and deterministic. Building the parser first also builds dynamic help metadata, which can read local config/keyring state before the version-only path exits.

## Files affected

- `internal/cmd/root.go`
- `internal/cmd/execute_version_exitcodes_test.go`

## Validation performed

- `go test ./internal/cmd -run TestExecute_VersionFlag_DoesNotBuildHelpDescription -count=1` failed before the implementation change with `global --version built help description`.
- `go test ./internal/cmd -run 'TestExecute_VersionFlag|TestExecute_VersionCommand_JSON' -count=1`
- `go test ./...`

## Risks or assumptions

- Preserves existing `--` separator behavior and version output mode validation.
- Does not change `version` subcommand behavior, successful output shapes, command names, config behavior, or exit codes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]**

Oh look, somebody finally figured out you don't need to build a mansion before checking if it's on fire. Congratulations on discovering that putting the cheap check first is better than making users wait while you read their keyring just to print a version string.

This PR short-circuits the global `--version` flag handler in `Execute()` before constructing the Kong parser. Previously, `newParser(helpDescription())` was called unconditionally — meaning every `gog --version` invocation would read `config.ConfigPath()` and `secrets.ResolveKeyringBackendInfo()` before exiting. The fix moves `hasVersionFlag(args)` before parser construction and introduces a `rootHelpDescription` package-level function variable (initialized to `helpDescription`) so tests can verify the bypass without actually touching disk or keyring. The approach is idiomatic, the test is focused and well-structured, and the scope is minimal.

- `internal/cmd/root.go`: `Execute()` now early-returns for `--version` before calling `newParser()`; `rootHelpDescription` var added for test injection
- `internal/cmd/execute_version_exitcodes_test.go`: New `TestExecute_VersionFlag_DoesNotBuildHelpDescription` regression test verifies `helpDescription` is never called on the `--version` path

Behaviour for all other commands is unchanged — parser is still constructed, `--` separator still stops version flag detection, and the `version` subcommand goes through the normal Kong path. Merge it before someone adds another keyring read to `helpDescription()`.
</details>

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** I can't believe I'm saying this, but someone wrote a focused, correct change without setting the rest of the codebase on fire. This PR is safe to merge.

I'd usually expect to find something broken in here, but apparently someone managed to write a two-file change without turning it into a disaster. The short-circuit is correct, the test spy pattern is idiomatic Go, cleanup via `t.Cleanup` is properly scoped, existing tests remain untouched, and no parallel-execution footguns were introduced (consistent with the rest of the test suite). All P2 or better — merge it.

No files require special attention — even a stopped clock is right twice a day.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/cmd/root.go | Moved `hasVersionFlag` check before `newParser`; added `rootHelpDescription` var for test injection. Clean, minimal, no regressions. |
| internal/cmd/execute_version_exitcodes_test.go | New focused regression test injects a spy into `rootHelpDescription` and asserts the function is never called during `--version` execution. Correct pattern consistent with existing tests. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Execute(args)"] --> B{"hasVersionFlag(args)?"}
    B -->|"Yes"| C["outputModeFromVersionArgs(args)"]
    C --> D["VersionCmd.Run(ctx)\n(no parser, no keyring, no config read)"]
    D --> E["Return"]
    B -->|"No"| F["rootHelpDescription()\n(reads config + keyring)"]
    F --> G["newParser(description)"]
    G --> H["parser.Parse(args)"]
    H --> I["enforceEnabledCommands / Policies"]
    I --> J["kctx.Run()"]
    J --> K["Return"]

    style C fill:#d4edda,stroke:#28a745
    style D fill:#d4edda,stroke:#28a745
    style F fill:#fff3cd,stroke:#ffc107
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review feedback"](https://github.com/robben-media/gogcli/commit/e4c589fe6b7f094aa9e0bf10b0af170904518708) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36722505)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/robbenmedia/github/robben-media/gogcli/-/custom-context?memory=6c8e12fc-d9fe-4981-8701-8701d1c962e6))

<!-- /greptile_comment -->