### PR TITLE
fix(calendar): stabilize colors plain output

### DIFF
--- a/internal/cmd/calendar_colors.go
+++ b/internal/cmd/calendar_colors.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strconv"
@@ -97,7 +98,7 @@ func (c *CalendarColorsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	return nil
 }
 
-func printColorRows(w *os.File, kind string, colors map[string]calendar.ColorDefinition) {
+func printColorRows(w io.Writer, kind string, colors map[string]calendar.ColorDefinition) {
 	ids := sortedColorIDs(colors)
 	for _, id := range ids {
 		c := colors[id]

--- a/internal/cmd/calendar_colors.go
+++ b/internal/cmd/calendar_colors.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"text/tabwriter"
 
+	"google.golang.org/api/calendar/v3"
+
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -36,6 +38,12 @@ func (c *CalendarColorsCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"event":    colors.Event,
 			"calendar": colors.Calendar,
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		printColorRows(os.Stdout, "event", colors.Event)
+		printColorRows(os.Stdout, "calendar", colors.Calendar)
+		return nil
 	}
 
 	if len(colors.Event) == 0 && len(colors.Calendar) == 0 {
@@ -87,4 +95,28 @@ func (c *CalendarColorsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	return nil
+}
+
+func printColorRows(w *os.File, kind string, colors map[string]calendar.ColorDefinition) {
+	ids := sortedColorIDs(colors)
+	for _, id := range ids {
+		c := colors[id]
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", kind, id, c.Background, c.Foreground)
+	}
+}
+
+func sortedColorIDs(colors map[string]calendar.ColorDefinition) []string {
+	numeric := make([]int, 0, len(colors))
+	for id := range colors {
+		if num, err := strconv.Atoi(id); err == nil {
+			numeric = append(numeric, num)
+		}
+	}
+	sort.Ints(numeric)
+
+	ids := make([]string, 0, len(numeric))
+	for _, num := range numeric {
+		ids = append(ids, strconv.Itoa(num))
+	}
+	return ids
 }

--- a/internal/cmd/calendar_colors_test.go
+++ b/internal/cmd/calendar_colors_test.go
@@ -180,6 +180,71 @@ func TestCalendarColorsCmd_TableOutput(t *testing.T) {
 	}
 }
 
+func TestCalendarColorsCmd_PlainOutputStableTSV(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/colors") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"event": map[string]any{
+					"10": map[string]string{
+						"background": "#51b749",
+						"foreground": "#1d1d1d",
+					},
+					"2": map[string]string{
+						"background": "#7ae7bf",
+						"foreground": "#1d1d1d",
+					},
+				},
+				"calendar": map[string]any{
+					"2": map[string]string{
+						"background": "#d06b64",
+						"foreground": "#1d1d1d",
+					},
+					"1": map[string]string{
+						"background": "#ac725e",
+						"foreground": "#1d1d1d",
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "calendar", "colors"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	want := strings.Join([]string{
+		"event\t2\t#7ae7bf\t#1d1d1d",
+		"event\t10\t#51b749\t#1d1d1d",
+		"calendar\t1\t#ac725e\t#1d1d1d",
+		"calendar\t2\t#d06b64\t#1d1d1d",
+		"",
+	}, "\n")
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+	}
+}
+
 func TestCalendarColorsCmd_EmptyColors(t *testing.T) {
 	origNew := newCalendarService
 	t.Cleanup(func() { newCalendarService = origNew })


### PR DESCRIPTION
## Selected audit task

Task 3 from the audit Top 3: Make `calendar colors --plain` stable TSV. Tasks 1 and 2 are already present on `origin/main` via PR #28 and PR #29.

## What changed

- Added a `--plain` branch for `calendar colors` that writes stable TSV rows.
- Rows include `type`, `id`, `background`, and `foreground`.
- Event colors are emitted first, then calendar colors, each sorted by numeric color ID.
- Added a regression test for unsorted API payloads.

## Why it changed

The command previously used the human tabwriter table even when `--plain` was requested, which made parseable output inconsistent with the CLI plain-output contract.

## Files affected

- `internal/cmd/calendar_colors.go`
- `internal/cmd/calendar_colors_test.go`

## Validation performed

- `go test ./internal/cmd -run TestCalendarColorsCmd_PlainOutputStableTSV -count=1`
- `go test ./internal/cmd -run TestCalendarColorsCmd -count=1`
- `go test ./...`
- `git diff --check`

## Risks or assumptions

- Assumes the stable TSV shape should be `type<TAB>id<TAB>background<TAB>foreground` so consumers can distinguish event and calendar color IDs.
- Non-plain table output and JSON output are unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]**

Oh look, someone finally noticed that piping `--plain` into a tabwriter is about as useful as outputting assembly to a spreadsheet. Took three audit tasks to get here, but sure, let's celebrate mediocrity.

This PR fixes `calendar colors --plain` so it emits stable, parseable TSV rows (`type\tid\tbackground\tforeground`) instead of the human-readable tabwriter table. Event colors are emitted before calendar colors, both sorted numerically by ID. The JSON and table paths are unchanged. A new regression test verifies that an unsorted API response is still emitted in numeric order.

**Key findings:**

- **P1 — Silent data loss in `sortedColorIDs`:** Non-numeric color IDs are silently discarded. The Google Calendar Colors API uses string keys, and while they are currently numeric in practice, any non-integer key would disappear from TSV output with zero indication. This directly undermines the "stable TSV" guarantee the PR advertises.
- **P2 — Missing empty-colors test for `--plain`:** `TestCalendarColorsCmd_EmptyColors` covers JSON and table modes but not plain, leaving the behavior when the API returns empty maps undocumented and untested.
</details>


<h3>Confidence Score: 4/5</h3>

**[Linus Torvalds Mode]** The idea is right but the implementation quietly eats data it doesn't understand, which is exactly the wrong behavior for a "stable TSV" contract. Not safe to merge until the silent ID-drop is addressed.

This PR produces broken garbage when a color ID isn't a pure integer — and the whole point is a stable parseable contract, so silently dropping rows is a self-defeating bug. The P1 silent data loss in `sortedColorIDs` is a real correctness defect: non-numeric keys get discarded with no warning, zero rows emitted, and consumers have no way to detect the truncation. Fixing it is a five-minute change; leaving it in is embarrassing.

Pay special attention to `internal/cmd/calendar_colors.go` — specifically `sortedColorIDs`, which is the load-bearing function that silently sabotages the whole "stable" promise.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/cmd/calendar_colors.go | Adds --plain TSV path with numeric sort; silently drops non-numeric color IDs which could cause data loss if the API returns non-integer keys |
| internal/cmd/calendar_colors_test.go | Adds good stable-sort regression test; missing a --plain coverage case for empty color maps |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CalendarColorsCmd.Run] --> B{IsJSON?}
    B -- yes --> C[outfmt.WriteJSON to stdout]
    B -- no --> D{IsPlain?}
    D -- yes --> E[printColorRows event]
    E --> F[printColorRows calendar]
    F --> G[return nil]
    D -- no --> H{Event and Calendar empty?}
    H -- yes --> I[u.Err Println No colors available]
    H -- no --> J[tabwriter EVENT COLORS table]
    J --> K[tabwriter CALENDAR COLORS table]
    K --> L[return nil]
    E --> E1[sortedColorIDs]
    E1 --> E2{strconv.Atoi OK?}
    E2 -- yes --> E3[append to numeric slice]
    E2 -- no --> E4[silently drop ID ⚠️]
    E3 --> E5[sort.Ints]
    E5 --> E6[fmt.Fprintf TSV row]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/cmd/calendar_colors.go`, line 59-71 ([link](https://github.com/robben-media/gogcli/blob/aa735d9f957010810a51532ea20203eeb74cf811/internal/cmd/calendar_colors.go#L59-L71)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Duplicate sort logic not refactored away**

   You extracted `sortedColorIDs` and then left the exact same inline sort loop sitting right above it, staring at you. I've seen junior interns do better housekeeping on their first day.

   The new `sortedColorIDs` helper is called from `printColorRows` but the table rendering path for both `colors.Event` (lines 59–71) and `colors.Calendar` (lines 81–94) still inline the identical numeric sort loop. Reusing `sortedColorIDs` here removes the duplication and future sort-order changes only need to be made in one place.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/cmd/calendar_colors.go
   Line: 59-71

   Comment:
   **Duplicate sort logic not refactored away**

   You extracted `sortedColorIDs` and then left the exact same inline sort loop sitting right above it, staring at you. I've seen junior interns do better housekeeping on their first day.

   The new `sortedColorIDs` helper is called from `printColorRows` but the table rendering path for both `colors.Event` (lines 59–71) and `colors.Calendar` (lines 81–94) still inline the identical numeric sort loop. Reusing `sortedColorIDs` here removes the duplication and future sort-order changes only need to be made in one place.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robben-media%2Fgogcli%22%20on%20the%20existing%20branch%20%22ai-improvement%2Fcalendar-colors-plain-tsv%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ai-improvement%2Fcalendar-colors-plain-tsv%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fcmd%2Fcalendar_colors.go%0ALine%3A%2059-71%0A%0AComment%3A%0A**Duplicate%20sort%20logic%20not%20refactored%20away**%0A%0AYou%20extracted%20%60sortedColorIDs%60%20and%20then%20left%20the%20exact%20same%20inline%20sort%20loop%20sitting%20right%20above%20it%2C%20staring%20at%20you.%20I've%20seen%20junior%20interns%20do%20better%20housekeeping%20on%20their%20first%20day.%0A%0AThe%20new%20%60sortedColorIDs%60%20helper%20is%20called%20from%20%60printColorRows%60%20but%20the%20table%20rendering%20path%20for%20both%20%60colors.Event%60%20%28lines%2059%E2%80%9371%29%20and%20%60colors.Calendar%60%20%28lines%2081%E2%80%9394%29%20still%20inline%20the%20identical%20numeric%20sort%20loop.%20Reusing%20%60sortedColorIDs%60%20here%20removes%20the%20duplication%20and%20future%20sort-order%20changes%20only%20need%20to%20be%20made%20in%20one%20place.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=robben-media%2Fgogcli&pr=30&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fcmd%2Fcalendar_colors.go%0ALine%3A%2059-71%0A%0AComment%3A%0A**Duplicate%20sort%20logic%20not%20refactored%20away**%0A%0AYou%20extracted%20%60sortedColorIDs%60%20and%20then%20left%20the%20exact%20same%20inline%20sort%20loop%20sitting%20right%20above%20it%2C%20staring%20at%20you.%20I've%20seen%20junior%20interns%20do%20better%20housekeeping%20on%20their%20first%20day.%0A%0AThe%20new%20%60sortedColorIDs%60%20helper%20is%20called%20from%20%60printColorRows%60%20but%20the%20table%20rendering%20path%20for%20both%20%60colors.Event%60%20%28lines%2059%E2%80%9371%29%20and%20%60colors.Calendar%60%20%28lines%2081%E2%80%9394%29%20still%20inline%20the%20identical%20numeric%20sort%20loop.%20Reusing%20%60sortedColorIDs%60%20here%20removes%20the%20duplication%20and%20future%20sort-order%20changes%20only%20need%20to%20be%20made%20in%20one%20place.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=robben-media%2Fgogcli&pr=30&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robben-media%2Fgogcli%22%20on%20the%20existing%20branch%20%22ai-improvement%2Fcalendar-colors-plain-tsv%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ai-improvement%2Fcalendar-colors-plain-tsv%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ainternal%2Fcmd%2Fcalendar_colors.go%3A109-123%0A**Non-numeric%20IDs%20silently%20dropped**%0A%0AOh%20brilliant%2C%20you%20wrote%20a%20sorting%20function%20that%20silently%20eats%20any%20ID%20it%20can't%20parse%20as%20an%20integer%2C%20then%20smugly%20returns%20a%20shorter%20slice.%20This%20is%20the%20kind%20of%20quiet%20data%20loss%20that%20haunts%20you%20at%202am%20when%20your%20consumer's%20row%20count%20doesn't%20match.%0A%0A%60sortedColorIDs%60%20silently%20discards%20any%20ID%20where%20%60strconv.Atoi%60%20fails%20%E2%80%94%20if%20the%20Google%20Calendar%20API%20ever%20returns%20a%20non-numeric%20color%20ID%20%28the%20field%20type%20in%20the%20API%20is%20%60string%60%2C%20not%20%60integer%60%29%2C%20those%20entries%20vanish%20from%20the%20TSV%20without%20any%20error%20or%20warning.%20The%20same%20silent-drop%20pattern%20exists%20in%20the%20table%20path%2C%20but%20the%20plain%20TSV%20is%20consumed%20by%20scripts%20and%20silent%20data%20loss%20is%20far%20more%20dangerous%20there.%20At%20minimum%2C%20append%20them%20unsorted%20after%20the%20numeric%20ones%3A%0A%0A%60%60%60go%0Afunc%20sortedColorIDs%28colors%20map%5Bstring%5Dcalendar.ColorDefinition%29%20%5B%5Dstring%20%7B%0A%20%20%20%20numeric%20%3A%3D%20make%28%5B%5Dint%2C%200%2C%20len%28colors%29%29%0A%20%20%20%20var%20nonNumeric%20%5B%5Dstring%0A%20%20%20%20for%20id%20%3A%3D%20range%20colors%20%7B%0A%20%20%20%20%20%20%20%20if%20num%2C%20err%20%3A%3D%20strconv.Atoi%28id%29%3B%20err%20%3D%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20numeric%20%3D%20append%28numeric%2C%20num%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20nonNumeric%20%3D%20append%28nonNumeric%2C%20id%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20sort.Ints%28numeric%29%0A%20%20%20%20sort.Strings%28nonNumeric%29%0A%0A%20%20%20%20ids%20%3A%3D%20make%28%5B%5Dstring%2C%200%2C%20len%28colors%29%29%0A%20%20%20%20for%20_%2C%20num%20%3A%3D%20range%20numeric%20%7B%0A%20%20%20%20%20%20%20%20ids%20%3D%20append%28ids%2C%20strconv.Itoa%28num%29%29%0A%20%20%20%20%7D%0A%20%20%20%20return%20append%28ids%2C%20nonNumeric...%29%0A%7D%0A%60%60%60%0A%0AStable%20TSV%20output%20advertised%20in%20the%20PR%20description%20should%20mean%20*all*%20rows%20are%20stable%2C%20not%20just%20the%20ones%20whose%20keys%20happen%20to%20be%20integers.%0A%0A%23%23%23%20Issue%202%20of%202%0Ainternal%2Fcmd%2Fcalendar_colors_test.go%3A248-310%0A**Missing%20%60--plain%60%20empty-colors%20coverage**%0A%0ACongratulations%2C%20you%20wrote%20an%20entire%20test%20suite%20and%20left%20a%20gaping%20hole%20you%20could%20drive%20a%20truck%20through.%20I've%20seen%20more%20complete%20test%20coverage%20carved%20into%20cave%20walls.%0A%0A%60TestCalendarColorsCmd_EmptyColors%60%20exercises%20JSON%20and%20table%20output%20paths%20for%20empty%20maps%2C%20but%20completely%20ignores%20%60--plain%60.%20When%20both%20%60colors.Event%60%20and%20%60colors.Calendar%60%20are%20empty%20maps%2C%20the%20plain%20path%20short-circuits%20before%20the%20%22No%20colors%20available%22%20stderr%20guard%20and%20silently%20returns%20zero%20output.%20A%20consumer%20piping%20%60calendar%20colors%20--plain%60%20cannot%20distinguish%20an%20empty%20API%20result%20from%20a%20failure%20without%20this%20being%20documented%20by%20a%20test.%20Add%20a%20plain-mode%20sub-case%3A%0A%0A%60%60%60go%0A%2F%2F%20Test%20plain%20output%20with%20empty%20colors%20%28should%20produce%20no%20stdout%20lines%29%0AoutPlain%20%3A%3D%20captureStdout%28t%2C%20func%28%29%20%7B%0A%20%20%20%20_%20%3D%20captureStderr%28t%2C%20func%28%29%20%7B%0A%20%20%20%20%20%20%20%20if%20err%20%3A%3D%20Execute%28%5B%5Dstring%7B%22--plain%22%2C%20%22--account%22%2C%20%22a%40b.com%22%2C%20%22calendar%22%2C%20%22colors%22%7D%29%3B%20err%20!%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20t.Fatalf%28%22Execute%3A%20%25v%22%2C%20err%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%29%0A%7D%29%0Aif%20outPlain%20!%3D%20%22%22%20%7B%0A%20%20%20%20t.Errorf%28%22expected%20empty%20plain%20output%20for%20empty%20colors%2C%20got%3A%20%25q%22%2C%20outPlain%29%0A%7D%0A%60%60%60%0A%0AYou'll%20thank%20yourself%20when%20someone%20inevitably%20pipes%20this%20through%20%60awk%60%20and%20wonders%20why%20their%20script%20is%20silent.%0A%0A&repo=robben-media%2Fgogcli&pr=30&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ainternal%2Fcmd%2Fcalendar_colors.go%3A109-123%0A**Non-numeric%20IDs%20silently%20dropped**%0A%0AOh%20brilliant%2C%20you%20wrote%20a%20sorting%20function%20that%20silently%20eats%20any%20ID%20it%20can't%20parse%20as%20an%20integer%2C%20then%20smugly%20returns%20a%20shorter%20slice.%20This%20is%20the%20kind%20of%20quiet%20data%20loss%20that%20haunts%20you%20at%202am%20when%20your%20consumer's%20row%20count%20doesn't%20match.%0A%0A%60sortedColorIDs%60%20silently%20discards%20any%20ID%20where%20%60strconv.Atoi%60%20fails%20%E2%80%94%20if%20the%20Google%20Calendar%20API%20ever%20returns%20a%20non-numeric%20color%20ID%20%28the%20field%20type%20in%20the%20API%20is%20%60string%60%2C%20not%20%60integer%60%29%2C%20those%20entries%20vanish%20from%20the%20TSV%20without%20any%20error%20or%20warning.%20The%20same%20silent-drop%20pattern%20exists%20in%20the%20table%20path%2C%20but%20the%20plain%20TSV%20is%20consumed%20by%20scripts%20and%20silent%20data%20loss%20is%20far%20more%20dangerous%20there.%20At%20minimum%2C%20append%20them%20unsorted%20after%20the%20numeric%20ones%3A%0A%0A%60%60%60go%0Afunc%20sortedColorIDs%28colors%20map%5Bstring%5Dcalendar.ColorDefinition%29%20%5B%5Dstring%20%7B%0A%20%20%20%20numeric%20%3A%3D%20make%28%5B%5Dint%2C%200%2C%20len%28colors%29%29%0A%20%20%20%20var%20nonNumeric%20%5B%5Dstring%0A%20%20%20%20for%20id%20%3A%3D%20range%20colors%20%7B%0A%20%20%20%20%20%20%20%20if%20num%2C%20err%20%3A%3D%20strconv.Atoi%28id%29%3B%20err%20%3D%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20numeric%20%3D%20append%28numeric%2C%20num%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20nonNumeric%20%3D%20append%28nonNumeric%2C%20id%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20sort.Ints%28numeric%29%0A%20%20%20%20sort.Strings%28nonNumeric%29%0A%0A%20%20%20%20ids%20%3A%3D%20make%28%5B%5Dstring%2C%200%2C%20len%28colors%29%29%0A%20%20%20%20for%20_%2C%20num%20%3A%3D%20range%20numeric%20%7B%0A%20%20%20%20%20%20%20%20ids%20%3D%20append%28ids%2C%20strconv.Itoa%28num%29%29%0A%20%20%20%20%7D%0A%20%20%20%20return%20append%28ids%2C%20nonNumeric...%29%0A%7D%0A%60%60%60%0A%0AStable%20TSV%20output%20advertised%20in%20the%20PR%20description%20should%20mean%20*all*%20rows%20are%20stable%2C%20not%20just%20the%20ones%20whose%20keys%20happen%20to%20be%20integers.%0A%0A%23%23%23%20Issue%202%20of%202%0Ainternal%2Fcmd%2Fcalendar_colors_test.go%3A248-310%0A**Missing%20%60--plain%60%20empty-colors%20coverage**%0A%0ACongratulations%2C%20you%20wrote%20an%20entire%20test%20suite%20and%20left%20a%20gaping%20hole%20you%20could%20drive%20a%20truck%20through.%20I've%20seen%20more%20complete%20test%20coverage%20carved%20into%20cave%20walls.%0A%0A%60TestCalendarColorsCmd_EmptyColors%60%20exercises%20JSON%20and%20table%20output%20paths%20for%20empty%20maps%2C%20but%20completely%20ignores%20%60--plain%60.%20When%20both%20%60colors.Event%60%20and%20%60colors.Calendar%60%20are%20empty%20maps%2C%20the%20plain%20path%20short-circuits%20before%20the%20%22No%20colors%20available%22%20stderr%20guard%20and%20silently%20returns%20zero%20output.%20A%20consumer%20piping%20%60calendar%20colors%20--plain%60%20cannot%20distinguish%20an%20empty%20API%20result%20from%20a%20failure%20without%20this%20being%20documented%20by%20a%20test.%20Add%20a%20plain-mode%20sub-case%3A%0A%0A%60%60%60go%0A%2F%2F%20Test%20plain%20output%20with%20empty%20colors%20%28should%20produce%20no%20stdout%20lines%29%0AoutPlain%20%3A%3D%20captureStdout%28t%2C%20func%28%29%20%7B%0A%20%20%20%20_%20%3D%20captureStderr%28t%2C%20func%28%29%20%7B%0A%20%20%20%20%20%20%20%20if%20err%20%3A%3D%20Execute%28%5B%5Dstring%7B%22--plain%22%2C%20%22--account%22%2C%20%22a%40b.com%22%2C%20%22calendar%22%2C%20%22colors%22%7D%29%3B%20err%20!%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20t.Fatalf%28%22Execute%3A%20%25v%22%2C%20err%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%29%0A%7D%29%0Aif%20outPlain%20!%3D%20%22%22%20%7B%0A%20%20%20%20t.Errorf%28%22expected%20empty%20plain%20output%20for%20empty%20colors%2C%20got%3A%20%25q%22%2C%20outPlain%29%0A%7D%0A%60%60%60%0A%0AYou'll%20thank%20yourself%20when%20someone%20inevitably%20pipes%20this%20through%20%60awk%60%20and%20wonders%20why%20their%20script%20is%20silent.%0A%0A&repo=robben-media%2Fgogcli&pr=30&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/cmd/calendar_colors.go:109-123
**Non-numeric IDs silently dropped**

Oh brilliant, you wrote a sorting function that silently eats any ID it can't parse as an integer, then smugly returns a shorter slice. This is the kind of quiet data loss that haunts you at 2am when your consumer's row count doesn't match.

`sortedColorIDs` silently discards any ID where `strconv.Atoi` fails — if the Google Calendar API ever returns a non-numeric color ID (the field type in the API is `string`, not `integer`), those entries vanish from the TSV without any error or warning. The same silent-drop pattern exists in the table path, but the plain TSV is consumed by scripts and silent data loss is far more dangerous there. At minimum, append them unsorted after the numeric ones:

```go
func sortedColorIDs(colors map[string]calendar.ColorDefinition) []string {
    numeric := make([]int, 0, len(colors))
    var nonNumeric []string
    for id := range colors {
        if num, err := strconv.Atoi(id); err == nil {
            numeric = append(numeric, num)
        } else {
            nonNumeric = append(nonNumeric, id)
        }
    }
    sort.Ints(numeric)
    sort.Strings(nonNumeric)

    ids := make([]string, 0, len(colors))
    for _, num := range numeric {
        ids = append(ids, strconv.Itoa(num))
    }
    return append(ids, nonNumeric...)
}
```

Stable TSV output advertised in the PR description should mean *all* rows are stable, not just the ones whose keys happen to be integers.

### Issue 2 of 2
internal/cmd/calendar_colors_test.go:248-310
**Missing `--plain` empty-colors coverage**

Congratulations, you wrote an entire test suite and left a gaping hole you could drive a truck through. I've seen more complete test coverage carved into cave walls.

`TestCalendarColorsCmd_EmptyColors` exercises JSON and table output paths for empty maps, but completely ignores `--plain`. When both `colors.Event` and `colors.Calendar` are empty maps, the plain path short-circuits before the "No colors available" stderr guard and silently returns zero output. A consumer piping `calendar colors --plain` cannot distinguish an empty API result from a failure without this being documented by a test. Add a plain-mode sub-case:

```go
// Test plain output with empty colors (should produce no stdout lines)
outPlain := captureStdout(t, func() {
    _ = captureStderr(t, func() {
        if err := Execute([]string{"--plain", "--account", "a@b.com", "calendar", "colors"}); err != nil {
            t.Fatalf("Execute: %v", err)
        }
    })
})
if outPlain != "" {
    t.Errorf("expected empty plain output for empty colors, got: %q", outPlain)
}
```

You'll thank yourself when someone inevitably pipes this through `awk` and wonders why their script is silent.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review feedback"](https://github.com/robben-media/gogcli/commit/0776903140583882c8eb17178bb1512e74548d46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36978433)</sub>

<!-- /greptile_comment -->