### PR TITLE
docs(audit): update gogcli improvement audit

### DIFF
--- a/.codex/audits/gogcli-audit-latest.md
+++ b/.codex/audits/gogcli-audit-latest.md
@@ -48,12 +48,12 @@ Current-state notes:
 - Priority: High
 - Why it matters: A CLI should make suggested follow-up commands executable. `gog` prints a next-page hint for BigQuery list commands, and JSON output includes `nextPageToken`, but the command help exposes no page-token input. Users can discover that another page exists but cannot fetch it through the CLI.
 - Exact location:
-  - `internal/cmd/bigquery.go:117` (`BigqueryDatasetsCmd`)
-  - `internal/cmd/bigquery.go:157` (`printNextPageHint(u, resp.NextPageToken)` for datasets)
-  - `internal/cmd/bigquery.go:164` (`BigqueryTablesCmd`)
-  - `internal/cmd/bigquery.go:219` (`printNextPageHint(u, resp.NextPageToken)` for tables)
-  - `internal/cmd/bigquery.go:266` (`BigqueryJobsCmd`)
-  - `internal/cmd/bigquery.go:320` (`printNextPageHint(u, resp.NextPageToken)` for jobs)
+  - `internal/cmd/bigquery.go:111` (`BigqueryDatasetsCmd`)
+  - `internal/cmd/bigquery.go:159` (`printNextPageHint(u, resp.NextPageToken)` for datasets)
+  - `internal/cmd/bigquery.go:165` (`BigqueryTablesCmd`)
+  - `internal/cmd/bigquery.go:218` (`printNextPageHint(u, resp.NextPageToken)` for tables)
+  - `internal/cmd/bigquery.go:281` (`BigqueryJobsCmd`)
+  - `internal/cmd/bigquery.go:348` (`printNextPageHint(u, resp.NextPageToken)` for jobs)
   - `internal/cmd/output_helpers.go:21` (`printNextPageHint`)
 - What is wrong:
   - `BigqueryDatasetsCmd`, `BigqueryTablesCmd`, and `BigqueryJobsCmd` have `Max` but no `Page`/`PageToken` field.

--- a/.codex/audits/gogcli-audit-latest.md
+++ b/.codex/audits/gogcli-audit-latest.md
@@ -1,8 +1,8 @@
 # gogcli Audit Report
 
-Date: 2026-06-07
+Date: 2026-06-14
 Branch: `ai-audit/gogcli-latest`
-Audited baseline: `origin/main` at `8ecc57c` (`fix(cli): make plain config and policy output TSV`)
+Audited baseline: `origin/main` at `9722c31` (`fix(calendar): stabilize colors plain output (#30)`)
 Mode: Audit report only; no source, test, README, or docs changes performed
 
 ## Audit Scope
@@ -12,201 +12,175 @@ Reviewed the current CLI across performance, developer experience, CLI usability
 Commands run:
 
 - `git status --short --branch`
-- `git branch --show-current`
+- `git log --oneline --decorate --max-count=5`
 - `git diff --name-status origin/main...HEAD`
-- `gh pr view 25 --json number,title,state,headRefName,baseRefName,url,labels,mergeStateStatus,changedFiles`
+- `gh pr list --head ai-audit/gogcli-latest --base main --json number,title,state,url,headRefName,baseRefName,labels`
 - `go run ./cmd/gog --help`
 - `go run ./cmd/gog --version --json --plain`
 - `go run ./cmd/gog --color nope version`
 - `GOG_JSON=1 GOG_PLAIN=1 go run ./cmd/gog version`
+- `go run ./cmd/gog config list --plain`
+- `go run ./cmd/gog policy list --plain`
+- `go run ./cmd/gog version --json`
+- `go run ./cmd/gog analytics admin data-streams list --help`
+- `go run ./cmd/gog bigquery datasets --help`
+- `go run ./cmd/gog bigquery tables --help`
 - `go list -m -u all`
 - `go test ./...`
 
 Web references used for comparison:
 
 - Command Line Interface Guidelines: <https://clig.dev/>
-- Cobra flag guidance: <https://cobra.dev/docs/how-to-guides/working-with-flags/>
-- The CLI Spec: <https://clispec.dev/>
+- GNU command-line standards: <https://www.gnu.org/prep/standards/standards.html>
 - gcloud output formatting: <https://docs.cloud.google.com/sdk/gcloud/reference/topic/formats>
 - AWS CLI output formats: <https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-output-format.html>
 
+Current-state notes:
+
+- Prior Top 3 tasks from the 2026-06-07 audit have landed in `origin/main`: pre-UI diagnostics (#28), global `--version` short-circuiting (#29), and `calendar colors --plain` TSV output (#30).
+- `go test ./...` passes on the audited baseline.
+- `config list --plain`, empty `policy list --plain`, and `version --json` now produce parseable output.
+
 ## 1. Prioritized Improvements
 
-### 1. Pre-UI usage and initialization errors exit without a gog diagnostic
+### 1. BigQuery paginated list commands expose next tokens without accepting them back
 
 - Priority: High
-- Why it matters: CLI tools should put diagnostics on stderr while keeping stdout reserved for command output. `gog` already does this for Kong parse errors and command-run errors, but several root initialization paths return before any formatter writes a message. Scripts then receive only a non-zero exit and no actionable `gog` error.
+- Why it matters: A CLI should make suggested follow-up commands executable. `gog` prints a next-page hint for BigQuery list commands, and JSON output includes `nextPageToken`, but the command help exposes no page-token input. Users can discover that another page exists but cannot fetch it through the CLI.
 - Exact location:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:82`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:85`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:129`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:131`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:143`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:149`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/outfmt/outfmt.go:21`
+  - `internal/cmd/bigquery.go:117` (`BigqueryDatasetsCmd`)
+  - `internal/cmd/bigquery.go:157` (`printNextPageHint(u, resp.NextPageToken)` for datasets)
+  - `internal/cmd/bigquery.go:164` (`BigqueryTablesCmd`)
+  - `internal/cmd/bigquery.go:219` (`printNextPageHint(u, resp.NextPageToken)` for tables)
+  - `internal/cmd/bigquery.go:266` (`BigqueryJobsCmd`)
+  - `internal/cmd/bigquery.go:320` (`printNextPageHint(u, resp.NextPageToken)` for jobs)
+  - `internal/cmd/output_helpers.go:21` (`printNextPageHint`)
 - What is wrong:
-  - `Execute()` prints formatted stderr for parser, enabled-command, policy, and command-run failures.
-  - `outfmt.FromFlags(cli.JSON, cli.Plain)` errors are wrapped with `newUsageError(err)` and returned without stderr output.
-  - `outputModeFromVersionArgs()` follows the same silent path for `gog --version --json --plain`.
-  - `ui.New()` errors such as invalid `--color` return before a UI exists and are not printed.
-  - Reproduction through `go run` showed empty stdout and only Go wrapper text (`exit status 1` or `exit status 2`) on stderr, which means `gog` itself emitted no useful diagnostic.
-- Recommended improvement: add a small helper for pre-UI usage/init errors that writes `errfmt.Format(err)` to stderr before returning the wrapped error. Use it for conflicting output modes, version output-mode parsing, and invalid UI color setup.
-- Expected impact: clearer CI and scripting failures without changing successful stdout output.
+  - `BigqueryDatasetsCmd`, `BigqueryTablesCmd`, and `BigqueryJobsCmd` have `Max` but no `Page`/`PageToken` field.
+  - Their run paths return `nextPageToken` in JSON and print `# Next page: --page <token>` in human/plain modes.
+  - `go run ./cmd/gog bigquery datasets --help` and `go run ./cmd/gog bigquery tables --help` show no `--page` or `--page-token` flag.
+- Recommended improvement: add `Page string 'name:"page" help:"Page token"'` to the three BigQuery list commands and pass it to `Datasets.List(...).PageToken(c.Page)`, `Tables.List(...).PageToken(c.Page)`, and `Jobs.List(...).PageToken(c.Page)`. Add tests that assert the outbound request includes `pageToken=...`.
+- Expected impact: fixes a broken pagination workflow without changing first-page output.
 - Estimated risk: Low
 - Safe to automate: Yes
 
-### 2. Global `--version` still builds parser/help metadata before short-circuiting
+### 2. Analytics Admin mutation commands still emit prose under `--plain`
 
 - Priority: High
-- Why it matters: `--version` should be cheap and deterministic. Current code creates the Kong parser and builds dynamic help text before checking for `--version`, so a version-only call can still read local config and keyring backend state.
+- Why it matters: The root flag promises stable, parseable text for `--plain`. gcloud and AWS both treat output format as a scripting contract, and `gog` already follows that pattern across many read commands. Analytics Admin mutations are exactly the kind of commands automation chains need to parse after creation, deletion, or patching.
 - Exact location:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:76`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:77`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:82`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:228`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:231`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:239`
+  - `internal/cmd/analytics_admin_streams.go:88` through `internal/cmd/analytics_admin_streams.go:97` (`AADataStreamsCreateCmd.Run`)
+  - `internal/cmd/analytics_admin_streams.go:128` through `internal/cmd/analytics_admin_streams.go:134` (`AADataStreamsDeleteCmd.Run`)
+  - `internal/cmd/analytics_admin_streams.go:280` through `internal/cmd/analytics_admin_streams.go:286` (`AADataStreamsPatchCmd.Run`)
+  - `internal/cmd/analytics_admin_streams.go:331` through `internal/cmd/analytics_admin_streams.go:338` (`AAMpSecretsCreateCmd.Run`)
+  - `internal/cmd/analytics_admin_streams.go:370` through `internal/cmd/analytics_admin_streams.go:376` (`AAMpSecretsDeleteCmd.Run`)
+  - `internal/cmd/analytics_admin_streams.go:513` through `internal/cmd/analytics_admin_streams.go:519` (`AAMpSecretsPatchCmd.Run`)
+  - `internal/cmd/analytics_admin_streams_test.go` (JSON tests exist; no `--plain` coverage)
 - What is wrong:
-  - `Execute()` calls `newParser(helpDescription())` before `hasVersionFlag(args)`.
-  - `helpDescription()` calls `config.ConfigPath()` and `secrets.ResolveKeyringBackendInfo()`.
-  - The short-circuit avoids command parsing, but not parser construction or local state reads.
-- Recommended improvement: move global version-flag handling before parser creation, while preserving current `--` separator behavior and `--json`/`--plain` validation.
-- Expected impact: faster and more reliable `gog --version`, especially when local config or keyring setup is damaged.
+  - Data stream create/delete/patch return JSON for `--json`; every non-JSON mode prints prose such as `Created data stream: ...`.
+  - Measurement Protocol secret create/delete/patch do the same with `Created secret: ...`, `Secret value: ...`, and deletion/update messages.
+  - List/get commands in the same file already use TSV-style table output, so the command family is inconsistent.
+- Recommended improvement: add explicit `outfmt.IsPlain(ctx)` branches for those six mutation paths. Use narrow TSV schemas, for example `NAME\tMEASUREMENT_ID` for stream create, `DELETED\tNAME` for deletes, `NAME\tSECRET_VALUE` for secret create, and `NAME` for patch results. Preserve default human prose and existing JSON shapes.
+- Expected impact: makes GA4 Admin automation easier and aligns mutation output with the root `--plain` contract.
 - Estimated risk: Low
 - Safe to automate: Yes
 
-### 3. `calendar colors --plain` ignores the documented TSV contract
+### 3. Analytics Admin pagination hints name the wrong flag
 
 - Priority: Medium
-- Why it matters: README documents `--plain` as stable TSV for automation. `calendar colors` supports JSON explicitly, but plain mode falls through to human section headings and pretty tabwriter output.
+- Why it matters: Helpful next-step hints should match the command surface. The shared helper prints `--page`, but Analytics Admin data-stream and Measurement Protocol secret list commands expose `--page-token`.
 - Exact location:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/README.md:257`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/README.md:258`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/calendar_colors.go:34`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/calendar_colors.go:46`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/calendar_colors.go:68`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/output_helpers.go:13`
+  - `internal/cmd/output_helpers.go:21` through `internal/cmd/output_helpers.go:25`
+  - `internal/cmd/analytics_admin_streams.go:186` (`PageToken string 'name:"page-token"'`)
+  - `internal/cmd/analytics_admin_streams.go:238` (`printNextPageHint(u, resp.NextPageToken)`)
+  - `internal/cmd/analytics_admin_streams.go:422` (`PageToken string 'name:"page-token"'`)
+  - `internal/cmd/analytics_admin_streams.go:470` (`printNextPageHint(u, resp.NextPageToken)`)
 - What is wrong:
-  - `CalendarColorsCmd.Run` checks only `outfmt.IsJSON(ctx)`.
-  - Plain mode emits `EVENT COLORS:`, a blank line, `CALENDAR COLORS:`, and aligned tables.
-  - The command does not use `tableWriter(ctx)` and has no single stable schema for both color families.
-- Recommended improvement: add an `outfmt.IsPlain(ctx)` branch with one stable schema, for example `TYPE\tID\tBACKGROUND\tFOREGROUND`, where `TYPE` is `event` or `calendar`. Preserve current default human output and current JSON output.
-- Expected impact: makes an existing read-only command consistent with the automation contract.
+  - `go run ./cmd/gog analytics admin data-streams list --help` shows `--page-token=STRING`.
+  - The shared hint would still print `# Next page: --page <token>` for any non-empty Analytics Admin response.
+  - The existing helper tests intentionally lock in `--page`, which is correct for most commands but not for these two.
+- Recommended improvement: either add `aliases:"page"` to both Analytics Admin `PageToken` fields, or make the helper accept the displayed flag name and update only these two call sites to print `--page-token`. The alias approach is the smallest compatibility-preserving fix; the helper-parameter approach is clearer but touches more tests.
+- Expected impact: users can copy the next-page hint without translating the flag name.
 - Estimated risk: Low
 - Safe to automate: Yes
 
-### 4. Analytics Admin mutation commands emit prose under `--plain`
+### 4. Shared optional `--out` help text is inaccurate for several commands
 
 - Priority: Medium
-- Why it matters: Analytics Admin list/get paths already provide TSV-friendly output, but create/delete/patch paths use human prose in all non-JSON modes. That makes automation less reliable exactly where follow-up scripts need created or deleted resource names.
+- Why it matters: Flag help is part of the CLI contract. The current shared optional output flag says the default is the gogcli config directory even when the command derives a file name, uses an attachment default, or delegates to an export helper.
 - Exact location:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:88`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:93`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:128`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:133`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:280`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:285`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:331`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:336`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:370`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:375`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:513`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/analytics_admin_streams.go:518`
+  - `internal/cmd/flags_output.go:3` through `internal/cmd/flags_output.go:5`
+  - `internal/cmd/sheets.go:52`
+  - `internal/cmd/docs.go:47`
+  - `internal/cmd/slides.go:24`
+  - `internal/cmd/gmail_attachment.go:22`
+  - `internal/cmd/chat_media.go:134`
 - What is wrong:
-  - Data stream `create`, `delete`, and `patch` return JSON only for `--json`; otherwise they print messages like `Created data stream: ...`.
-  - Measurement Protocol secret `create`, `delete`, and `patch` follow the same pattern with `Created secret: ...`, `Secret value: ...`, `Deleted secret: ...`, and `Updated secret: ...`.
-  - The same file's list/get paths already use table output, so this command family has mixed machine-output behavior.
-- Recommended improvement: add explicit `outfmt.IsPlain(ctx)` branches for these six mutation paths with narrow TSV schemas, such as `NAME\tMEASUREMENT_ID` for stream create, `DELETED\tNAME` for deletes, and `NAME\tSECRET_VALUE` for secret create.
-- Expected impact: easier chaining after GA4 resource mutations while preserving default human output and existing JSON shapes.
+  - `OutputPathFlag` hard-codes `Output file path (default: gogcli config dir)`.
+  - The same embedded flag is used by sheet/doc/slide exports, Gmail attachment download, and Chat media download.
+  - Required output and output-directory flags have more accurate wording.
+- Recommended improvement: change the shared optional help to a generic phrase such as `Output file path (default: command-specific)` or split specialized flag structs only where a precise default is important.
+- Expected impact: clearer `--help` output with no runtime behavior change.
 - Estimated risk: Low
 - Safe to automate: Yes
 
-### 5. Shared `--out` help text is misleading for several export/download commands
+### 5. README overstates what `--verbose` logs
 
 - Priority: Medium
-- Why it matters: Clear flag help is part of CLI usability. The shared optional output flag says the default is the gogcli config directory, but not every consumer writes there. For example, Gmail attachments default to the Gmail attachments directory, while Google Workspace exports often derive a file name and path through `exportViaDrive`.
+- Why it matters: The README says verbose mode shows API requests and responses, but the implementation only raises the global slog level. Full request/response logging would need a redaction design because this CLI handles OAuth tokens, Gmail bodies, Drive files, and service-account material.
 - Exact location:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/flags_output.go:3`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/flags_output.go:4`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/sheets.go:50`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/sheets.go:52`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/gmail_attachment.go:19`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/gmail_attachment.go:22`
+  - `README.md:1231` through `README.md:1240`
+  - `internal/cmd/root.go:121` through `internal/cmd/root.go:126`
+  - `internal/googleapi/transport.go:89` through `internal/googleapi/transport.go:115`
 - What is wrong:
-  - `OutputPathFlag` is reused across optional export/download commands.
-  - Its help text hard-codes `default: gogcli config dir`, which is too specific for all current call sites.
-  - The required output flag and output-dir flag are clearer because their help text reflects their actual semantics.
-- Recommended improvement: make the shared optional `--out` help text generic, for example `Output file path (default: command-specific)`, or split the optional output flag into command-specific variants only where help needs to name the default.
-- Expected impact: more accurate `--help` output with no runtime behavior change.
+  - `--verbose` sets slog to debug.
+  - The retry transport logs retry and circuit-breaker events, not all API requests/responses.
+  - The docs promise more than the code safely provides.
+- Recommended improvement: update README wording to say verbose logging enables debug diagnostics such as retry/service setup logs. Do not add raw HTTP logging as an automated small task.
+- Expected impact: fewer false troubleshooting expectations and no additional secret exposure.
 - Estimated risk: Low
 - Safe to automate: Yes
 
-### 6. README overstates what `--verbose` currently logs
-
-- Priority: Medium
-- Why it matters: The docs say verbose mode shows API requests and responses, but the implementation only raises the global slog level. The retry transport logs retry/circuit events; there is no general request/response dumper. Full request/response logging would also be sensitive because this CLI handles OAuth tokens, Gmail bodies, Drive files, and service-account material.
-- Exact location:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/README.md:1236`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/README.md:1240`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:121`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:125`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/googleapi/transport.go:89`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/googleapi/transport.go:115`
-- What is wrong:
-  - `--verbose` sets slog level to debug.
-  - The transport logs retry attempts, not every API request and response.
-  - The README promise is stronger than the current behavior and stronger than what should be added without a redaction design.
-- Recommended improvement: update README wording to say verbose logging enables debug diagnostics such as retry/service setup logs. Do not add raw request/response logging as an automated small task.
-- Expected impact: fewer false expectations during troubleshooting, with no security risk.
-- Estimated risk: Low
-- Safe to automate: Yes
-
-### 7. Help text depends on local config and keyring state
+### 6. Help rendering still depends on local config and keyring state
 
 - Priority: Low
-- Why it matters: Help should usually be stable and safe to render anywhere. Current root help includes local config and keyring backend details, which is useful diagnostics but couples discovery UX to machine state.
+- Why it matters: Help output should normally be stable and safe to render anywhere. `gog` currently includes local config and keyring backend details in the top-level description, which is useful but makes `--help` machine-dependent.
 - Exact location:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:77`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:228`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:231`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:239`
+  - `internal/cmd/root.go:76` through `internal/cmd/root.go:78`
+  - `internal/cmd/root.go:228` through `internal/cmd/root.go:247`
 - What is wrong:
-  - `gog --help` varies by machine and can include config/keyring resolution errors in the description block.
-  - The behavior may be intentional for this operator-focused CLI, so changing it is not a low-risk automation task.
-- Recommended improvement: consider moving dynamic local state to an explicit diagnostics/status command, or make dynamic help diagnostics opt-in.
+  - `helpDescription()` calls `config.ConfigPath()` and `secrets.ResolveKeyringBackendInfo()`.
+  - `gog --help` varies by machine and can include local resolution errors in the description block.
+  - This may be intentional for an operator-focused Google CLI, so it is not a safe automatic change.
+- Recommended improvement: consider moving dynamic environment diagnostics to an explicit `gog config doctor` or status command, or make dynamic help diagnostics opt-in.
 - Expected impact: more deterministic help output.
 - Estimated risk: Medium
 - Safe to automate: No
 
-### 8. Retry transport returns raw exhausted responses instead of typed retry outcomes
+### 7. Retry exhaustion remains HTTP-native rather than a typed outcome
 
 - Priority: Low
-- Why it matters: The repo has retry, circuit-breaker, and error-formatting abstractions. Exhausted 429/5xx retries currently return raw HTTP responses, which leaves higher layers to infer whether a request failed after retry exhaustion from API-specific errors.
+- Why it matters: Retry and circuit-breaker behavior is centralized, but exhausted 429/5xx retries return the final HTTP response with no typed retry-exhausted signal. Higher layers then rely on Google API error handling to infer what happened.
 - Exact location:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/googleapi/transport.go:40`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/googleapi/transport.go:41`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/googleapi/transport.go:83`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/googleapi/transport.go:85`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/googleapi/transport.go:106`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/googleapi/transport.go:112`
+  - `internal/googleapi/transport.go:35` through `internal/googleapi/transport.go:113`
 - What is wrong:
-  - `CircuitBreakerError` is returned directly when the breaker is open.
-  - Exhausted 429 and 5xx retries return `resp, nil`.
-  - Changing this affects all Google API clients, so it needs a design decision rather than an automated small PR.
-- Recommended improvement: decide whether the transport should stay HTTP-native or promote exhausted retry states into typed errors consistently.
-- Expected impact: clearer retry observability if adopted.
+  - An open circuit returns `CircuitBreakerError`.
+  - Exhausted 429/5xx retries return `resp, nil`.
+  - Changing this affects every Google API client and needs a design decision about compatibility with Google client internals.
+- Recommended improvement: decide whether retry exhaustion should remain HTTP-native or be promoted into typed errors with consistent user-facing formatting.
+- Expected impact: clearer observability if adopted.
 - Estimated risk: Medium
 - Safe to automate: No
 
-### 9. Direct dependencies have newer releases available
+### 8. Direct and security-adjacent dependencies have newer releases available
 
 - Priority: Low
-- Why it matters: Dependency drift is normal, but this repository touches auth, Google APIs, terminal output, and CLI parsing, so periodic bounded updates are useful.
+- Why it matters: Dependency drift is normal, but this CLI depends on Google APIs, OAuth, terminal handling, Kong parsing, and security-adjacent Go packages.
 - Exact location:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/go.mod:5`
+  - `go.mod`
 - What is wrong:
-  - `go list -m -u all` reports newer direct or security-adjacent dependencies, including `github.com/alecthomas/kong` `v1.13.0 -> v1.15.0`, `golang.org/x/crypto` `v0.47.0 -> v0.52.0`, `golang.org/x/net` `v0.49.0 -> v0.55.0`, `golang.org/x/oauth2` `v0.34.0 -> v0.36.0`, `golang.org/x/term` `v0.39.0 -> v0.43.0`, and `google.golang.org/api` `v0.260.0 -> v0.283.0`.
-- Recommended improvement: handle dependency updates as a dedicated maintenance PR with full `make ci`, not as part of the CLI UX queue.
+  - `go list -m -u all` reports newer direct or security-adjacent versions, including `github.com/alecthomas/kong v1.13.0 -> v1.15.0`, `golang.org/x/crypto v0.47.0 -> v0.53.0`, `golang.org/x/net v0.49.0 -> v0.56.0`, `golang.org/x/oauth2 v0.34.0 -> v0.36.0`, `golang.org/x/term v0.39.0 -> v0.44.0`, and `google.golang.org/api v0.260.0 -> v0.284.0`.
+- Recommended improvement: handle dependency updates as a dedicated maintenance PR with `make ci` and smoke checks for auth/help/version output.
 - Expected impact: keeps parser/API/security-adjacent packages current.
 - Estimated risk: Medium
 - Safe to automate: No
@@ -215,200 +189,157 @@ Web references used for comparison:
 
 ### Quick Wins
 
-- Print pre-UI usage/init errors to stderr for conflicting output modes and invalid color mode.
-- Short-circuit global `--version` before parser/help config reads.
-- Add a stable TSV `--plain` branch for `calendar colors`.
-- Add stable TSV `--plain` output for Analytics Admin stream and MP secret mutations.
-- Correct generic optional `--out` help copy.
-- Correct README verbose-mode wording so it matches current slog-based implementation.
+- Add `--page` support to BigQuery datasets/tables/jobs list commands.
+- Add explicit `--plain` TSV branches for Analytics Admin data-stream and Measurement Protocol secret mutation commands.
+- Make Analytics Admin next-page hints executable by supporting or printing the right page-token flag.
+- Correct shared optional `--out` help text.
+- Correct README `--verbose` wording.
 
 ### Larger Refactors
 
-- Move dynamic config/keyring state out of root help or redesign help diagnostics.
-- Redesign retry transport semantics around typed exhausted-retry errors.
-- Refresh direct dependencies in a maintenance PR with full regression coverage.
-- Normalize every remaining prose mutation command under `--plain` in one sweep. The safer path is one command family per PR.
+- Moving dynamic config/keyring state out of help and into a diagnostic command.
+- Changing retry exhaustion from raw HTTP responses to typed errors.
+- Batching dependency updates across Google API, OAuth, and `x/*` modules.
+- Designing safe full HTTP request/response logging with redaction.
 
 ## 3. Do Not Change List
 
-- Stable command names and aliases:
-  - `gmail` aliases `mail,email`; `youtube` alias `yt`; `bigquery` alias `bq`; `analytics` aliases `ga,ga4`; `search-console` aliases `gsc,sc`; `tag-manager` alias `gtm`; `business-profile` aliases `gbp,business`.
-  - Why: these are user-facing entrypoints and likely embedded in scripts.
+- Stable top-level commands and aliases: `gmail/mail/email`, `analytics/ga/ga4`, `search-console/gsc/sc`, `tag-manager/gtm`, `business-profile/gbp/business`, `bigquery/bq`, and existing Google service command names. These are user-facing workflows and likely scripted.
+- Output mode contract: keep `--json` and `--plain` as separate global booleans and preserve stdout for primary output. Scripts depend on these modes.
+- Existing JSON shapes: do not rename keys such as `nextPageToken`, `dataStream`, `measurementProtocolSecret`, `deleted`, or existing resource wrappers in small automation PRs.
+- Default human output: keep readable prose/tables for non-JSON, non-plain modes unless the specific task is to fix misleading or broken output.
+- Config and keyring behavior: do not alter config path resolution, keyring backend selection, OAuth client selection, or token storage semantics as part of UX cleanup.
+- Destructive-command safeguards: keep `--force`, `--no-input`, and confirmation behavior intact for delete/update flows.
+- README examples and existing documented command names: docs wording can be corrected, but do not redesign the command vocabulary in an audit-driven PR.
 
-- Successful machine output on stdout, hints/errors on stderr:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/output_helpers.go:21`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/README.md:260`
-  - Why: this matches established CLI scripting practice and is already documented.
+## 4. Execution Plan
 
-- `--json` as the richest machine-readable mode:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/outfmt/outfmt.go:21`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/root.go:35`
-  - Why: changing this would break scripts. Add missing plain branches without changing JSON shapes.
+Convert only `Safe to automate: Yes` items into independent PR tasks.
 
-- `--plain` as TSV, not pretty tables:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/README.md:258`
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/output_helpers.go:13`
-  - Why: this is the right contract for automation; current issues are command-specific gaps.
+### Task 1
 
-- Destructive-operation gates:
-  - `/Users/jeremydjohnson/.codex/worktrees/2b04/gogcli/internal/cmd/confirm.go:14`
-  - Why: `--force`, `--no-input`, non-interactive refusal, and policy checks are central to safe automation.
-
-- Existing `config list --plain` and `policy list --plain` TSV output:
-  - Why: those previous audit tasks are complete on current `main`; do not duplicate them.
-
-- Root help diagnostic block without maintainer approval:
-  - Why: local config/keyring details appear intentional for operator support, even though they make help dynamic.
-
-## 4. Task Plan
-
-Task 1:
-
-- Title: Print pre-UI usage errors to stderr
-- Why: conflicting output modes and invalid color modes should not fail silently.
+- Title: Add BigQuery page-token input flags
+- Why: BigQuery datasets/tables/jobs expose `nextPageToken` and print next-page hints but cannot accept the token back.
 - Files/modules:
-  - `internal/cmd/root.go`
-  - `internal/cmd/execute_version_exitcodes_test.go`
-  - `internal/cmd/root_test.go` or a focused root execution test file
+  - `internal/cmd/bigquery.go`
+  - `internal/cmd/bigquery_test.go`
 - Risk: Low
-- Expected impact: clearer CI/script failures for bad global flag combinations.
+- Expected impact: fixes a broken pagination loop without changing first-page behavior.
 - Steps:
-  1. Add a helper in `internal/cmd/root.go` that writes `errfmt.Format(err)` to `os.Stderr` and returns the original or wrapped error.
-  2. Use it for `outputModeFromVersionArgs()` errors, `outfmt.FromFlags()` errors, and `ui.New()` errors before UI initialization.
-  3. Add tests for `--version --json --plain`, normal command `--json --plain`, env `GOG_JSON=1 GOG_PLAIN=1`, and `--color nope`.
+  1. Add `Page string 'name:"page" help:"Page token"'` to `BigqueryDatasetsCmd`, `BigqueryTablesCmd`, and `BigqueryJobsCmd`.
+  2. Pass the field to each corresponding Google API list call with `.PageToken(c.Page)` when non-empty or directly in the call chain.
+  3. Add tests that run each command with `--page tok` and assert the test server receives `pageToken=tok`.
 - Validation:
-  - `go test ./internal/cmd`
+  - `go test ./internal/cmd -run Bigquery`
   - `go test ./...`
-  - Manual compiled-binary spot check if desired: `gog --json --plain version` should exit non-zero with a clear stderr message.
+  - `go run ./cmd/gog bigquery datasets --help`
 - Do not change:
-  - Exit code `2` for usage errors.
-  - JSON/plain successful output shapes.
-  - Existing parse-error formatting.
+  - JSON output shapes.
+  - Human/TSV columns.
+  - BigQuery query/schema command behavior.
 
-Task 2:
+### Task 2
 
-- Title: Short-circuit global version before parser construction
-- Why: `gog --version` should not read config/keyring state or build help metadata.
-- Files/modules:
-  - `internal/cmd/root.go`
-  - `internal/cmd/version_test.go`
-  - `internal/cmd/execute_version_exitcodes_test.go`
-- Risk: Low
-- Expected impact: faster, more deterministic version output in damaged local environments.
-- Steps:
-  1. Move `hasVersionFlag(args)` and `outputModeFromVersionArgs(args)` handling to the top of `Execute()`, before `newParser(helpDescription())`.
-  2. Preserve the existing `--` behavior where `gog -- --version` is not treated as a global version request.
-  3. Add or adjust tests that prove `--version`, `--version --json`, `--version --plain`, and conflicting output-mode errors still behave correctly.
-- Validation:
-  - `go test ./internal/cmd`
-  - `go test ./...`
-- Do not change:
-  - `version` subcommand behavior.
-  - `VersionString()` formatting.
-  - JSON keys for version output.
-
-Task 3:
-
-- Title: Make `calendar colors --plain` stable TSV
-- Why: the command is read-only and currently violates the documented `--plain` TSV contract.
-- Files/modules:
-  - `internal/cmd/calendar_colors.go`
-  - `internal/cmd/calendar_colors_test.go`
-- Risk: Low
-- Expected impact: better automation ergonomics for color lookup scripts.
-- Steps:
-  1. Add an `outfmt.IsPlain(ctx)` branch before the human-output branch.
-  2. Emit one schema for both color families, for example `TYPE\tID\tBACKGROUND\tFOREGROUND`.
-  3. Add a test fixture that verifies ordering and stdout for event and calendar colors in plain mode.
-- Validation:
-  - `go test ./internal/cmd -run CalendarColors`
-  - `go test ./...`
-- Do not change:
-  - Current JSON payload shape.
-  - Current default human headings and pretty table output.
-  - Authentication/service construction behavior.
-
-Task 4:
-
-- Title: Add plain TSV for Analytics Admin mutations
-- Why: Analytics Admin list/get commands are already script-friendly; create/delete/patch should expose narrow plain output too.
+- Title: Make Analytics Admin mutations plain-parseable
+- Why: Six Analytics Admin mutation paths print prose under `--plain`, violating the root scripting contract.
 - Files/modules:
   - `internal/cmd/analytics_admin_streams.go`
   - `internal/cmd/analytics_admin_streams_test.go`
 - Risk: Low
-- Expected impact: resource creation/deletion scripts can parse names and measurement IDs without prose handling.
+- Expected impact: enables reliable parsing of created, deleted, and updated GA4 Admin resources.
 - Steps:
-  1. Add `outfmt.IsPlain(ctx)` branches for data stream create/delete/patch.
-  2. Add `outfmt.IsPlain(ctx)` branches for Measurement Protocol secret create/delete/patch.
-  3. Add focused tests for the TSV schemas using existing Analytics Admin command test patterns.
+  1. Add `outfmt.IsPlain(ctx)` branches after existing JSON branches in data-stream create/delete/patch.
+  2. Add matching `outfmt.IsPlain(ctx)` branches in Measurement Protocol secret create/delete/patch.
+  3. Add focused tests for `--plain` output schemas using the existing `analyticsAdminStreamsTestServer`.
 - Validation:
-  - `go test ./internal/cmd -run AnalyticsAdmin`
+  - `go test ./internal/cmd -run 'AA(DataStreams|MpSecrets)'`
   - `go test ./...`
 - Do not change:
-  - Current human prose output.
-  - Current JSON payload shapes.
-  - Destructive confirmation behavior.
+  - Existing JSON response wrappers.
+  - Default human prose.
+  - Confirmation requirements for delete commands.
 
-Task 5:
+### Task 3
 
-- Title: Correct optional `--out` help copy
-- Why: shared help text currently claims a gogcli config-dir default for commands whose defaults are command-specific.
+- Title: Fix Analytics Admin next-page hints
+- Why: The commands expose `--page-token`, but the shared hint tells users to run `--page`.
+- Files/modules:
+  - `internal/cmd/analytics_admin_streams.go`
+  - `internal/cmd/analytics_admin_streams_test.go`
+  - optionally `internal/cmd/output_helpers.go` if choosing a helper-parameter approach
+- Risk: Low
+- Expected impact: makes copied pagination hints executable.
+- Steps:
+  1. Choose the smaller compatibility path: add `aliases:"page"` to both Analytics Admin `PageToken` fields, or update the helper to accept a displayed flag name.
+  2. Add tests with non-empty `nextPageToken` responses that verify the suggested or accepted flag works.
+  3. Confirm `analytics admin data-streams list --help` still clearly documents page-token usage.
+- Validation:
+  - `go test ./internal/cmd -run AnalyticsAdmin`
+  - `go run ./cmd/gog analytics admin data-streams list --help`
+  - `go test ./...`
+- Do not change:
+  - Existing `--page-token` flag support.
+  - JSON `nextPageToken` keys.
+  - Pagination behavior for commands that already use `--page`.
+
+### Task 4
+
+- Title: Correct optional output-path help
+- Why: The shared `--out` help names the gogcli config directory even when consumers use command-specific defaults.
 - Files/modules:
   - `internal/cmd/flags_output.go`
   - `internal/cmd/flags_output_test.go`
 - Risk: Low
-- Expected impact: more accurate `--help` output with no behavior change.
+- Expected impact: clearer help text with no runtime behavior change.
 - Steps:
-  1. Replace `OutputPathFlag` help text with generic wording such as `Output file path (default: command-specific)`.
-  2. Keep `OutputPathRequiredFlag` and `OutputDirFlag` wording unchanged unless tests show a direct mismatch.
-  3. Update help/flag tests to assert the alias still works and the copy is accurate.
+  1. Replace the shared optional help string with generic command-specific wording.
+  2. Keep `--out` and `--output` parsing unchanged.
+  3. Update or add help/parser tests only if they assert the help string.
 - Validation:
   - `go test ./internal/cmd -run OutputPathFlag`
+  - `go run ./cmd/gog sheets export --help`
   - `go test ./...`
 - Do not change:
-  - `--out` and `--output` aliases.
-  - Runtime output path defaults.
+  - Output path resolution.
+  - Required `--out` help.
+  - `--out-dir` behavior.
 
-Task 6:
+### Task 5
 
-- Title: Correct README verbose logging claim
-- Why: docs should not promise raw API requests/responses when the implementation only enables debug logging.
+- Title: Narrow README verbose wording
+- Why: Documentation promises request/response logging that the implementation does not provide and should not add without redaction.
 - Files/modules:
   - `README.md`
 - Risk: Low
-- Expected impact: safer and more accurate troubleshooting expectations.
+- Expected impact: removes a misleading troubleshooting claim.
 - Steps:
-  1. Replace the `# Shows API requests and responses` comment with wording about debug diagnostics such as retry/service setup logs.
-  2. Avoid promising raw HTTP logging unless a redaction design exists.
+  1. Replace the verbose-mode comment with wording that matches debug retry/service diagnostics.
+  2. Avoid promising raw request/response logging.
   3. Keep the example command unchanged.
 - Validation:
-  - `rg -n "requests and responses|verbose" README.md`
-  - `go test ./...`
+  - `rg -n "Verbose Mode|request|response|--verbose" README.md`
 - Do not change:
-  - CLI verbose implementation.
-  - Logging of sensitive request/response payloads.
+  - CLI behavior.
+  - Logging implementation.
+  - Auth or token handling.
 
-## 5. Final Section
+## Final Section
 
 Top 3 Tasks to Execute First:
 
-1. Print pre-UI usage errors to stderr
-2. Short-circuit global version before parser construction
-3. Make `calendar colors --plain` stable TSV
+1. Add BigQuery page-token input flags.
+2. Make Analytics Admin mutations plain-parseable.
+3. Fix Analytics Admin next-page hints.
 
 Tasks Excluded:
 
-- Task: Move dynamic config/keyring state out of root help
-  - Reason: likely product/UX decision; current behavior may be intentional diagnostics.
-
-- Task: Redesign retry transport exhausted-retry behavior
-  - Reason: changes cross-service error semantics and needs maintainer design review.
-
-- Task: Update direct dependencies
-  - Reason: maintenance PR with broader regression surface; not a narrow CLI usability task.
-
-- Task: Repo-wide plain-output normalization
-  - Reason: too broad for a single safe automation PR; use one command family per PR.
-
-- Task: Add full API request/response verbose logging
-  - Reason: high sensitivity and requires redaction design for OAuth tokens, message bodies, Drive files, and service-account material.
+- Task: Move dynamic config/keyring details out of help.
+  - Reason: Potentially intentional operator diagnostics; needs product decision.
+- Task: Convert retry exhaustion into typed errors.
+  - Reason: Cross-cutting transport semantics; could affect every Google client.
+- Task: Bulk dependency updates.
+  - Reason: Maintenance batch with broader CI surface, not a low-risk CLI UX PR.
+- Task: Add full API request/response verbose logging.
+  - Reason: Requires secret/body redaction design before implementation.
+- Task: Re-run prior Top 3 from 2026-06-07.
+  - Reason: Those items are already merged in #28, #29, and #30.


### PR DESCRIPTION
## Summary
- Refreshes the safe automation audit against origin/main at 9722c31.
- Removes landed prior Top 3 items from the active queue.
- Adds current Top 3 tasks: BigQuery page-token input flags, Analytics Admin plain mutation output, and Analytics Admin next-page hint alignment.

## Validation
- go test ./...
- go list -m -u all
- CLI help/output probes listed in .codex/audits/gogcli-audit-latest.md

Report-only PR: only .codex/audits/gogcli-audit-latest.md changed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refreshes the gogcli audit from the 2026-06-07 baseline at `8ecc57c` to `origin/main` at `9722c31`, retiring the three prior Top-3 tasks (#28, #29, #30) as landed and promoting three new Top-3 tasks: BigQuery page-token input flags, Analytics Admin plain mutation output, and Analytics Admin next-page hint alignment. All high-priority task line references were verified accurate; one stale reference remains in a low-priority, non-automatable item.
</details>

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** Still can't get every line number right in a single pass, but at least the parts that matter are correct this time. The PR is safe to merge — the only remaining issue is a P2 line-reference typo in a low-priority, non-automatable item that no task runner will touch.

I've seen kindergarteners produce more consistent documentation, but I've also seen worse. All three Top-3 task references — BigQuery page-token, Analytics Admin plain output, and Analytics Admin next-page hints — were verified against the actual source files and are accurate. The single remaining error (root.go:76-78 pointing at exitPanic/Execute instead of helpDescription at 230-250) only affects item 6, which is Priority: Low and explicitly 'Safe to automate: No'. It won't send any task runner to the wrong place. P2-or-lower findings don't block merge — this is a 5.

The one file that changed is `.codex/audits/gogcli-audit-latest.md`. Most of it is fine; go fix root.go:76-78 before someone navigates there in confusion.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .codex/audits/gogcli-audit-latest.md | Audit refreshed against 9722c31; all Top-3 task line references verified accurate; root.go:76-78 in item 6 (Priority: Low, Not safe to automate) still points at the wrong code |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Audit Baseline: 9722c31] --> B[gogcli-audit-latest.md Refresh]
    B --> C[Retire Prior Top 3]
    C --> C1["#28 Pre-UI diagnostics ✓"]
    C --> C2["#29 --version short-circuit ✓"]
    C --> C3["#30 calendar colors --plain ✓"]
    B --> D[New Top 3 Tasks]
    D --> D1["Task 1: BigQuery --page flags\nbigquery.go:111,165,281"]
    D --> D2["Task 2: Analytics Admin plain output\nanalytics_admin_streams.go:88-519"]
    D --> D3["Task 3: Fix --page-token hints\noutput_helpers.go:21-25"]
    B --> E[Carry-forward items 4-8]
    E --> E3["Item 6: Help machine-dependent ⚠️\nroot.go:76-78 WRONG ref"]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robben-media%2Fgogcli%22%20on%20the%20existing%20branch%20%22ai-audit%2Fgogcli-latest%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ai-audit%2Fgogcli-latest%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.codex%2Faudits%2Fgogcli-audit-latest.md%3A149-150%0A**Stale%20root.go%20line%20reference%20in%20item%206**%0A%0ACongratulations%2C%20you%20fixed%20bigquery%20and%20immediately%20broke%20root.go.%20Did%20you%20check%20any%20of%20these%2C%20or%20just%20pick%20numbers%20at%20random%3F%0A%0A%60root.go%3A76-78%60%20points%20at%20%60type%20exitPanic%20struct%7B%20code%20int%20%7D%60%20and%20the%20opening%20line%20of%20%60func%20Execute%60%20%E2%80%94%20neither%20has%20anything%20to%20do%20with%20help%20rendering%20or%20config%20resolution.%20The%20%60helpDescription%28%29%60%20function%20that%20actually%20calls%20%60config.ConfigPath%28%29%60%20and%20%60secrets.ResolveKeyringBackendInfo%28%29%60%20lives%20at%20%60root.go%3A230-250%60.%20The%20companion%20range%20%60root.go%3A228-247%60%20is%20also%20two%20lines%20short%20of%20the%20end%20of%20the%20function%20%28it%20closes%20at%20line%20250%29%2C%20but%20at%20least%20it%20overlaps%20the%20right%20code.%0A%0AAny%20implementor%20who%20follows%20the%20first%20reference%20to%20%60root.go%3A76%60%20is%20going%20to%20land%20in%20the%20middle%20of%20the%20panic-recovery%20handler%20and%20wonder%20why%20the%20audit%20thinks%20that%20has%20anything%20to%20do%20with%20keyring%20state.%0A%0AFix%20it%20before%20someone%20wastes%20twenty%20minutes%20in%20the%20wrong%20function.%0A%0A%60%60%60suggestion%0A%20%20-%20%60internal%2Fcmd%2Froot.go%3A230%60%20through%20%60internal%2Fcmd%2Froot.go%3A250%60%0A%20%20-%20%60internal%2Fcmd%2Froot.go%3A230%60%20through%20%60internal%2Fcmd%2Froot.go%3A250%60%0A%60%60%60%0A%0A&repo=robben-media%2Fgogcli&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.codex%2Faudits%2Fgogcli-audit-latest.md%3A149-150%0A**Stale%20root.go%20line%20reference%20in%20item%206**%0A%0ACongratulations%2C%20you%20fixed%20bigquery%20and%20immediately%20broke%20root.go.%20Did%20you%20check%20any%20of%20these%2C%20or%20just%20pick%20numbers%20at%20random%3F%0A%0A%60root.go%3A76-78%60%20points%20at%20%60type%20exitPanic%20struct%7B%20code%20int%20%7D%60%20and%20the%20opening%20line%20of%20%60func%20Execute%60%20%E2%80%94%20neither%20has%20anything%20to%20do%20with%20help%20rendering%20or%20config%20resolution.%20The%20%60helpDescription%28%29%60%20function%20that%20actually%20calls%20%60config.ConfigPath%28%29%60%20and%20%60secrets.ResolveKeyringBackendInfo%28%29%60%20lives%20at%20%60root.go%3A230-250%60.%20The%20companion%20range%20%60root.go%3A228-247%60%20is%20also%20two%20lines%20short%20of%20the%20end%20of%20the%20function%20%28it%20closes%20at%20line%20250%29%2C%20but%20at%20least%20it%20overlaps%20the%20right%20code.%0A%0AAny%20implementor%20who%20follows%20the%20first%20reference%20to%20%60root.go%3A76%60%20is%20going%20to%20land%20in%20the%20middle%20of%20the%20panic-recovery%20handler%20and%20wonder%20why%20the%20audit%20thinks%20that%20has%20anything%20to%20do%20with%20keyring%20state.%0A%0AFix%20it%20before%20someone%20wastes%20twenty%20minutes%20in%20the%20wrong%20function.%0A%0A%60%60%60suggestion%0A%20%20-%20%60internal%2Fcmd%2Froot.go%3A230%60%20through%20%60internal%2Fcmd%2Froot.go%3A250%60%0A%20%20-%20%60internal%2Fcmd%2Froot.go%3A230%60%20through%20%60internal%2Fcmd%2Froot.go%3A250%60%0A%60%60%60%0A%0A&repo=robben-media%2Fgogcli&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.codex/audits/gogcli-audit-latest.md:149-150
**Stale root.go line reference in item 6**

Congratulations, you fixed bigquery and immediately broke root.go. Did you check any of these, or just pick numbers at random?

`root.go:76-78` points at `type exitPanic struct{ code int }` and the opening line of `func Execute` — neither has anything to do with help rendering or config resolution. The `helpDescription()` function that actually calls `config.ConfigPath()` and `secrets.ResolveKeyringBackendInfo()` lives at `root.go:230-250`. The companion range `root.go:228-247` is also two lines short of the end of the function (it closes at line 250), but at least it overlaps the right code.

Any implementor who follows the first reference to `root.go:76` is going to land in the middle of the panic-recovery handler and wonder why the audit thinks that has anything to do with keyring state.

Fix it before someone wastes twenty minutes in the wrong function.

```suggestion
  - `internal/cmd/root.go:230` through `internal/cmd/root.go:250`
  - `internal/cmd/root.go:230` through `internal/cmd/root.go:250`
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review feedback"](https://github.com/robben-media/gogcli/commit/b36b45036a10485b374b60aed24bce7457457832) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37488348)</sub>

<!-- /greptile_comment -->