### PR TITLE
fix(bigquery): accept page tokens for list commands

### DIFF
--- a/internal/cmd/bigquery.go
+++ b/internal/cmd/bigquery.go
@@ -111,6 +111,7 @@ func (c *BigqueryQueryCmd) Run(ctx context.Context, flags *RootFlags) error {
 type BigqueryDatasetsCmd struct {
 	Project string `name:"project" required:"" help:"Google Cloud project ID"`
 	Max     int64  `name:"max" aliases:"limit" help:"Max results" default:"50"`
+	Page    string `name:"page" help:"Page token"`
 }
 
 func (c *BigqueryDatasetsCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -129,7 +130,11 @@ func (c *BigqueryDatasetsCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	resp, err := svc.Datasets.List(project).MaxResults(c.Max).Do()
+	call := svc.Datasets.List(project).MaxResults(c.Max)
+	if page := strings.TrimSpace(c.Page); page != "" {
+		call = call.PageToken(page)
+	}
+	resp, err := call.Do()
 	if err != nil {
 		return fmt.Errorf("list datasets: %w", err)
 	}
@@ -166,6 +171,7 @@ type BigqueryTablesCmd struct {
 	Project string `name:"project" required:"" help:"Google Cloud project ID"`
 	Dataset string `name:"dataset" required:"" help:"Dataset ID"`
 	Max     int64  `name:"max" aliases:"limit" help:"Max results" default:"50"`
+	Page    string `name:"page" help:"Page token"`
 }
 
 func (c *BigqueryTablesCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -188,7 +194,11 @@ func (c *BigqueryTablesCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	resp, err := svc.Tables.List(project, dataset).MaxResults(c.Max).Do()
+	call := svc.Tables.List(project, dataset).MaxResults(c.Max)
+	if page := strings.TrimSpace(c.Page); page != "" {
+		call = call.PageToken(page)
+	}
+	resp, err := call.Do()
 	if err != nil {
 		return fmt.Errorf("list tables: %w", err)
 	}
@@ -281,6 +291,7 @@ func (c *BigquerySchemaCmd) Run(ctx context.Context, flags *RootFlags) error {
 type BigqueryJobsCmd struct {
 	Project     string `name:"project" required:"" help:"Google Cloud project ID"`
 	Max         int64  `name:"max" aliases:"limit" help:"Max results" default:"20"`
+	Page        string `name:"page" help:"Page token"`
 	StateFilter string `name:"state-filter" help:"Filter by job state: running, done, pending"`
 }
 
@@ -301,6 +312,9 @@ func (c *BigqueryJobsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	call := svc.Jobs.List(project).MaxResults(c.Max)
+	if page := strings.TrimSpace(c.Page); page != "" {
+		call = call.PageToken(page)
+	}
 	stateFilter := strings.TrimSpace(c.StateFilter)
 	if stateFilter != "" {
 		call = call.StateFilter(stateFilter)

--- a/internal/cmd/bigquery_test.go
+++ b/internal/cmd/bigquery_test.go
@@ -18,6 +18,9 @@ func TestExecute_BigqueryDatasets_JSON(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/datasets") && r.Method == http.MethodGet {
+			if got := r.URL.Query().Get("pageToken"); got != "page2" {
+				t.Fatalf("pageToken=%q", got)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"datasets": []map[string]any{
@@ -50,7 +53,7 @@ func TestExecute_BigqueryDatasets_JSON(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "bigquery", "datasets", "--project", "proj1"}); err != nil {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "bigquery", "datasets", "--project", "proj1", "--page", "page2"}); err != nil {
 				t.Fatalf("Execute: %v", err)
 			}
 		})
@@ -86,6 +89,9 @@ func TestExecute_BigqueryTables_JSON(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/tables") && r.Method == http.MethodGet {
+			if got := r.URL.Query().Get("pageToken"); got != "page2" {
+				t.Fatalf("pageToken=%q", got)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"tables": []map[string]any{
@@ -119,7 +125,7 @@ func TestExecute_BigqueryTables_JSON(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "bigquery", "tables", "--project", "proj1", "--dataset", "my_dataset"}); err != nil {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "bigquery", "tables", "--project", "proj1", "--dataset", "my_dataset", "--page", "page2"}); err != nil {
 				t.Fatalf("Execute: %v", err)
 			}
 		})
@@ -249,6 +255,9 @@ func TestExecute_BigqueryJobs_JSON(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/jobs") && r.Method == http.MethodGet {
+			if got := r.URL.Query().Get("pageToken"); got != "page2" {
+				t.Fatalf("pageToken=%q", got)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"jobs": []map[string]any{
@@ -288,7 +297,7 @@ func TestExecute_BigqueryJobs_JSON(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "bigquery", "jobs", "--project", "proj1"}); err != nil {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "bigquery", "jobs", "--project", "proj1", "--page", "page2"}); err != nil {
 				t.Fatalf("Execute: %v", err)
 			}
 		})

--- a/internal/cmd/bigquery_test.go
+++ b/internal/cmd/bigquery_test.go
@@ -19,7 +19,9 @@ func TestExecute_BigqueryDatasets_JSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/datasets") && r.Method == http.MethodGet {
 			if got := r.URL.Query().Get("pageToken"); got != "page2" {
-				t.Fatalf("pageToken=%q", got)
+				t.Errorf("pageToken=%q", got)
+				http.Error(w, "unexpected pageToken", http.StatusBadRequest)
+				return
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -90,7 +92,9 @@ func TestExecute_BigqueryTables_JSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/tables") && r.Method == http.MethodGet {
 			if got := r.URL.Query().Get("pageToken"); got != "page2" {
-				t.Fatalf("pageToken=%q", got)
+				t.Errorf("pageToken=%q", got)
+				http.Error(w, "unexpected pageToken", http.StatusBadRequest)
+				return
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -150,6 +154,81 @@ func TestExecute_BigqueryTables_JSON(t *testing.T) {
 	}
 	if parsed.Tables[0].Type != "TABLE" {
 		t.Fatalf("unexpected table type: %q", parsed.Tables[0].Type)
+	}
+}
+
+func TestExecute_BigqueryListCommands_FirstPageOmitsPageToken(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		path     string
+		args     []string
+		response map[string]any
+	}{
+		{
+			name: "datasets",
+			path: "/datasets",
+			args: []string{"--json", "--account", "a@b.com", "bigquery", "datasets", "--project", "proj1"},
+			response: map[string]any{
+				"datasets":      []map[string]any{},
+				"nextPageToken": "",
+			},
+		},
+		{
+			name: "tables",
+			path: "/tables",
+			args: []string{"--json", "--account", "a@b.com", "bigquery", "tables", "--project", "proj1", "--dataset", "my_dataset"},
+			response: map[string]any{
+				"tables":        []map[string]any{},
+				"nextPageToken": "",
+			},
+		},
+		{
+			name: "jobs",
+			path: "/jobs",
+			args: []string{"--json", "--account", "a@b.com", "bigquery", "jobs", "--project", "proj1"},
+			response: map[string]any{
+				"jobs":          []map[string]any{},
+				"nextPageToken": "",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			origNew := newBigqueryService
+			t.Cleanup(func() { newBigqueryService = origNew })
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, tt.path) && r.Method == http.MethodGet {
+					if got := r.URL.Query().Get("pageToken"); got != "" {
+						t.Errorf("pageToken=%q", got)
+						http.Error(w, "unexpected pageToken", http.StatusBadRequest)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(tt.response)
+					return
+				}
+				http.NotFound(w, r)
+			}))
+			defer srv.Close()
+
+			svc, err := bigquery.NewService(context.Background(),
+				option.WithoutAuthentication(),
+				option.WithHTTPClient(srv.Client()),
+				option.WithEndpoint(srv.URL+"/"),
+			)
+			if err != nil {
+				t.Fatalf("NewService: %v", err)
+			}
+			newBigqueryService = func(context.Context, string) (*bigquery.Service, error) { return svc, nil }
+
+			_ = captureStdout(t, func() {
+				_ = captureStderr(t, func() {
+					if err := Execute(tt.args); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+		})
 	}
 }
 
@@ -256,7 +335,9 @@ func TestExecute_BigqueryJobs_JSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/jobs") && r.Method == http.MethodGet {
 			if got := r.URL.Query().Get("pageToken"); got != "page2" {
-				t.Fatalf("pageToken=%q", got)
+				t.Errorf("pageToken=%q", got)
+				http.Error(w, "unexpected pageToken", http.StatusBadRequest)
+				return
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{


### PR DESCRIPTION
Selected audit task
- BigQuery paginated list commands expose next tokens without accepting them back.

What changed
- Added a `--page` flag to `bigquery datasets`, `bigquery tables`, and `bigquery jobs`.
- Passed non-empty `--page` values through to the BigQuery API as `pageToken`.
- Extended existing BigQuery command tests to assert outbound `pageToken` query parameters.

Why it changed
- These commands already emit `nextPageToken` in JSON and print `# Next page: --page <token>` hints, but the hinted flag was not accepted.

Files affected
- `internal/cmd/bigquery.go`
- `internal/cmd/bigquery_test.go`

Validation performed
- `go test ./internal/cmd -run Bigquery`
- `git diff --check`
- `go test ./...`

Risks or assumptions
- Low risk: first-page behavior is unchanged when `--page` is omitted. The new flag matches the existing next-page hint wording.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]**

Oh, what a surprise — someone finally realized that emitting a \"# Next page: --page \<token\>\" hint while *not accepting the flag* is the kind of API design you'd expect from a sleep-deprived intern. Congratulations on fixing the embarrassingly incomplete pagination loop.

This PR adds a `--page` flag to `bigquery datasets`, `bigquery tables`, and `bigquery jobs`, wires non-empty values through to the upstream BigQuery API as `pageToken`, and extends the test suite to cover both the new flag and the unchanged first-page path. Previous review findings (goroutine-unsafe `t.Fatalf` in handlers, deleted first-page regression tests) have been addressed.

Key changes:
- `BigqueryDatasetsCmd`, `BigqueryTablesCmd`, `BigqueryJobsCmd` each gain a `Page string` field tagged as `--page`
- Each `Run` method conditionally calls `.PageToken(page)` only when `strings.TrimSpace(c.Page) != \"\"`
- `TestExecute_BigqueryDatasets_JSON`, `TestExecute_BigqueryTables_JSON`, and `TestExecute_BigqueryJobs_JSON` now pass `--page page2` and assert the outbound `pageToken` query parameter
- New table-driven `TestExecute_BigqueryListCommands_FirstPageOmitsPageToken` verifies the absence of `pageToken` on first-page calls for all three commands

The code is small, mechanical, and consistent — for once the author managed not to introduce something catastrophically wrong, which is more than can usually be said.
</details>

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** The bar was on the floor and the author cleared it — the fix is mechanical and correct, the previously howling bugs are plugged, and somehow nothing new is on fire. Safe to merge.

Previous review round uncovered two real defects (goroutine-unsafe t.Fatalf calls and deleted first-page regression coverage); both are now fixed. The production code change is a trivial three-location pattern that is identical and correct across all three commands. No P0 or P1 findings remain. Go 1.26 module version eliminates any loop-variable capture concerns in the table-driven test. Full score — not because the work is brilliant, but because the bar for 'safe to merge' is 'doesn't break anything,' and this clears it.

No files need special attention — even the test file, which in a previous life was a masterclass in how to write tests that prove nothing, has been cleaned up.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/cmd/bigquery.go | Adds `--page` flag to three list commands and conditionally passes it to the BigQuery API as `pageToken`; implementation is clean and consistent. |
| internal/cmd/bigquery_test.go | Extends existing tests to assert `pageToken` query parameter and adds a new table-driven test for the first-page (no token) case; previous goroutine-safety issues resolved. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as bigquery {datasets,tables,jobs}
    participant BQ as BigQuery API

    User->>CLI: --project proj --page token
    CLI->>CLI: "strings.TrimSpace(c.Page) != """
    CLI->>BQ: List(...).MaxResults(n).PageToken(token).Do()
    BQ-->>CLI: "{ items: [...], nextPageToken: "..." }"
    CLI-->>User: "JSON / table + # Next page: --page nextToken"

    Note over User,BQ: First page (--page omitted)
    User->>CLI: --project proj
    CLI->>CLI: "strings.TrimSpace(c.Page) == "" skip PageToken"
    CLI->>BQ: List(...).MaxResults(n).Do()
    BQ-->>CLI: "{ items: [...], nextPageToken: "abc" }"
    CLI-->>User: "JSON / table + # Next page: --page abc"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review feedback"](https://github.com/robben-media/gogcli/commit/9dc54849c6d1e38d01486f2d395fdb3e78818c02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37629360)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/robbenmedia/github/robben-media/gogcli/-/custom-context?memory=6c8e12fc-d9fe-4981-8701-8701d1c962e6))

<!-- /greptile_comment -->