### PR TITLE
fix(analytics): make admin mutations plain parseable

### DIFF
--- a/internal/cmd/analytics_admin_streams.go
+++ b/internal/cmd/analytics_admin_streams.go
@@ -88,6 +88,17 @@ func (c *AADataStreamsCreateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"dataStream": resp})
 	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		measurementID := ""
+		if resp.WebStreamData != nil {
+			measurementID = resp.WebStreamData.MeasurementId
+		}
+		fmt.Fprintln(w, "NAME\tMEASUREMENT_ID")
+		fmt.Fprintf(w, "%s\t%s\n", resp.Name, measurementID)
+		return nil
+	}
 
 	u := ui.FromContext(ctx)
 	u.Out().Printf("Created data stream: %s", resp.Name)
@@ -127,6 +138,13 @@ func (c *AADataStreamsDeleteCmd) Run(ctx context.Context, flags *RootFlags) erro
 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "name": name})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "DELETED\tNAME")
+		fmt.Fprintf(w, "true\t%s\n", name)
+		return nil
 	}
 
 	u := ui.FromContext(ctx)
@@ -280,6 +298,13 @@ func (c *AADataStreamsPatchCmd) Run(ctx context.Context, flags *RootFlags, kctx 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"dataStream": resp})
 	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "NAME")
+		fmt.Fprintf(w, "%s\n", resp.Name)
+		return nil
+	}
 
 	u := ui.FromContext(ctx)
 	u.Out().Printf("Updated data stream: %s", resp.Name)
@@ -331,6 +356,13 @@ func (c *AAMpSecretsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"measurementProtocolSecret": resp})
 	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "NAME\tSECRET_VALUE")
+		fmt.Fprintf(w, "%s\t%s\n", resp.Name, resp.SecretValue)
+		return nil
+	}
 
 	u := ui.FromContext(ctx)
 	u.Out().Printf("Created secret: %s", resp.Name)
@@ -369,6 +401,13 @@ func (c *AAMpSecretsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "name": name})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "DELETED\tNAME")
+		fmt.Fprintf(w, "true\t%s\n", name)
+		return nil
 	}
 
 	u := ui.FromContext(ctx)
@@ -512,6 +551,13 @@ func (c *AAMpSecretsPatchCmd) Run(ctx context.Context, flags *RootFlags, kctx *k
 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"measurementProtocolSecret": resp})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "NAME")
+		fmt.Fprintf(w, "%s\n", resp.Name)
+		return nil
 	}
 
 	u := ui.FromContext(ctx)

--- a/internal/cmd/analytics_admin_streams.go
+++ b/internal/cmd/analytics_admin_streams.go
@@ -91,12 +91,13 @@ func (c *AADataStreamsCreateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
 		defer flush()
-		measurementID := ""
-		if resp.WebStreamData != nil {
-			measurementID = resp.WebStreamData.MeasurementId
+		if resp.WebStreamData == nil {
+			fmt.Fprintln(w, "NAME")
+			fmt.Fprintf(w, "%s\n", resp.Name)
+			return nil
 		}
 		fmt.Fprintln(w, "NAME\tMEASUREMENT_ID")
-		fmt.Fprintf(w, "%s\t%s\n", resp.Name, measurementID)
+		fmt.Fprintf(w, "%s\t%s\n", resp.Name, resp.WebStreamData.MeasurementId)
 		return nil
 	}
 

--- a/internal/cmd/analytics_admin_streams_test.go
+++ b/internal/cmd/analytics_admin_streams_test.go
@@ -220,6 +220,32 @@ func TestExecute_AADataStreamsCreate_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_AADataStreamsCreate_Plain(t *testing.T) {
+	srv := analyticsAdminStreamsTestServer()
+	defer srv.Close()
+	setupAnalyticsServices(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"analytics", "admin", "data-streams", "create",
+				"--property", "123",
+				"--type", "WEB_DATA_STREAM",
+				"--display-name", "Healthcare LP",
+				"--web-default-uri", "https://healthcare.itallyllc.com",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	const want = "NAME\tMEASUREMENT_ID\nproperties/123/dataStreams/789\tG-NEW123\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+	}
+}
+
 func TestExecute_AADataStreamsGet_JSON(t *testing.T) {
 	srv := analyticsAdminStreamsTestServer()
 	defer srv.Close()
@@ -301,6 +327,30 @@ func TestExecute_AADataStreamsDelete_WithForce_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_AADataStreamsDelete_WithForce_Plain(t *testing.T) {
+	srv := analyticsAdminStreamsTestServer()
+	defer srv.Close()
+	setupAnalyticsServices(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com", "--force",
+				"analytics", "admin", "data-streams", "delete",
+				"--property", "123",
+				"456",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	const want = "DELETED\tNAME\ntrue\tproperties/123/dataStreams/456\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+	}
+}
+
 func TestExecute_AADataStreamsPatch_UpdateMask(t *testing.T) {
 	var gotUpdateMask string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -343,6 +393,31 @@ func TestExecute_AADataStreamsPatch_UpdateMask(t *testing.T) {
 	}
 	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
 		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+}
+
+func TestExecute_AADataStreamsPatch_Plain(t *testing.T) {
+	srv := analyticsAdminStreamsTestServer()
+	defer srv.Close()
+	setupAnalyticsServices(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"analytics", "admin", "data-streams", "patch",
+				"--property", "123",
+				"--display-name", "Updated Name",
+				"456",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	const want = "NAME\nproperties/123/dataStreams/456\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
 	}
 }
 
@@ -417,6 +492,31 @@ func TestExecute_AAMpSecretsCreate_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_AAMpSecretsCreate_Plain(t *testing.T) {
+	srv := analyticsAdminStreamsTestServer()
+	defer srv.Close()
+	setupAnalyticsServices(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"analytics", "admin", "mp-secrets", "create",
+				"--property", "123",
+				"--stream", "456",
+				"--display-name", "New Secret",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	const want = "NAME\tSECRET_VALUE\nproperties/123/dataStreams/456/measurementProtocolSecrets/999\tsecret_new123\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+	}
+}
+
 func TestExecute_AAMpSecretsDelete_WithoutForce(t *testing.T) {
 	srv := analyticsAdminStreamsTestServer()
 	defer srv.Close()
@@ -434,6 +534,31 @@ func TestExecute_AAMpSecretsDelete_WithoutForce(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "without --force") {
 		t.Fatalf("expected 'without --force' in error, got: %v", err)
+	}
+}
+
+func TestExecute_AAMpSecretsDelete_WithForce_Plain(t *testing.T) {
+	srv := analyticsAdminStreamsTestServer()
+	defer srv.Close()
+	setupAnalyticsServices(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com", "--force",
+				"analytics", "admin", "mp-secrets", "delete",
+				"--property", "123",
+				"--stream", "456",
+				"789",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	const want = "DELETED\tNAME\ntrue\tproperties/123/dataStreams/456/measurementProtocolSecrets/789\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
 	}
 }
 
@@ -481,5 +606,31 @@ func TestExecute_AAMpSecretsPatch_UpdateMask(t *testing.T) {
 	}
 	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
 		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+}
+
+func TestExecute_AAMpSecretsPatch_Plain(t *testing.T) {
+	srv := analyticsAdminStreamsTestServer()
+	defer srv.Close()
+	setupAnalyticsServices(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"analytics", "admin", "mp-secrets", "patch",
+				"--property", "123",
+				"--stream", "456",
+				"--display-name", "Updated Secret",
+				"789",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	const want = "NAME\nproperties/123/dataStreams/456/measurementProtocolSecrets/789\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
 	}
 }

--- a/internal/cmd/analytics_admin_streams_test.go
+++ b/internal/cmd/analytics_admin_streams_test.go
@@ -246,6 +246,46 @@ func TestExecute_AADataStreamsCreate_Plain(t *testing.T) {
 	}
 }
 
+func TestExecute_AADataStreamsCreate_Plain_NonWeb(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/dataStreams") && r.Method == http.MethodPost {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":        "properties/123/dataStreams/790",
+				"type":        "ANDROID_APP_DATA_STREAM",
+				"displayName": "Android App",
+				"androidAppStreamData": map[string]any{
+					"packageName": "com.example.app",
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	setupAnalyticsServices(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"analytics", "admin", "data-streams", "create",
+				"--property", "123",
+				"--type", "ANDROID_APP_DATA_STREAM",
+				"--display-name", "Android App",
+				"--package-name", "com.example.app",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	const want = "NAME\nproperties/123/dataStreams/790\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+	}
+}
+
 func TestExecute_AADataStreamsGet_JSON(t *testing.T) {
 	srv := analyticsAdminStreamsTestServer()
 	defer srv.Close()


### PR DESCRIPTION
## Selected audit task

Task 2: Make Analytics Admin mutations plain-parseable.

## What changed

- Added explicit `--plain` TSV output for Analytics Admin data-stream create/delete/patch.
- Added explicit `--plain` TSV output for Measurement Protocol secret create/delete/patch.
- Added regression coverage for all six mutation paths.

## Why it changed

The audit found these mutation commands printed human prose under `--plain`, which breaks the CLI scripting contract. JSON output and default human prose are preserved.

## Files affected

- `internal/cmd/analytics_admin_streams.go`
- `internal/cmd/analytics_admin_streams_test.go`

## Validation performed

- `go test ./internal/cmd -run 'AA(DataStreams|MpSecrets).*(Plain|WithForce_Plain)'`\n- `go test ./internal/cmd -run 'AA(DataStreams|MpSecrets)'`\n- `go test ./...`\n- `git diff --check`\n\n## Risks or assumptions\n\n- Plain schemas are intentionally narrow TSV outputs: create returns resource identifiers plus generated IDs/secrets where relevant, delete returns `DELETED` and `NAME`, and patch returns `NAME`.\n- No change to JSON wrappers, confirmation behavior, or default human output.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]** Oh look, someone finally remembered that `--plain` means machine-parseable output and not "prose, but sadder." Congratulations on discovering how contracts work. This PR adds TSV plain-mode output for six Analytics Admin mutation commands (`data-streams create/delete/patch` and `mp-secrets create/delete/patch`), fixing a scripting contract violation where those commands printed human prose under `--plain`. The previous finding about non-web data stream types emitting a dangling empty `MEASUREMENT_ID` column has been addressed — non-web streams now emit a single `NAME`-only row, and an Android coverage test was added. JSON output and default human output are unchanged.

**Changes:**
- `internal/cmd/analytics_admin_streams.go`: Adds `IsPlain` branches to all six mutation `Run` methods. Web stream create emits `NAME	MEASUREMENT_ID`; non-web emits `NAME` only; delete emits `DELETED	NAME`; patch emits `NAME`; MP secret create emits `NAME	SECRET_VALUE`; MP secret delete/patch follow the same delete/patch schema.
- `internal/cmd/analytics_admin_streams_test.go`: Adds six corresponding `_Plain` test cases, including a dedicated non-web (Android) create test with a custom stub server.

If only everything were this mechanical to fix, we might get somewhere someday.
</details>

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** It's only output formatting, you've actually tested it, and the previous embarrassing empty-column disaster was cleaned up — merge this before someone asks you to explain it again.

This PR once had a real flaw — the dangling empty MEASUREMENT_ID column for non-web streams — and it was fixed. All six plain-mode paths now emit correct narrow TSV, all six have test coverage, JSON and human outputs are untouched. There are no remaining P0 or P1 findings; the only observations are cosmetic. Frankly I'm surprised it all looks this clean.

No files need attention. The two changed files are embarrassingly straightforward.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/cmd/analytics_admin_streams.go | Adds IsPlain branches to all six mutation handlers; consistent pattern, correct TSV columns, non-web stream divergence handled. |
| internal/cmd/analytics_admin_streams_test.go | Adds six plain-mode regression tests covering all mutation paths; non-web Android case uses custom stub server with correct assertion. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Mutation Run\ncreate / delete / patch] --> B{API call\nsucceeds?}
    B -- error --> Z[return err]
    B -- ok --> C{IsJSON?}
    C -- yes --> D[WriteJSON to stdout\nfull resource wrapper]
    C -- no --> E{IsPlain?}
    E -- yes --> F{Which command?}
    F --> G[data-streams create\nweb: NAME + MEASUREMENT_ID\nnon-web: NAME only]
    F --> H[data-streams delete\nDELETED + NAME]
    F --> I[data-streams patch\nNAME]
    F --> J[mp-secrets create\nNAME + SECRET_VALUE]
    F --> K[mp-secrets delete\nDELETED + NAME]
    F --> L[mp-secrets patch\nNAME]
    E -- no --> M[Human prose\nvia ui.Out Printf]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Mutation Run\ncreate / delete / patch] --> B{API call\nsucceeds?}
    B -- error --> Z[return err]
    B -- ok --> C{IsJSON?}
    C -- yes --> D[WriteJSON to stdout\nfull resource wrapper]
    C -- no --> E{IsPlain?}
    E -- yes --> F{Which command?}
    F --> G[data-streams create\nweb: NAME + MEASUREMENT_ID\nnon-web: NAME only]
    F --> H[data-streams delete\nDELETED + NAME]
    F --> I[data-streams patch\nNAME]
    F --> J[mp-secrets create\nNAME + SECRET_VALUE]
    F --> K[mp-secrets delete\nDELETED + NAME]
    F --> L[mp-secrets patch\nNAME]
    E -- no --> M[Human prose\nvia ui.Out Printf]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review feedback"](https://github.com/robben-media/gogcli/commit/dfd0c6e5ea161737ea9d6b93e40d24c7eb8fc470) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37897363)</sub>

<!-- /greptile_comment -->