### PR TITLE
fix(analytics): use page-token in next-page hints

### DIFF
--- a/internal/cmd/analytics_admin_streams.go
+++ b/internal/cmd/analytics_admin_streams.go
@@ -254,7 +254,7 @@ func (c *AADataStreamsListCmd) Run(ctx context.Context, flags *RootFlags) error 
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", ds.Name, ds.Type, ds.DisplayName, mid)
 	}
-	printNextPageHint(u, resp.NextPageToken)
+	printNextPageHintWithFlag(u, "--page-token", resp.NextPageToken)
 	return nil
 }
 
@@ -507,7 +507,7 @@ func (c *AAMpSecretsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	for _, s := range resp.MeasurementProtocolSecrets {
 		fmt.Fprintf(w, "%s\t%s\t%s\n", s.Name, s.DisplayName, s.SecretValue)
 	}
-	printNextPageHint(u, resp.NextPageToken)
+	printNextPageHintWithFlag(u, "--page-token", resp.NextPageToken)
 	return nil
 }
 

--- a/internal/cmd/analytics_admin_streams_test.go
+++ b/internal/cmd/analytics_admin_streams_test.go
@@ -29,7 +29,7 @@ func analyticsAdminStreamsTestServer() *httptest.Server {
 						"updateTime": "2026-01-01T00:00:00Z",
 					},
 				},
-				"nextPageToken": "",
+				"nextPageToken": "npt",
 			})
 			return
 
@@ -95,7 +95,7 @@ func analyticsAdminStreamsTestServer() *httptest.Server {
 						"secretValue": "secret_abc123",
 					},
 				},
-				"nextPageToken": "",
+				"nextPageToken": "npt",
 			})
 			return
 
@@ -177,6 +177,31 @@ func TestExecute_AADataStreamsList_JSON(t *testing.T) {
 	}
 	if parsed.DataStreams[0].WebStreamData.MeasurementId != "G-ABC123" {
 		t.Fatalf("unexpected measurement ID: %q", parsed.DataStreams[0].WebStreamData.MeasurementId)
+	}
+}
+
+func TestExecute_AADataStreamsList_NextPageHintUsesPageToken(t *testing.T) {
+	srv := analyticsAdminStreamsTestServer()
+	defer srv.Close()
+	setupAnalyticsServices(t, srv)
+
+	errOut := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := Execute([]string{
+				"--account", "a@b.com",
+				"analytics", "admin", "data-streams", "list",
+				"--property", "123",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if !strings.Contains(errOut, "# Next page: --page-token npt") {
+		t.Fatalf("expected page-token next-page hint, got stderr=%q", errOut)
+	}
+	if strings.Contains(errOut, "--page npt") {
+		t.Fatalf("expected no stale --page hint, got stderr=%q", errOut)
 	}
 }
 
@@ -496,6 +521,32 @@ func TestExecute_AAMpSecretsList_JSON(t *testing.T) {
 	}
 	if parsed.Secrets[0].SecretValue != "secret_abc123" {
 		t.Fatalf("unexpected secret value: %q", parsed.Secrets[0].SecretValue)
+	}
+}
+
+func TestExecute_AAMpSecretsList_NextPageHintUsesPageToken(t *testing.T) {
+	srv := analyticsAdminStreamsTestServer()
+	defer srv.Close()
+	setupAnalyticsServices(t, srv)
+
+	errOut := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := Execute([]string{
+				"--account", "a@b.com",
+				"analytics", "admin", "mp-secrets", "list",
+				"--property", "123",
+				"--stream", "456",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if !strings.Contains(errOut, "# Next page: --page-token npt") {
+		t.Fatalf("expected page-token next-page hint, got stderr=%q", errOut)
+	}
+	if strings.Contains(errOut, "--page npt") {
+		t.Fatalf("expected no stale --page hint, got stderr=%q", errOut)
 	}
 }
 

--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -19,8 +19,12 @@ func tableWriter(ctx context.Context) (io.Writer, func()) {
 }
 
 func printNextPageHint(u *ui.UI, nextPageToken string) {
+	printNextPageHintWithFlag(u, "--page", nextPageToken)
+}
+
+func printNextPageHintWithFlag(u *ui.UI, flagName string, nextPageToken string) {
 	if u == nil || nextPageToken == "" {
 		return
 	}
-	u.Err().Printf("# Next page: --page %s", nextPageToken)
+	u.Err().Printf("# Next page: %s %s", flagName, nextPageToken)
 }


### PR DESCRIPTION
## Selected audit task

Task 3: Fix Analytics Admin next-page hints.

## What changed

- Kept the shared default next-page hint as `--page`.
- Added a flag-aware helper for commands whose pagination flag is named differently.
- Updated Analytics Admin data-stream and Measurement Protocol secret list commands to print `--page-token` in next-page hints.
- Added regression tests proving both commands no longer emit the stale `--page` hint.

## Why it changed

The audit found Analytics Admin list commands expose `--page-token`, but their next-page hint was generated by the shared helper as `--page`, making the suggested follow-up command invalid for those commands.

## Files affected

- `internal/cmd/output_helpers.go`
- `internal/cmd/analytics_admin_streams.go`
- `internal/cmd/analytics_admin_streams_test.go`

## Validation performed

- `go test ./internal/cmd -run 'AA(DataStreams|MpSecrets).*NextPageHint|TestExecute_AA(DataStreams|MpSecrets)List'`\n- `go test ./internal/cmd -run 'AA(DataStreams|MpSecrets)'`\n- `go test ./...`\n- `git diff --check`\n\n## Risks or assumptions\n\n- Low risk: existing commands that use `--page` still call the original helper and keep the old hint.\n- This only changes stderr guidance for Analytics Admin pagination; JSON/stdout payloads are unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a broken next-page hint for two Analytics Admin list commands whose pagination flag is `--page-token`, not the `--page` flag assumed by the shared helper. A new `printNextPageHintWithFlag` helper is introduced so each command can specify its flag name, while all other callers continue using the existing `printNextPageHint` wrapper unchanged.

- **`output_helpers.go`**: Extracts a `printNextPageHintWithFlag(u, flagName, token)` helper; `printNextPageHint` now delegates to it with `\"--page\"`, keeping all other commands identical.
- **`analytics_admin_streams.go`**: Both `AADataStreamsList` and `AAMpSecretsList` now call `printNextPageHintWithFlag` with `\"--page-token\"`, matching their `PageToken string` struct fields.
- **`analytics_admin_streams_test.go`**: Adds targeted regression tests for each command confirming the hint text is `--page-token <token>` and does not contain the stale `--page` form; mock updated to return a non-empty token so the hint code path is exercised.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to stderr hint text for two Analytics Admin commands; JSON output, stdout table, and all other commands are untouched.

The refactor is minimal: a one-line delegation wrapper preserves every existing caller's behavior, and only the two commands whose pagination flag was already named --page-token are updated. Both are covered by new regression tests that exercise the exact code path changed. No data path, auth logic, or external API contract is affected.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/cmd/output_helpers.go | Refactors `printNextPageHint` to delegate to a new `printNextPageHintWithFlag` helper that accepts an arbitrary flag name; backward-compatible with all existing callers. |
| internal/cmd/analytics_admin_streams.go | Swaps `printNextPageHint` to `printNextPageHintWithFlag(u, "--page-token", ...)` for both `AADataStreamsList` and `AAMpSecretsList`, matching their actual `--page-token` flag definition. |
| internal/cmd/analytics_admin_streams_test.go | Adds two regression tests verifying next-page hints use `--page-token`; changes mock to always return a non-empty `nextPageToken` for list endpoints to trigger the hint. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Run list command"] --> B{"outfmt.IsJSON?"}
    B -- yes --> C["Write JSON to stdout\n(includes nextPageToken field)"]
    B -- no --> D["Write table to stdout"]
    D --> E{"nextPageToken empty?"}
    E -- yes --> F["Done — no hint"]
    E -- no --> G{"Which command?"}
    G -- "AADataStreamsList\nAAMpSecretsList" --> H["printNextPageHintWithFlag\n(u, '--page-token', token)"]
    G -- "All other list commands" --> I["printNextPageHint\n→ printNextPageHintWithFlag\n(u, '--page', token)"]
    H --> J["stderr: # Next page: --page-token <token>"]
    I --> K["stderr: # Next page: --page <token>"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Run list command"] --> B{"outfmt.IsJSON?"}
    B -- yes --> C["Write JSON to stdout\n(includes nextPageToken field)"]
    B -- no --> D["Write table to stdout"]
    D --> E{"nextPageToken empty?"}
    E -- yes --> F["Done — no hint"]
    E -- no --> G{"Which command?"}
    G -- "AADataStreamsList\nAAMpSecretsList" --> H["printNextPageHintWithFlag\n(u, '--page-token', token)"]
    G -- "All other list commands" --> I["printNextPageHint\n→ printNextPageHintWithFlag\n(u, '--page', token)"]
    H --> J["stderr: # Next page: --page-token <token>"]
    I --> K["stderr: # Next page: --page <token>"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(analytics): use page-token in next-p..."](https://github.com/robben-media/gogcli/commit/9d6750dfaf5afe555a44e5cc0c0318234ddf9c52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38302354)</sub>

<!-- /greptile_comment -->