### PR TITLE
[codex] Normalize gogcli formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Coding Style & Naming Conventions
 
-- Formatting: `make fmt` (`goimports` local prefix `github.com/steipete/gogcli` + `gofumpt`).
+- Formatting: `make fmt` (`goimports` local prefix `github.com/Robben-Media/gogcli` + `gofumpt`).
 - Output: keep stdout parseable (`--json` / `--plain`); send human hints/progress to stderr.
 
 ## Testing Guidelines

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-\g<1>2026 Peter Steinberger
+Copyright (c) 2026 Peter Steinberger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CMD := ./cmd/gog
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT := $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo "")
 DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-LDFLAGS := -X github.com/steipete/gogcli/internal/cmd.version=$(VERSION) -X github.com/steipete/gogcli/internal/cmd.commit=$(COMMIT) -X github.com/steipete/gogcli/internal/cmd.date=$(DATE)
+LDFLAGS := -X github.com/Robben-Media/gogcli/internal/cmd.version=$(VERSION) -X github.com/Robben-Media/gogcli/internal/cmd.commit=$(COMMIT) -X github.com/Robben-Media/gogcli/internal/cmd.date=$(DATE)
 
 TOOLS_DIR := $(CURDIR)/.tools
 GOFUMPT := $(TOOLS_DIR)/gofumpt
@@ -65,11 +65,11 @@ tools:
 	@GOBIN=$(TOOLS_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
 
 fmt: tools
-	@$(GOIMPORTS) -local github.com/steipete/gogcli -w .
+	@$(GOIMPORTS) -local github.com/Robben-Media/gogcli -w .
 	@$(GOFUMPT) -w .
 
 fmt-check: tools
-	@$(GOIMPORTS) -local github.com/steipete/gogcli -w .
+	@$(GOIMPORTS) -local github.com/Robben-Media/gogcli -w .
 	@$(GOFUMPT) -w .
 	@git diff --exit-code -- '*.go' go.mod go.sum
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Fast, script-friendly CLI for Gmail, Calendar, Chat, Classroom, Drive, Docs, Sli
 ### Homebrew
 
 ```bash
-brew install steipete/tap/gogcli
+brew install itsjeremyjohnson/tap/gogcli
 ```
 
 ### Build from Source
 
 ```bash
-git clone https://github.com/steipete/gogcli.git
+git clone https://github.com/Robben-Media/gogcli.git
 cd gogcli
 make
 ```
@@ -1359,7 +1359,7 @@ Optional env:
 - `GOG_LIVE_SKIP=groups,keep`
 - `GOG_LIVE_AUTH=all,groups`
 - `GOG_LIVE_ALLOW_NONTEST=1`
-- `GOG_LIVE_EMAIL_TEST=steipete+gogtest@gmail.com`
+- `GOG_LIVE_EMAIL_TEST=jeremy+gogtest@robbenmedia.com`
 - `GOG_LIVE_GROUP_EMAIL=group@domain`
 - `GOG_LIVE_CLASSROOM_COURSE=<courseId>`
 - `GOG_LIVE_CLASSROOM_CREATE=1`
@@ -1391,7 +1391,7 @@ MIT
 
 ## Links
 
-- [GitHub Repository](https://github.com/steipete/gogcli)
+- [GitHub Repository](https://github.com/Robben-Media/gogcli)
 - [Gmail API Documentation](https://developers.google.com/gmail/api)
 - [Google Calendar API Documentation](https://developers.google.com/calendar)
 - [Google Drive API Documentation](https://developers.google.com/drive)

--- a/cmd/gog/main.go
+++ b/cmd/gog/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/steipete/gogcli/internal/cmd"
+	"github.com/Robben-Media/gogcli/internal/cmd"
 )
 
 func main() {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -15,15 +15,15 @@ scripts/verify-release.sh X.Y.Z
 ```
 
 Assumptions:
-- Repo: `steipete/gogcli`
-- Tap repo: `../homebrew-tap` (tap: `steipete/tap`)
+- Repo: `Robben-Media/gogcli`
+- Tap repo: `../homebrew-tap` (tap: `itsjeremyjohnson/tap`)
 - Homebrew formula name: `gogcli` (installs the `gog` binary)
 
 ## 0) Prereqs
 - Clean working tree on `main`.
 - Go toolchain installed (Go version comes from `go.mod`).
 - `make` works locally.
-- Access to the tap repo (e.g. `steipete/homebrew-tap`).
+- Access to the tap repo (e.g. `itsjeremyjohnson/homebrew-tap`).
 
 ## 1) Verify build is green
 ```sh
@@ -73,7 +73,7 @@ In the tap repo (assumed sibling at `../homebrew-tap`), create/update `Formula/g
 
 Recommended formula shape (build-from-source, no binary assets needed):
 - `version "X.Y.Z"`
-- `url "https://github.com/steipete/gogcli/archive/refs/tags/vX.Y.Z.tar.gz"`
+- `url "https://github.com/Robben-Media/gogcli/archive/refs/tags/vX.Y.Z.tar.gz"`
 - `sha256 "<sha256>"`
 - `depends_on "go" => :build`
 - Build:
@@ -81,7 +81,7 @@ Recommended formula shape (build-from-source, no binary assets needed):
 
 Compute the SHA256 for the tag tarball:
 ```sh
-curl -L -o /tmp/gogcli.tar.gz https://github.com/steipete/gogcli/archive/refs/tags/vX.Y.Z.tar.gz
+curl -L -o /tmp/gogcli.tar.gz https://github.com/Robben-Media/gogcli/archive/refs/tags/vX.Y.Z.tar.gz
 shasum -a 256 /tmp/gogcli.tar.gz
 ```
 
@@ -97,14 +97,13 @@ git push origin main
 ```sh
 brew update
 brew uninstall gogcli || true
-brew untap steipete/tap || true
-brew tap steipete/tap
-brew install steipete/tap/gogcli
-brew test steipete/tap/gogcli
+brew untap itsjeremyjohnson/tap || true
+brew tap itsjeremyjohnson/tap
+brew install itsjeremyjohnson/tap/gogcli
+brew test itsjeremyjohnson/tap/gogcli
 
 gog --help
 ```
 
 ## Notes
-- `gog` currently does not print a version string; use tags + changelog as the source of truth.
-- If you later add `gog version`, update this doc to validate `gog version` post-install.
+- Validate `gog --version` after the Homebrew install to confirm the released binary matches the tag you published.

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,7 +48,7 @@
           <a href="#quickstart">Quickstart</a>
           <a href="#features">Features</a>
           <a href="#examples">Examples</a>
-          <a class="nav__cta" href="https://github.com/steipete/gogcli">GitHub</a>
+          <a class="nav__cta" href="https://github.com/Robben-Media/gogcli">GitHub</a>
         </nav>
       </div>
     </header>
@@ -82,7 +82,7 @@
 
             <div class="hero__actions">
               <a class="btn btn--primary" href="#install">Install</a>
-              <a class="btn btn--ghost" href="https://github.com/steipete/gogcli#quick-start">Readme</a>
+              <a class="btn btn--ghost" href="https://github.com/Robben-Media/gogcli#quick-start">Readme</a>
             </div>
 
             <p class="note">
@@ -102,7 +102,7 @@
               </div>
               <div class="term__body">
                 <pre class="term__pre"><code id="demo">
-$ brew install steipete/tap/gogcli
+$ brew install itsjeremyjohnson/tap/gogcli
 $ gog auth credentials ~/Downloads/client_secret.json
 $ gog auth add you@gmail.com
 
@@ -142,11 +142,11 @@ $ gog drive ls --query "mimeType='application/pdf'" --max 3
           <div class="cols">
             <div class="card block">
               <h3>Homebrew</h3>
-              <pre class="code"><code>brew install steipete/tap/gogcli</code></pre>
+              <pre class="code"><code>brew install itsjeremyjohnson/tap/gogcli</code></pre>
             </div>
             <div class="card block">
               <h3>From source</h3>
-              <pre class="code"><code>git clone https://github.com/steipete/gogcli.git
+              <pre class="code"><code>git clone https://github.com/Robben-Media/gogcli.git
 cd gogcli
 make
 ./bin/gog --help</code></pre>
@@ -264,8 +264,8 @@ gog slides export &lt;presentationId&gt; --format pptx --out ./deck.pptx</code><
           </div>
 
           <div class="footerline">
-            <a class="btn btn--primary" href="https://github.com/steipete/gogcli">Go to GitHub</a>
-            <a class="btn btn--ghost" href="https://github.com/steipete/gogcli/blob/main/CHANGELOG.md">Changelog</a>
+            <a class="btn btn--primary" href="https://github.com/Robben-Media/gogcli">Go to GitHub</a>
+            <a class="btn btn--ghost" href="https://github.com/Robben-Media/gogcli/blob/main/CHANGELOG.md">Changelog</a>
           </div>
         </div>
       </section>
@@ -279,15 +279,15 @@ gog slides export &lt;presentationId&gt; --format pptx --out ./deck.pptx</code><
             <span>gog</span>
           </div>
           <div class="sitefoot__small">
-            <span>Built by <a href="https://steipete.me">Peter Steinberger</a>.</span>
+            <span>Maintained by Robben Media.</span>
             <span class="sep" aria-hidden="true">·</span>
-            <a href="https://github.com/steipete/gogcli/blob/main/LICENSE">MIT</a>
+            <a href="https://github.com/Robben-Media/gogcli/blob/main/LICENSE">MIT</a>
           </div>
         </div>
         <div class="sitefoot__right">
-          <a href="https://github.com/steipete/gogcli">Source</a>
-          <a href="https://github.com/steipete/gogcli#installation">Install</a>
-          <a href="https://github.com/steipete/gogcli#commands">Commands</a>
+          <a href="https://github.com/Robben-Media/gogcli">Source</a>
+          <a href="https://github.com/Robben-Media/gogcli#installation">Install</a>
+          <a href="https://github.com/Robben-Media/gogcli#commands">Commands</a>
         </div>
       </div>
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/steipete/gogcli
+module github.com/Robben-Media/gogcli
 
 go 1.26.0
 

--- a/internal/authclient/authclient.go
+++ b/internal/authclient/authclient.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 type contextKey struct{}

--- a/internal/cmd/account.go
+++ b/internal/cmd/account.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 var openSecretsStoreForAccount = secrets.OpenDefault

--- a/internal/cmd/account_test.go
+++ b/internal/cmd/account_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 type fakeSecretsStore struct {

--- a/internal/cmd/analytics.go
+++ b/internal/cmd/analytics.go
@@ -9,9 +9,9 @@ import (
 	analyticsadmin "google.golang.org/api/analyticsadmin/v1beta"
 	analyticsdata "google.golang.org/api/analyticsdata/v1beta"
 
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var (

--- a/internal/cmd/analytics_admin.go
+++ b/internal/cmd/analytics_admin.go
@@ -16,11 +16,13 @@ type AnalyticsAdminCmd struct {
 
 // Stubs for resources not yet implemented (PR 2).
 
-type AAAccountsCmd struct{}
-type AAPropertiesCmd struct{}
-type AAConversionEventsCmd struct{}
-type AACustomDimensionsCmd struct{}
-type AACustomMetricsCmd struct{}
-type AAFirebaseLinksCmd struct{}
-type AAGoogleAdsLinksCmd struct{}
-type AAKeyEventsCmd struct{}
+type (
+	AAAccountsCmd         struct{}
+	AAPropertiesCmd       struct{}
+	AAConversionEventsCmd struct{}
+	AACustomDimensionsCmd struct{}
+	AACustomMetricsCmd    struct{}
+	AAFirebaseLinksCmd    struct{}
+	AAGoogleAdsLinksCmd   struct{}
+	AAKeyEventsCmd        struct{}
+)

--- a/internal/cmd/analytics_admin_streams.go
+++ b/internal/cmd/analytics_admin_streams.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	analyticsadmin "google.golang.org/api/analyticsadmin/v1beta"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ---------------------------------------------------------------------------
@@ -22,7 +22,7 @@ type AADataStreamsCmd struct {
 	Delete AADataStreamsDeleteCmd `cmd:"" name:"delete" help:"Delete a data stream"`
 	Get    AADataStreamsGetCmd    `cmd:"" name:"get" help:"Get a data stream"`
 	List   AADataStreamsListCmd   `cmd:"" name:"list" help:"List data streams for a property"`
-	Patch  AADataStreamsPatchCmd `cmd:"" name:"patch" help:"Update a data stream"`
+	Patch  AADataStreamsPatchCmd  `cmd:"" name:"patch" help:"Update a data stream"`
 }
 
 // --- create ---

--- a/internal/cmd/analytics_admin_streams_test.go
+++ b/internal/cmd/analytics_admin_streams_test.go
@@ -157,9 +157,9 @@ func TestExecute_AADataStreamsList_JSON(t *testing.T) {
 
 	var parsed struct {
 		DataStreams []struct {
-			Name        string `json:"name"`
-			Type        string `json:"type"`
-			DisplayName string `json:"displayName"`
+			Name          string `json:"name"`
+			Type          string `json:"type"`
+			DisplayName   string `json:"displayName"`
 			WebStreamData struct {
 				MeasurementId string `json:"measurementId"`
 			} `json:"webStreamData"`
@@ -202,8 +202,8 @@ func TestExecute_AADataStreamsCreate_JSON(t *testing.T) {
 
 	var parsed struct {
 		DataStream struct {
-			Name        string `json:"name"`
-			DisplayName string `json:"displayName"`
+			Name          string `json:"name"`
+			DisplayName   string `json:"displayName"`
 			WebStreamData struct {
 				MeasurementId string `json:"measurementId"`
 			} `json:"webStreamData"`

--- a/internal/cmd/analytics_audience.go
+++ b/internal/cmd/analytics_audience.go
@@ -8,8 +8,8 @@ import (
 
 	analyticsdata "google.golang.org/api/analyticsdata/v1beta"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // --- audience-exports parent command ---

--- a/internal/cmd/analytics_reports.go
+++ b/internal/cmd/analytics_reports.go
@@ -10,9 +10,9 @@ import (
 
 	analyticsdata "google.golang.org/api/analyticsdata/v1beta"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // --- pivot-report ---

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -11,12 +11,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/steipete/gogcli/internal/authclient"
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleauth"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/secrets"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/authclient"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var (

--- a/internal/cmd/auth_add_keep_more_test.go
+++ b/internal/cmd/auth_add_keep_more_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleauth"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/secrets"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestAuthAddCmd_JSON_More(t *testing.T) {

--- a/internal/cmd/auth_add_test.go
+++ b/internal/cmd/auth_add_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleauth"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 func TestAuthAddCmd_JSON(t *testing.T) {

--- a/internal/cmd/auth_alias.go
+++ b/internal/cmd/auth_alias.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type AuthAliasCmd struct {

--- a/internal/cmd/auth_alias_test.go
+++ b/internal/cmd/auth_alias_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestAuthAliasSetListUnset_JSON(t *testing.T) {

--- a/internal/cmd/auth_cmd_test.go
+++ b/internal/cmd/auth_cmd_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/99designs/keyring"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 type memSecretsStore struct {

--- a/internal/cmd/auth_keychain_test.go
+++ b/internal/cmd/auth_keychain_test.go
@@ -5,7 +5,7 @@ package cmd
 import (
 	"testing"
 
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 func TestAuthAddCmd_ChecksKeychainFirst(t *testing.T) {

--- a/internal/cmd/auth_keyring.go
+++ b/internal/cmd/auth_keyring.go
@@ -7,10 +7,10 @@ import (
 
 	"golang.org/x/term"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/secrets"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type AuthKeyringCmd struct {

--- a/internal/cmd/auth_keyring_test.go
+++ b/internal/cmd/auth_keyring_test.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/secrets"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestAuthKeyringSet_WritesConfig(t *testing.T) {

--- a/internal/cmd/auth_manage_test.go
+++ b/internal/cmd/auth_manage_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func TestAuthManageCmd_ServicesAndOptions(t *testing.T) {

--- a/internal/cmd/auth_more_test.go
+++ b/internal/cmd/auth_more_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleauth"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestAuthKeepCmd_JSON(t *testing.T) {

--- a/internal/cmd/auth_service_account.go
+++ b/internal/cmd/auth_service_account.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type AuthServiceAccountCmd struct {

--- a/internal/cmd/auth_service_account_more_test.go
+++ b/internal/cmd/auth_service_account_more_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 func TestAuthServiceAccountSet_AndList_Text(t *testing.T) {

--- a/internal/cmd/auth_services_test.go
+++ b/internal/cmd/auth_services_test.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestAuthServices_JSON(t *testing.T) {

--- a/internal/cmd/auth_text_test.go
+++ b/internal/cmd/auth_text_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 func TestAuthTextOutputs(t *testing.T) {

--- a/internal/cmd/auth_tokens_more_test.go
+++ b/internal/cmd/auth_tokens_more_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/secrets"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestAuthTokensExportImport_JSON(t *testing.T) {

--- a/internal/cmd/auth_validation_more_test.go
+++ b/internal/cmd/auth_validation_more_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleauth"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/secrets"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestAuthCredentialsCmd_ErrorsAndStdin(t *testing.T) {

--- a/internal/cmd/bigquery.go
+++ b/internal/cmd/bigquery.go
@@ -8,9 +8,9 @@ import (
 
 	"google.golang.org/api/bigquery/v2"
 
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var newBigqueryService = googleapi.NewBigquery

--- a/internal/cmd/businessprofile.go
+++ b/internal/cmd/businessprofile.go
@@ -8,9 +8,9 @@ import (
 
 	mybusinessbusinessinformation "google.golang.org/api/mybusinessbusinessinformation/v1"
 
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var (

--- a/internal/cmd/businessprofile_accounts.go
+++ b/internal/cmd/businessprofile_accounts.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	mybusinessaccountmanagement "google.golang.org/api/mybusinessaccountmanagement/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // BusinessProfileAccountsCreateCmd creates a new account.

--- a/internal/cmd/businessprofile_admins.go
+++ b/internal/cmd/businessprofile_admins.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	mybusinessaccountmanagement "google.golang.org/api/mybusinessaccountmanagement/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // BusinessProfileAccountAdminsCmd is a parent for account admin subcommands.

--- a/internal/cmd/businessprofile_info_attributes.go
+++ b/internal/cmd/businessprofile_info_attributes.go
@@ -9,8 +9,8 @@ import (
 
 	mybusinessbusinessinformation "google.golang.org/api/mybusinessbusinessinformation/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // BusinessProfileInfoAttributesCmd is a parent for attribute subcommands.

--- a/internal/cmd/businessprofile_info_categories.go
+++ b/internal/cmd/businessprofile_info_categories.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // BusinessProfileInfoCategoriesCmd is a parent for category subcommands.

--- a/internal/cmd/businessprofile_info_chains.go
+++ b/internal/cmd/businessprofile_info_chains.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // BusinessProfileInfoChainsCmd is a parent for chain subcommands.

--- a/internal/cmd/businessprofile_info_locations.go
+++ b/internal/cmd/businessprofile_info_locations.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	mybusinessbusinessinformation "google.golang.org/api/mybusinessbusinessinformation/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // BusinessProfileInfoLocationsCmd is a parent for location info subcommands.

--- a/internal/cmd/businessprofile_invitations.go
+++ b/internal/cmd/businessprofile_invitations.go
@@ -8,8 +8,8 @@ import (
 
 	mybusinessaccountmanagement "google.golang.org/api/mybusinessaccountmanagement/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // BusinessProfileInvitationsCmd is a parent for account invitation subcommands.

--- a/internal/cmd/businessprofile_location_admins.go
+++ b/internal/cmd/businessprofile_location_admins.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	mybusinessaccountmanagement "google.golang.org/api/mybusinessaccountmanagement/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // BusinessProfileLocationAdminsCmd is a parent for location admin subcommands.

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 const calendarIDPrimary = "primary"

--- a/internal/cmd/calendar_acl.go
+++ b/internal/cmd/calendar_acl.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ACL scope type constants

--- a/internal/cmd/calendar_acl_test.go
+++ b/internal/cmd/calendar_acl_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // Test Calendar ACL List Command

--- a/internal/cmd/calendar_all_events_test.go
+++ b/internal/cmd/calendar_all_events_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestListAllCalendarsEvents_JSON(t *testing.T) {

--- a/internal/cmd/calendar_base.go
+++ b/internal/cmd/calendar_base.go
@@ -1,6 +1,6 @@
 package cmd
 
-import "github.com/steipete/gogcli/internal/googleapi"
+import "github.com/Robben-Media/gogcli/internal/googleapi"
 
 var newCalendarService = googleapi.NewCalendar
 

--- a/internal/cmd/calendar_channels.go
+++ b/internal/cmd/calendar_channels.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // CalendarChannelsCmd is the parent command for channel operations.

--- a/internal/cmd/calendar_channels_test.go
+++ b/internal/cmd/calendar_channels_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestCalendarChannelsStopCmd_JSON(t *testing.T) {

--- a/internal/cmd/calendar_colors.go
+++ b/internal/cmd/calendar_colors.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"text/tabwriter"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type CalendarColorsCmd struct{}

--- a/internal/cmd/calendar_conflicts.go
+++ b/internal/cmd/calendar_conflicts.go
@@ -11,8 +11,8 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type conflict struct {

--- a/internal/cmd/calendar_create_update_test.go
+++ b/internal/cmd/calendar_create_update_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestCalendarCreateCmd_RunJSON(t *testing.T) {

--- a/internal/cmd/calendar_delete_test.go
+++ b/internal/cmd/calendar_delete_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestCalendarDeleteCmd_ScopeSingle(t *testing.T) {

--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type CalendarCreateCmd struct {

--- a/internal/cmd/calendar_edit_test.go
+++ b/internal/cmd/calendar_edit_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/alecthomas/kong"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func parseKongContext(t *testing.T, cmd any, args []string) *kong.Context {

--- a/internal/cmd/calendar_edit_validation_more_test.go
+++ b/internal/cmd/calendar_edit_validation_more_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestCalendarCreateCmd_ValidationErrors(t *testing.T) {

--- a/internal/cmd/calendar_events_edit.go
+++ b/internal/cmd/calendar_events_edit.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // Calendar events operations - watch, import, instances, quick-add, move.

--- a/internal/cmd/calendar_events_edit_test.go
+++ b/internal/cmd/calendar_events_edit_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestCalendarEventsWatchCmd_JSON(t *testing.T) {

--- a/internal/cmd/calendar_events_test.go
+++ b/internal/cmd/calendar_events_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestListCalendarEvents_JSON(t *testing.T) {

--- a/internal/cmd/calendar_focus_time.go
+++ b/internal/cmd/calendar_focus_time.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type CalendarFocusTimeCmd struct {

--- a/internal/cmd/calendar_freebusy.go
+++ b/internal/cmd/calendar_freebusy.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type CalendarFreeBusyCmd struct {

--- a/internal/cmd/calendar_list.go
+++ b/internal/cmd/calendar_list.go
@@ -10,8 +10,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	gapi "google.golang.org/api/googleapi"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func listCalendarEvents(ctx context.Context, svc *calendar.Service, calendarID, from, to string, maxResults int64, page, query, privatePropFilter, sharedPropFilter, fields string, showWeekday bool) error {

--- a/internal/cmd/calendar_list_edit.go
+++ b/internal/cmd/calendar_list_edit.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // Calendar list management commands - manage the user's calendar list.

--- a/internal/cmd/calendar_list_edit_test.go
+++ b/internal/cmd/calendar_list_edit_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // Test Calendar Calendars List Command

--- a/internal/cmd/calendar_more_commands_test.go
+++ b/internal/cmd/calendar_more_commands_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestCalendarMoreCommands_JSON(t *testing.T) {

--- a/internal/cmd/calendar_more_commands_text_test.go
+++ b/internal/cmd/calendar_more_commands_text_test.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestCalendarMoreCommands_Text(t *testing.T) {

--- a/internal/cmd/calendar_ooo.go
+++ b/internal/cmd/calendar_ooo.go
@@ -7,8 +7,8 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type CalendarOOOCmd struct {

--- a/internal/cmd/calendar_print.go
+++ b/internal/cmd/calendar_print.go
@@ -7,7 +7,7 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func printCalendarEventWithTimezone(u *ui.UI, event *calendar.Event, calendarTimezone string, loc *time.Location) {

--- a/internal/cmd/calendar_print_test.go
+++ b/internal/cmd/calendar_print_test.go
@@ -8,7 +8,7 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestEventStartEnd_Extra(t *testing.T) {

--- a/internal/cmd/calendar_propose_time.go
+++ b/internal/cmd/calendar_propose_time.go
@@ -11,8 +11,8 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 const (

--- a/internal/cmd/calendar_propose_time_test.go
+++ b/internal/cmd/calendar_propose_time_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestProposeTimeURLGeneration(t *testing.T) {

--- a/internal/cmd/calendar_respond.go
+++ b/internal/cmd/calendar_respond.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type CalendarRespondCmd struct {

--- a/internal/cmd/calendar_respond_cmd_test.go
+++ b/internal/cmd/calendar_respond_cmd_test.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestCalendarRespondCmd_Text(t *testing.T) {

--- a/internal/cmd/calendar_search.go
+++ b/internal/cmd/calendar_search.go
@@ -8,8 +8,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type CalendarSearchCmd struct {

--- a/internal/cmd/calendar_settings.go
+++ b/internal/cmd/calendar_settings.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // Calendar settings commands - manage user calendar settings.

--- a/internal/cmd/calendar_settings_test.go
+++ b/internal/cmd/calendar_settings_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // Test Calendar Settings List Command

--- a/internal/cmd/calendar_team.go
+++ b/internal/cmd/calendar_team.go
@@ -11,8 +11,8 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type CalendarTeamCmd struct {

--- a/internal/cmd/calendar_team_test.go
+++ b/internal/cmd/calendar_team_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestCalendarTeamRunFreeBusy(t *testing.T) {

--- a/internal/cmd/calendar_time.go
+++ b/internal/cmd/calendar_time.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type CalendarTimeCmd struct {

--- a/internal/cmd/calendar_update_delete_test.go
+++ b/internal/cmd/calendar_update_delete_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestCalendarUpdateAndDelete(t *testing.T) {

--- a/internal/cmd/calendar_users.go
+++ b/internal/cmd/calendar_users.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 const calendarUsersRequestTimeout = 20 * time.Second

--- a/internal/cmd/calendar_working_location.go
+++ b/internal/cmd/calendar_working_location.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type CalendarWorkingLocationCmd struct {

--- a/internal/cmd/calendar_working_location_test.go
+++ b/internal/cmd/calendar_working_location_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestWorkingLocationProperties(t *testing.T) {

--- a/internal/cmd/chat_dm.go
+++ b/internal/cmd/chat_dm.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ChatDMCmd struct {

--- a/internal/cmd/chat_emoji.go
+++ b/internal/cmd/chat_emoji.go
@@ -10,9 +10,9 @@ import (
 
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ChatEmojiCmd contains subcommands for custom emoji management.

--- a/internal/cmd/chat_events.go
+++ b/internal/cmd/chat_events.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ChatEventsCmd contains subcommands for space events.

--- a/internal/cmd/chat_media.go
+++ b/internal/cmd/chat_media.go
@@ -11,9 +11,9 @@ import (
 	"google.golang.org/api/chat/v1"
 	gapi "google.golang.org/api/googleapi"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ChatMediaCmd contains subcommands for media management.

--- a/internal/cmd/chat_members.go
+++ b/internal/cmd/chat_members.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ChatMembersCmd contains subcommands for space members management.

--- a/internal/cmd/chat_messages.go
+++ b/internal/cmd/chat_messages.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ChatMessagesCmd struct {

--- a/internal/cmd/chat_messages_edit.go
+++ b/internal/cmd/chat_messages_edit.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ChatMessagesGetCmd gets details about a message.

--- a/internal/cmd/chat_reactions.go
+++ b/internal/cmd/chat_reactions.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ChatReactionsCmd contains subcommands for reaction management.

--- a/internal/cmd/chat_readstate.go
+++ b/internal/cmd/chat_readstate.go
@@ -8,8 +8,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ChatNotificationSettingsCmd contains subcommands for space notification settings.

--- a/internal/cmd/chat_services.go
+++ b/internal/cmd/chat_services.go
@@ -5,7 +5,7 @@ import (
 
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
 )
 
 var newChatService func(ctx context.Context, email string) (*chat.Service, error) = googleapi.NewChat

--- a/internal/cmd/chat_spaces.go
+++ b/internal/cmd/chat_spaces.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ChatSpacesCmd struct {

--- a/internal/cmd/chat_spaces_edit.go
+++ b/internal/cmd/chat_spaces_edit.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ChatSpacesCompleteImportCmd completes the import of a space.

--- a/internal/cmd/chat_threads.go
+++ b/internal/cmd/chat_threads.go
@@ -7,8 +7,8 @@ import (
 
 	"google.golang.org/api/chat/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ChatThreadsCmd struct {

--- a/internal/cmd/classroom.go
+++ b/internal/cmd/classroom.go
@@ -1,6 +1,6 @@
 package cmd
 
-import "github.com/steipete/gogcli/internal/googleapi"
+import "github.com/Robben-Media/gogcli/internal/googleapi"
 
 var newClassroomService = googleapi.NewClassroom
 

--- a/internal/cmd/classroom_announcements.go
+++ b/internal/cmd/classroom_announcements.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/classroom/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ClassroomAnnouncementsCmd struct {

--- a/internal/cmd/classroom_courses.go
+++ b/internal/cmd/classroom_courses.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/classroom/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ClassroomCoursesCmd struct {

--- a/internal/cmd/classroom_coursework.go
+++ b/internal/cmd/classroom_coursework.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/classroom/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ClassroomCourseworkCmd struct {

--- a/internal/cmd/classroom_guardians.go
+++ b/internal/cmd/classroom_guardians.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/classroom/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ClassroomGuardiansCmd struct {

--- a/internal/cmd/classroom_invitations.go
+++ b/internal/cmd/classroom_invitations.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/classroom/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ClassroomInvitationsCmd struct {

--- a/internal/cmd/classroom_materials.go
+++ b/internal/cmd/classroom_materials.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/classroom/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ClassroomMaterialsCmd struct {

--- a/internal/cmd/classroom_profile.go
+++ b/internal/cmd/classroom_profile.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ClassroomProfileCmd struct {

--- a/internal/cmd/classroom_rosters.go
+++ b/internal/cmd/classroom_rosters.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/classroom/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ClassroomStudentsCmd struct {

--- a/internal/cmd/classroom_submissions.go
+++ b/internal/cmd/classroom_submissions.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/classroom/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ClassroomSubmissionsCmd struct {

--- a/internal/cmd/classroom_topics.go
+++ b/internal/cmd/classroom_topics.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/classroom/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ClassroomTopicsCmd struct {

--- a/internal/cmd/client_helpers.go
+++ b/internal/cmd/client_helpers.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/authclient"
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/authclient"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 func resolveClientOverride(flags *RootFlags, cmdClient string) string {

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
 )
 
 type ConfigCmd struct {

--- a/internal/cmd/config_cmd_test.go
+++ b/internal/cmd/config_cmd_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 func TestConfigCmd_JSONParity(t *testing.T) {

--- a/internal/cmd/confirm.go
+++ b/internal/cmd/confirm.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/term"
 
-	"github.com/steipete/gogcli/internal/input"
+	"github.com/Robben-Media/gogcli/internal/input"
 )
 
 func confirmDestructive(ctx context.Context, flags *RootFlags, action string) error {

--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type ContactsCmd struct {

--- a/internal/cmd/contacts_crud.go
+++ b/internal/cmd/contacts_crud.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 const (

--- a/internal/cmd/contacts_crud_error_test.go
+++ b/internal/cmd/contacts_crud_error_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func newPeopleService(t *testing.T, handler http.HandlerFunc) (*people.Service, func()) {

--- a/internal/cmd/contacts_crud_validation_more_test.go
+++ b/internal/cmd/contacts_crud_validation_more_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/alecthomas/kong"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func parseContactsKong(t *testing.T, cmd any, args []string) *kong.Context {

--- a/internal/cmd/contacts_directory.go
+++ b/internal/cmd/contacts_directory.go
@@ -9,8 +9,8 @@ import (
 
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 const (

--- a/internal/cmd/contacts_groups.go
+++ b/internal/cmd/contacts_groups.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ContactGroupsCmd contains subcommands for contact groups.

--- a/internal/cmd/contacts_groups_test.go
+++ b/internal/cmd/contacts_groups_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestContactGroupsList(t *testing.T) {

--- a/internal/cmd/contacts_output.go
+++ b/internal/cmd/contacts_output.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func writeDeleteResult(ctx context.Context, u *ui.UI, resourceName string) error {

--- a/internal/cmd/contacts_services.go
+++ b/internal/cmd/contacts_services.go
@@ -5,7 +5,7 @@ import (
 
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
 )
 
 var (

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -16,10 +16,10 @@ import (
 	"google.golang.org/api/drive/v3"
 	gapi "google.golang.org/api/googleapi"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var newDocsService = googleapi.NewDocs

--- a/internal/cmd/docs_commands_test.go
+++ b/internal/cmd/docs_commands_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDocsCreateCopyCat_JSON(t *testing.T) {

--- a/internal/cmd/docs_create_test.go
+++ b/internal/cmd/docs_create_test.go
@@ -15,8 +15,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var errUnexpectedFactoryCall = errors.New("unexpected factory call")

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/docs/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // DocsDeleteRangeCmd deletes content in a range within a Google Doc.

--- a/internal/cmd/docs_edit_test.go
+++ b/internal/cmd/docs_edit_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/docs/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func newDocsEditTestServer(t *testing.T, batchRequests *[][]*docs.Request) *httptest.Server {

--- a/internal/cmd/docs_tabs_test.go
+++ b/internal/cmd/docs_tabs_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/docs/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDocsCat_Tab(t *testing.T) {

--- a/internal/cmd/docs_validation_more_test.go
+++ b/internal/cmd/docs_validation_more_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/docs/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDocsInfo_ValidationAndText(t *testing.T) {

--- a/internal/cmd/docs_write_update_test.go
+++ b/internal/cmd/docs_write_update_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/docs/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDocsWriteUpdate_JSON(t *testing.T) {

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -13,10 +13,10 @@ import (
 	"google.golang.org/api/drive/v3"
 	gapi "google.golang.org/api/googleapi"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var newDriveService = googleapi.NewDrive
@@ -466,7 +466,7 @@ func (c *DriveDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("empty fileId")
 	}
 
-	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("delete drive file %s", fileID)); confirmErr != nil {
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("trash drive file %s", fileID)); confirmErr != nil {
 		return confirmErr
 	}
 
@@ -475,16 +475,16 @@ func (c *DriveDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	if err := svc.Files.Delete(fileID).SupportsAllDrives(true).Context(ctx).Do(); err != nil {
+	if _, err := svc.Files.Update(fileID, &drive.File{Trashed: true}).SupportsAllDrives(true).Context(ctx).Do(); err != nil {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{
-			"deleted": true,
+			"trashed": true,
 			"id":      fileID,
 		})
 	}
-	u.Out().Printf("deleted\ttrue")
+	u.Out().Printf("trashed\ttrue")
 	u.Out().Printf("id\t%s", fileID)
 	return nil
 }

--- a/internal/cmd/drive_about.go
+++ b/internal/cmd/drive_about.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // DriveAboutCmd gets information about the user's Drive account

--- a/internal/cmd/drive_about_test.go
+++ b/internal/cmd/drive_about_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveAboutCmd_JSON(t *testing.T) {

--- a/internal/cmd/drive_changes.go
+++ b/internal/cmd/drive_changes.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 const allDrivesCorpora = "allDrives"

--- a/internal/cmd/drive_changes_test.go
+++ b/internal/cmd/drive_changes_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveChangesGetStartPageTokenCmd_JSON(t *testing.T) {

--- a/internal/cmd/drive_channels.go
+++ b/internal/cmd/drive_channels.go
@@ -7,8 +7,8 @@ import (
 
 	"google.golang.org/api/drive/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // DriveChannelsCmd is the parent command for channel operations

--- a/internal/cmd/drive_channels_test.go
+++ b/internal/cmd/drive_channels_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveChannelsStopCmd(t *testing.T) {

--- a/internal/cmd/drive_comments.go
+++ b/internal/cmd/drive_comments.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/drive/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // DriveCommentsCmd is the parent command for comments subcommands

--- a/internal/cmd/drive_comments_cmd_test.go
+++ b/internal/cmd/drive_comments_cmd_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveCommentsListCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/drive_comments_validation_more_test.go
+++ b/internal/cmd/drive_comments_validation_more_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveComments_ValidationErrors(t *testing.T) {

--- a/internal/cmd/drive_copy.go
+++ b/internal/cmd/drive_copy.go
@@ -9,8 +9,8 @@ import (
 
 	"google.golang.org/api/drive/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type copyViaDriveOptions struct {

--- a/internal/cmd/drive_download_helpers.go
+++ b/internal/cmd/drive_download_helpers.go
@@ -9,7 +9,7 @@ import (
 
 	"google.golang.org/api/drive/v3"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 func resolveDriveDownloadDestPath(meta *drive.File, outPathFlag string) (string, error) {

--- a/internal/cmd/drive_drives.go
+++ b/internal/cmd/drive_drives.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // DriveDrivesCmd lists all shared drives the user has access to.

--- a/internal/cmd/drive_drives_admin.go
+++ b/internal/cmd/drive_drives_admin.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/api/drive/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // DriveDrivesAdminCmd is the parent command for shared drives admin operations

--- a/internal/cmd/drive_drives_test.go
+++ b/internal/cmd/drive_drives_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveDrivesCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/drive_files_edit.go
+++ b/internal/cmd/drive_files_edit.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // DriveFilesCmd is the parent command for file operations

--- a/internal/cmd/drive_files_edit_test.go
+++ b/internal/cmd/drive_files_edit_test.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
 )
 
 // ============================================

--- a/internal/cmd/drive_get_download_more_test.go
+++ b/internal/cmd/drive_get_download_more_test.go
@@ -15,8 +15,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveGetCmd_TextWithDetailsAndJSON(t *testing.T) {

--- a/internal/cmd/drive_ls_cmd_test.go
+++ b/internal/cmd/drive_ls_cmd_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveLsCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/drive_more_commands_test.go
+++ b/internal/cmd/drive_more_commands_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveGetDownloadUploadURL_JSON(t *testing.T) {

--- a/internal/cmd/drive_permissions.go
+++ b/internal/cmd/drive_permissions.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/drive/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // Permission type constants

--- a/internal/cmd/drive_permissions_test.go
+++ b/internal/cmd/drive_permissions_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDrivePermissionsListCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/drive_replies_test.go
+++ b/internal/cmd/drive_replies_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveRepliesListCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/drive_revisions.go
+++ b/internal/cmd/drive_revisions.go
@@ -9,8 +9,8 @@ import (
 
 	"google.golang.org/api/drive/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // DriveRevisionsCmd is the parent command for revisions subcommands

--- a/internal/cmd/drive_revisions_test.go
+++ b/internal/cmd/drive_revisions_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveRevisionsListCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/drive_search_more_test.go
+++ b/internal/cmd/drive_search_more_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func driveAllDrivesQueryError(r *http.Request) string {

--- a/internal/cmd/drive_upload_convert_test.go
+++ b/internal/cmd/drive_upload_convert_test.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveUploadConvertMetadata(t *testing.T) {

--- a/internal/cmd/drive_url_cmd_test.go
+++ b/internal/cmd/drive_url_cmd_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveURLCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/drive_validation_more_test.go
+++ b/internal/cmd/drive_validation_more_test.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestDriveCommands_MissingAccount(t *testing.T) {

--- a/internal/cmd/execute_auth_add_test.go
+++ b/internal/cmd/execute_auth_add_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleauth"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 func TestExecute_AuthAdd_JSON(t *testing.T) {

--- a/internal/cmd/execute_auth_credentials_test.go
+++ b/internal/cmd/execute_auth_credentials_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 func TestExecute_AuthCredentials_JSON(t *testing.T) {

--- a/internal/cmd/execute_drive_test.go
+++ b/internal/cmd/execute_drive_test.go
@@ -15,9 +15,9 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestExecute_DriveGet_JSON(t *testing.T) {

--- a/internal/cmd/export_via_drive.go
+++ b/internal/cmd/export_via_drive.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type exportViaDriveOptions struct {

--- a/internal/cmd/gmail.go
+++ b/internal/cmd/gmail.go
@@ -11,9 +11,9 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var newGmailService = googleapi.NewGmail

--- a/internal/cmd/gmail_attachment.go
+++ b/internal/cmd/gmail_attachment.go
@@ -11,9 +11,9 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailAttachmentCmd struct {

--- a/internal/cmd/gmail_attachments.go
+++ b/internal/cmd/gmail_attachments.go
@@ -7,7 +7,7 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type attachmentInfo struct {

--- a/internal/cmd/gmail_autoforward.go
+++ b/internal/cmd/gmail_autoforward.go
@@ -8,8 +8,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailAutoForwardCmd struct {

--- a/internal/cmd/gmail_autoforward_cmd_test.go
+++ b/internal/cmd/gmail_autoforward_cmd_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailAutoForwardGetCmd_Text(t *testing.T) {

--- a/internal/cmd/gmail_batch.go
+++ b/internal/cmd/gmail_batch.go
@@ -7,8 +7,8 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailBatchCmd struct {

--- a/internal/cmd/gmail_body_input.go
+++ b/internal/cmd/gmail_body_input.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 func resolveBodyInput(body, bodyFile string) (string, error) {

--- a/internal/cmd/gmail_cse.go
+++ b/internal/cmd/gmail_cse.go
@@ -12,8 +12,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // GmailCseCmd handles CSE (Client-Side Encryption) operations.

--- a/internal/cmd/gmail_cse_test.go
+++ b/internal/cmd/gmail_cse_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // Test CSE Identities List

--- a/internal/cmd/gmail_delegates.go
+++ b/internal/cmd/gmail_delegates.go
@@ -9,8 +9,8 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailDelegatesCmd struct {

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -9,9 +9,9 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailDraftsCmd struct {

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -15,8 +15,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailDraftsListCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/gmail_drafts_more_coverage_test.go
+++ b/internal/cmd/gmail_drafts_more_coverage_test.go
@@ -15,8 +15,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailDraftsList_Empty(t *testing.T) {

--- a/internal/cmd/gmail_drafts_text_more_test.go
+++ b/internal/cmd/gmail_drafts_text_more_test.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailDraftsCreateDelete_Text(t *testing.T) {

--- a/internal/cmd/gmail_filters.go
+++ b/internal/cmd/gmail_filters.go
@@ -10,8 +10,8 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailFiltersCmd struct {

--- a/internal/cmd/gmail_filters_cmd_test.go
+++ b/internal/cmd/gmail_filters_cmd_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailFiltersCreate_Validation(t *testing.T) {

--- a/internal/cmd/gmail_forwarding.go
+++ b/internal/cmd/gmail_forwarding.go
@@ -9,8 +9,8 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailForwardingCmd struct {

--- a/internal/cmd/gmail_get.go
+++ b/internal/cmd/gmail_get.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailGetCmd struct {

--- a/internal/cmd/gmail_get_cmd_test.go
+++ b/internal/cmd/gmail_get_cmd_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailGetCmd_JSON_Full(t *testing.T) {

--- a/internal/cmd/gmail_history.go
+++ b/internal/cmd/gmail_history.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailHistoryCmd struct {

--- a/internal/cmd/gmail_history_cmd_test.go
+++ b/internal/cmd/gmail_history_cmd_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailHistoryCmd_JSON(t *testing.T) {

--- a/internal/cmd/gmail_imap_pop_language.go
+++ b/internal/cmd/gmail_imap_pop_language.go
@@ -8,8 +8,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // GmailImapCmd handles IMAP settings operations.

--- a/internal/cmd/gmail_labels.go
+++ b/internal/cmd/gmail_labels.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailLabelsCmd struct {

--- a/internal/cmd/gmail_labels_cmd_test.go
+++ b/internal/cmd/gmail_labels_cmd_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func newLabelsServer(t *testing.T, listLabels []map[string]any, handleCreate func(http.ResponseWriter, *http.Request)) *httptest.Server {

--- a/internal/cmd/gmail_labels_edit_test.go
+++ b/internal/cmd/gmail_labels_edit_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // TestGmailLabelsPatchCmd tests partial update of a label

--- a/internal/cmd/gmail_messages.go
+++ b/internal/cmd/gmail_messages.go
@@ -10,8 +10,8 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailMessagesCmd struct {

--- a/internal/cmd/gmail_messages_edit.go
+++ b/internal/cmd/gmail_messages_edit.go
@@ -10,8 +10,8 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // GmailMessagesImportCmd imports a message into the mailbox.

--- a/internal/cmd/gmail_messages_edit_test.go
+++ b/internal/cmd/gmail_messages_edit_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // TestGmailMessagesImportCmd tests importing a message

--- a/internal/cmd/gmail_send.go
+++ b/internal/cmd/gmail_send.go
@@ -10,10 +10,10 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/tracking"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/tracking"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailSendCmd struct {

--- a/internal/cmd/gmail_send_batches_test.go
+++ b/internal/cmd/gmail_send_batches_test.go
@@ -14,9 +14,9 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/tracking"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/tracking"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestSendGmailBatches_WithTracking(t *testing.T) {

--- a/internal/cmd/gmail_send_reply_test.go
+++ b/internal/cmd/gmail_send_reply_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestReplyInfoFromMessage_More(t *testing.T) {

--- a/internal/cmd/gmail_send_test.go
+++ b/internal/cmd/gmail_send_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestReplyHeaders(t *testing.T) {

--- a/internal/cmd/gmail_send_tracking_test.go
+++ b/internal/cmd/gmail_send_tracking_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/tracking"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/tracking"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestResolveTrackingConfig(t *testing.T) {

--- a/internal/cmd/gmail_send_validation_more_test.go
+++ b/internal/cmd/gmail_send_validation_more_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailSendCmd_ValidationErrors(t *testing.T) {

--- a/internal/cmd/gmail_sendas.go
+++ b/internal/cmd/gmail_sendas.go
@@ -11,8 +11,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailSendAsCmd struct {

--- a/internal/cmd/gmail_sendas_errors_more_test.go
+++ b/internal/cmd/gmail_sendas_errors_more_test.go
@@ -8,7 +8,7 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailSendAsCmd_ValidationErrors(t *testing.T) {

--- a/internal/cmd/gmail_sendas_more_test.go
+++ b/internal/cmd/gmail_sendas_more_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailSendAs_VerifyDeleteUpdate_JSON(t *testing.T) {

--- a/internal/cmd/gmail_sendas_test.go
+++ b/internal/cmd/gmail_sendas_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailSendAsListCmd_JSON(t *testing.T) {

--- a/internal/cmd/gmail_sendas_text_more_test.go
+++ b/internal/cmd/gmail_sendas_text_more_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailSendAsCreateVerifyDeleteUpdate_Text(t *testing.T) {

--- a/internal/cmd/gmail_sendas_text_test.go
+++ b/internal/cmd/gmail_sendas_text_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailSendAsListCmd_Text(t *testing.T) {

--- a/internal/cmd/gmail_settings_text_test.go
+++ b/internal/cmd/gmail_settings_text_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailSettings_TextPaths(t *testing.T) {

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -20,9 +20,9 @@ import (
 	"golang.org/x/text/encoding/ianaindex"
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // HTML stripping patterns for cleaner text output.

--- a/internal/cmd/gmail_thread_cmd_test.go
+++ b/internal/cmd/gmail_thread_cmd_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailThreadModifyCmd_JSON(t *testing.T) {

--- a/internal/cmd/gmail_thread_helpers_more_test.go
+++ b/internal/cmd/gmail_thread_helpers_more_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailURLCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/gmail_thread_validation_more_test.go
+++ b/internal/cmd/gmail_thread_validation_more_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailThreadGet_ValidationErrors(t *testing.T) {

--- a/internal/cmd/gmail_threads_edit.go
+++ b/internal/cmd/gmail_threads_edit.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // GmailThreadDeleteCmd permanently deletes a thread and all its messages.

--- a/internal/cmd/gmail_threads_edit_test.go
+++ b/internal/cmd/gmail_threads_edit_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // TestGmailThreadDeleteCmd tests permanent deletion of a thread

--- a/internal/cmd/gmail_track_cmd_test.go
+++ b/internal/cmd/gmail_track_cmd_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/tracking"
+	"github.com/Robben-Media/gogcli/internal/tracking"
 )
 
 func setupTrackingEnv(t *testing.T) {

--- a/internal/cmd/gmail_track_helpers.go
+++ b/internal/cmd/gmail_track_helpers.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/steipete/gogcli/internal/tracking"
+	"github.com/Robben-Media/gogcli/internal/tracking"
 )
 
 func loadTrackingConfigForAccount(flags *RootFlags) (string, *tracking.Config, error) {

--- a/internal/cmd/gmail_track_opens.go
+++ b/internal/cmd/gmail_track_opens.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/tracking"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/tracking"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 const trackingUnknown = "unknown"

--- a/internal/cmd/gmail_track_setup.go
+++ b/internal/cmd/gmail_track_setup.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/input"
-	"github.com/steipete/gogcli/internal/tracking"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/input"
+	"github.com/Robben-Media/gogcli/internal/tracking"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailTrackSetupCmd struct {

--- a/internal/cmd/gmail_track_status.go
+++ b/internal/cmd/gmail_track_status.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/tracking"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/tracking"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailTrackStatusCmd struct{}

--- a/internal/cmd/gmail_trash.go
+++ b/internal/cmd/gmail_trash.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailTrashCmd struct {

--- a/internal/cmd/gmail_url_test.go
+++ b/internal/cmd/gmail_url_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailURLCmd_JSON(t *testing.T) {

--- a/internal/cmd/gmail_vacation.go
+++ b/internal/cmd/gmail_vacation.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type GmailVacationCmd struct {

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/idtoken"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var (

--- a/internal/cmd/gmail_watch_cmds_errors_test.go
+++ b/internal/cmd/gmail_watch_cmds_errors_test.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/api/idtoken"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailWatchStartCmd_MissingTopic(t *testing.T) {

--- a/internal/cmd/gmail_watch_cmds_more_test.go
+++ b/internal/cmd/gmail_watch_cmds_more_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailWatchRenewAndStop_JSON(t *testing.T) {

--- a/internal/cmd/gmail_watch_helpers_test.go
+++ b/internal/cmd/gmail_watch_helpers_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestWriteWatchState_TextAndJSON(t *testing.T) {

--- a/internal/cmd/gmail_watch_serve_test.go
+++ b/internal/cmd/gmail_watch_serve_test.go
@@ -9,7 +9,7 @@ import (
 
 	"google.golang.org/api/idtoken"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailWatchServeCmd_UsesStoredHook(t *testing.T) {

--- a/internal/cmd/gmail_watch_server_more_test.go
+++ b/internal/cmd/gmail_watch_server_more_test.go
@@ -17,8 +17,8 @@ import (
 	gapi "google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailWatchServer_ServeHTTP_AllowNoHook(t *testing.T) {

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 type gmailWatchStore struct {

--- a/internal/cmd/gmail_watch_test.go
+++ b/internal/cmd/gmail_watch_test.go
@@ -15,8 +15,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGmailWatchStartCmd_JSON(t *testing.T) {

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -9,10 +9,10 @@ import (
 
 	"google.golang.org/api/cloudidentity/v1"
 
-	"github.com/steipete/gogcli/internal/errfmt"
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/errfmt"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var newCloudIdentityService = googleapi.NewCloudIdentityGroups

--- a/internal/cmd/groups_validation_more_test.go
+++ b/internal/cmd/groups_validation_more_test.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/api/cloudidentity/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestGroupsMembers_ValidationErrors(t *testing.T) {

--- a/internal/cmd/info_via_drive.go
+++ b/internal/cmd/info_via_drive.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type infoViaDriveOptions struct {

--- a/internal/cmd/info_via_drive_test.go
+++ b/internal/cmd/info_via_drive_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestInfoViaDriveCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/keep.go
+++ b/internal/cmd/keep.go
@@ -10,10 +10,10 @@ import (
 
 	keepapi "google.golang.org/api/keep/v1"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var newKeepServiceWithSA = googleapi.NewKeepWithServiceAccount

--- a/internal/cmd/keep_notes_edit.go
+++ b/internal/cmd/keep_notes_edit.go
@@ -8,8 +8,8 @@ import (
 
 	keepapi "google.golang.org/api/keep/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // KeepNotesCreateCmd creates a new Google Keep note (text or list).

--- a/internal/cmd/keep_permissions.go
+++ b/internal/cmd/keep_permissions.go
@@ -8,8 +8,8 @@ import (
 
 	keepapi "google.golang.org/api/keep/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // KeepPermissionsCmd contains subcommands for note permissions.

--- a/internal/cmd/keep_test.go
+++ b/internal/cmd/keep_test.go
@@ -14,7 +14,7 @@ import (
 	keepapi "google.golang.org/api/keep/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 func writeKeepSA(t *testing.T, email string) string {

--- a/internal/cmd/misc_more_test.go
+++ b/internal/cmd/misc_more_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
 )
 
 func TestCompletionCmdRun(t *testing.T) {

--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func tableWriter(ctx context.Context) (io.Writer, func()) {

--- a/internal/cmd/people.go
+++ b/internal/cmd/people.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"os"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type PeopleCmd struct {

--- a/internal/cmd/people_batch.go
+++ b/internal/cmd/people_batch.go
@@ -10,9 +10,9 @@ import (
 
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ContactsBatchCmd contains subcommands for batch contact operations.

--- a/internal/cmd/people_batch_test.go
+++ b/internal/cmd/people_batch_test.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestContactsBatchCreate(t *testing.T) {

--- a/internal/cmd/people_group_members.go
+++ b/internal/cmd/people_group_members.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ContactGroupMembersCmd contains subcommands for contact group members.

--- a/internal/cmd/people_group_members_test.go
+++ b/internal/cmd/people_group_members_test.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestContactGroupMembersModify(t *testing.T) {

--- a/internal/cmd/people_photo.go
+++ b/internal/cmd/people_photo.go
@@ -10,9 +10,9 @@ import (
 
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // ContactsPhotoCmd contains subcommands for contact photo management.

--- a/internal/cmd/people_photo_test.go
+++ b/internal/cmd/people_photo_test.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestContactsPhotoDelete(t *testing.T) {

--- a/internal/cmd/people_profile.go
+++ b/internal/cmd/people_profile.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/people/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 const (

--- a/internal/cmd/policy.go
+++ b/internal/cmd/policy.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
 )
 
 type PolicyCmd struct {

--- a/internal/cmd/policy_enforcement.go
+++ b/internal/cmd/policy_enforcement.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/alecthomas/kong"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 var commandServiceAliases = map[string]string{

--- a/internal/cmd/policy_enforcement_test.go
+++ b/internal/cmd/policy_enforcement_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 func TestPolicyEnforcement_DeniesBlockedGmailAction(t *testing.T) {

--- a/internal/cmd/policy_test.go
+++ b/internal/cmd/policy_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 func TestPolicyCreateListGetDelete(t *testing.T) {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/alecthomas/kong"
 
-	"github.com/steipete/gogcli/internal/authclient"
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/errfmt"
-	"github.com/steipete/gogcli/internal/googleauth"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/secrets"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/authclient"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/errfmt"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 const (

--- a/internal/cmd/searchconsole.go
+++ b/internal/cmd/searchconsole.go
@@ -8,9 +8,9 @@ import (
 
 	"google.golang.org/api/searchconsole/v1"
 
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var newSearchConsoleService = googleapi.NewSearchConsole

--- a/internal/cmd/searchconsole_sitemaps.go
+++ b/internal/cmd/searchconsole_sitemaps.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // --- sitemaps get ---

--- a/internal/cmd/searchconsole_sites.go
+++ b/internal/cmd/searchconsole_sites.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/searchconsole/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // --- sites get ---

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -10,9 +10,9 @@ import (
 
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var newSheetsService = googleapi.NewSheets

--- a/internal/cmd/sheets_append_validation_test.go
+++ b/internal/cmd/sheets_append_validation_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestSheetsAppendCopyValidationFrom(t *testing.T) {

--- a/internal/cmd/sheets_batch.go
+++ b/internal/cmd/sheets_batch.go
@@ -9,8 +9,8 @@ import (
 
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type SheetsBatchGetCmd struct {

--- a/internal/cmd/sheets_batch_test.go
+++ b/internal/cmd/sheets_batch_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var errUnexpectedCall = errors.New("unexpected call")

--- a/internal/cmd/sheets_commands_test.go
+++ b/internal/cmd/sheets_commands_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestSheetsCommands_JSON(t *testing.T) {

--- a/internal/cmd/sheets_format.go
+++ b/internal/cmd/sheets_format.go
@@ -9,8 +9,8 @@ import (
 
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type SheetsFormatCmd struct {

--- a/internal/cmd/sheets_format_test.go
+++ b/internal/cmd/sheets_format_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestSheetsFormatCmd(t *testing.T) {

--- a/internal/cmd/sheets_gaps.go
+++ b/internal/cmd/sheets_gaps.go
@@ -9,8 +9,8 @@ import (
 
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // SheetsDeveloperMetadataCmd contains subcommands for developer metadata.

--- a/internal/cmd/sheets_metadata_test.go
+++ b/internal/cmd/sheets_metadata_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestSheetsMetadataCmd_TextAndJSON(t *testing.T) {

--- a/internal/cmd/sheets_tabs.go
+++ b/internal/cmd/sheets_tabs.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type SheetsSheetCmd struct {

--- a/internal/cmd/sheets_tabs_test.go
+++ b/internal/cmd/sheets_tabs_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestExecute_SheetsSheetAdd_JSON(t *testing.T) {

--- a/internal/cmd/sheets_update_validation_test.go
+++ b/internal/cmd/sheets_update_validation_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestSheetsUpdateCopyValidationFrom(t *testing.T) {

--- a/internal/cmd/sheets_validation_more_test.go
+++ b/internal/cmd/sheets_validation_more_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestSheetsGet_ValidationAndNoData(t *testing.T) {

--- a/internal/cmd/slides.go
+++ b/internal/cmd/slides.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/drive/v3"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type SlidesCmd struct {

--- a/internal/cmd/tagmanager.go
+++ b/internal/cmd/tagmanager.go
@@ -8,9 +8,9 @@ import (
 
 	"google.golang.org/api/tagmanager/v2"
 
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var newTagManagerService = googleapi.NewTagManager

--- a/internal/cmd/tasks.go
+++ b/internal/cmd/tasks.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/steipete/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
 )
 
 var newTasksService = googleapi.NewTasks

--- a/internal/cmd/tasks_due.go
+++ b/internal/cmd/tasks_due.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"strings"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func warnTasksDueTime(u *ui.UI, due string) {

--- a/internal/cmd/tasks_edit.go
+++ b/internal/cmd/tasks_edit.go
@@ -7,8 +7,8 @@ import (
 
 	"google.golang.org/api/tasks/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // TasksMoveCmd moves a task within a task list (repositioning and nesting).

--- a/internal/cmd/tasks_edit_test.go
+++ b/internal/cmd/tasks_edit_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/tasks/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestTasksMove_JSON(t *testing.T) {

--- a/internal/cmd/tasks_items.go
+++ b/internal/cmd/tasks_items.go
@@ -10,8 +10,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/tasks/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 const (

--- a/internal/cmd/tasks_items_json_test.go
+++ b/internal/cmd/tasks_items_json_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/tasks/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestTasksItems_JSONPaths(t *testing.T) {

--- a/internal/cmd/tasks_items_validation_more_test.go
+++ b/internal/cmd/tasks_items_validation_more_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/alecthomas/kong"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func parseTasksKong(t *testing.T, cmd any, args []string) *kong.Context {

--- a/internal/cmd/tasks_lists.go
+++ b/internal/cmd/tasks_lists.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/api/tasks/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type TasksListsCmd struct {

--- a/internal/cmd/tasks_repeat_test.go
+++ b/internal/cmd/tasks_repeat_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/tasks/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestTasksAddCmd_RepeatCreatesMultiple(t *testing.T) {

--- a/internal/cmd/tasks_tasklists_edit.go
+++ b/internal/cmd/tasks_tasklists_edit.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/tasks/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 // TasksListsGetCmd retrieves a single task list by ID.

--- a/internal/cmd/tasks_tasklists_edit_test.go
+++ b/internal/cmd/tasks_tasklists_edit_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/tasks/v1"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestTasksLists_Get_JSON(t *testing.T) {

--- a/internal/cmd/tasks_text_test.go
+++ b/internal/cmd/tasks_text_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/tasks/v1"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestTasks_TextPaths(t *testing.T) {

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/alecthomas/kong"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 // withPrimaryCalendar wraps an http.Handler to also respond to primary calendar requests

--- a/internal/cmd/time_helpers.go
+++ b/internal/cmd/time_helpers.go
@@ -8,7 +8,7 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/cli"
+	"github.com/Robben-Media/gogcli/internal/cli"
 )
 
 // TimeRangeFlags provides common time range options for calendar commands.

--- a/internal/cmd/time_helpers_test.go
+++ b/internal/cmd/time_helpers_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/steipete/gogcli/internal/cli"
+	"github.com/Robben-Media/gogcli/internal/cli"
 )
 
 func TestParseTimeExpr(t *testing.T) {

--- a/internal/cmd/time_now.go
+++ b/internal/cmd/time_now.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 type TimeCmd struct {

--- a/internal/cmd/time_now_test.go
+++ b/internal/cmd/time_now_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestTimeNowCmd_JSON(t *testing.T) {

--- a/internal/cmd/timezone.go
+++ b/internal/cmd/timezone.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 type timezoneResolveMode int

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
 )
 
 var (

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestVersionStringVariants(t *testing.T) {

--- a/internal/cmd/youtube.go
+++ b/internal/cmd/youtube.go
@@ -8,9 +8,9 @@ import (
 
 	"google.golang.org/api/youtube/v3"
 
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/outfmt"
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/outfmt"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 var newYoutubeService = googleapi.NewYoutube

--- a/internal/errfmt/errfmt.go
+++ b/internal/errfmt/errfmt.go
@@ -10,8 +10,8 @@ import (
 	"github.com/alecthomas/kong"
 	ggoogleapi "google.golang.org/api/googleapi"
 
-	"github.com/steipete/gogcli/internal/config"
-	gogapi "github.com/steipete/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/config"
+	gogapi "github.com/Robben-Media/gogcli/internal/googleapi"
 )
 
 func Format(err error) string {

--- a/internal/errfmt/errfmt_test.go
+++ b/internal/errfmt/errfmt_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/kong"
 	ggoogleapi "google.golang.org/api/googleapi"
 
-	"github.com/steipete/gogcli/internal/config"
-	gogapi "github.com/steipete/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/config"
+	gogapi "github.com/Robben-Media/gogcli/internal/googleapi"
 )
 
 var errNope = errors.New("nope")

--- a/internal/googleapi/analytics.go
+++ b/internal/googleapi/analytics.go
@@ -7,7 +7,7 @@ import (
 	analyticsadmin "google.golang.org/api/analyticsadmin/v1beta"
 	analyticsdata "google.golang.org/api/analyticsdata/v1beta"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewAnalyticsData(ctx context.Context, email string) (*analyticsdata.Service, error) {

--- a/internal/googleapi/bigquery.go
+++ b/internal/googleapi/bigquery.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/api/bigquery/v2"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewBigquery(ctx context.Context, email string) (*bigquery.Service, error) {

--- a/internal/googleapi/businessprofile.go
+++ b/internal/googleapi/businessprofile.go
@@ -7,7 +7,7 @@ import (
 	mybusinessaccountmanagement "google.golang.org/api/mybusinessaccountmanagement/v1"
 	mybusinessbusinessinformation "google.golang.org/api/mybusinessbusinessinformation/v1"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewBusinessProfileInfo(ctx context.Context, email string) (*mybusinessbusinessinformation.Service, error) {

--- a/internal/googleapi/calendar.go
+++ b/internal/googleapi/calendar.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/api/calendar/v3"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewCalendar(ctx context.Context, email string) (*calendar.Service, error) {

--- a/internal/googleapi/classroom.go
+++ b/internal/googleapi/classroom.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/api/classroom/v1"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewClassroom(ctx context.Context, email string) (*classroom.Service, error) {

--- a/internal/googleapi/client.go
+++ b/internal/googleapi/client.go
@@ -14,10 +14,10 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/authclient"
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleauth"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/authclient"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 const defaultHTTPTimeout = 30 * time.Second

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/99designs/keyring"
 	"golang.org/x/oauth2"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleauth"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 var (

--- a/internal/googleapi/docs.go
+++ b/internal/googleapi/docs.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/api/docs/v1"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewDocs(ctx context.Context, email string) (*docs.Service, error) {

--- a/internal/googleapi/drive.go
+++ b/internal/googleapi/drive.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/api/drive/v3"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewDrive(ctx context.Context, email string) (*drive.Service, error) {

--- a/internal/googleapi/gmail.go
+++ b/internal/googleapi/gmail.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/api/gmail/v1"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewGmail(ctx context.Context, email string) (*gmail.Service, error) {

--- a/internal/googleapi/keep.go
+++ b/internal/googleapi/keep.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/api/keep/v1"
 	"google.golang.org/api/option"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewKeep(ctx context.Context, email string) (*keep.Service, error) {

--- a/internal/googleapi/searchconsole.go
+++ b/internal/googleapi/searchconsole.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/api/searchconsole/v1"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewSearchConsole(ctx context.Context, email string) (*searchconsole.Service, error) {

--- a/internal/googleapi/service_account.go
+++ b/internal/googleapi/service_account.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 var newServiceAccountTokenSource = func(ctx context.Context, keyJSON []byte, subject string, scopes []string) (oauth2.TokenSource, error) {

--- a/internal/googleapi/services_more_test.go
+++ b/internal/googleapi/services_more_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 func TestNewServicesWithStoredToken(t *testing.T) {

--- a/internal/googleapi/sheets.go
+++ b/internal/googleapi/sheets.go
@@ -7,7 +7,7 @@ import (
 
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewSheets(ctx context.Context, email string) (*sheets.Service, error) {

--- a/internal/googleapi/tagmanager.go
+++ b/internal/googleapi/tagmanager.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/api/tagmanager/v2"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewTagManager(ctx context.Context, email string) (*tagmanager.Service, error) {

--- a/internal/googleapi/tasks.go
+++ b/internal/googleapi/tasks.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/api/tasks/v1"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewTasks(ctx context.Context, email string) (*tasks.Service, error) {

--- a/internal/googleapi/tasks_test.go
+++ b/internal/googleapi/tasks_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 type tasksStubStore struct {

--- a/internal/googleapi/youtube.go
+++ b/internal/googleapi/youtube.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/api/youtube/v3"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 func NewYoutube(ctx context.Context, email string) (*youtube.Service, error) {

--- a/internal/googleauth/accounts_server.go
+++ b/internal/googleauth/accounts_server.go
@@ -19,8 +19,8 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 // AccountInfo represents an account for the UI

--- a/internal/googleauth/accounts_server_more_test.go
+++ b/internal/googleauth/accounts_server_more_test.go
@@ -14,8 +14,8 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 var errTestStoreBoom = errors.New("boom")

--- a/internal/googleauth/accounts_server_test.go
+++ b/internal/googleauth/accounts_server_test.go
@@ -19,8 +19,8 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 var (

--- a/internal/googleauth/oauth_flow.go
+++ b/internal/googleauth/oauth_flow.go
@@ -18,8 +18,8 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/input"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/input"
 )
 
 type AuthorizeOptions struct {

--- a/internal/googleauth/oauth_flow_authorize_test.go
+++ b/internal/googleauth/oauth_flow_authorize_test.go
@@ -15,7 +15,7 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 var errMissingRedirectState = errors.New("missing redirect/state")

--- a/internal/googleauth/templates/accounts.html
+++ b/internal/googleauth/templates/accounts.html
@@ -707,7 +707,7 @@
             <h1>Google Accounts</h1>
             <p class="subtitle">Manage your connected accounts</p>
             <p class="setup-link">
-                <a href="https://github.com/steipete/gogcli#quick-start" target="_blank">
+                <a href="https://github.com/Robben-Media/gogcli#quick-start" target="_blank">
                     First time? Set up Google Cloud credentials →
                 </a>
             </p>
@@ -767,7 +767,7 @@
         <footer class="footer">
             <p>You can close this window and return to your terminal.</p>
             <p class="github-link">
-                <a href="https://github.com/steipete/gogcli" target="_blank">
+                <a href="https://github.com/Robben-Media/gogcli" target="_blank">
                     <span class="icon-github"></span>
                     View on GitHub
                 </a>

--- a/internal/googleauth/templates/success.html
+++ b/internal/googleauth/templates/success.html
@@ -673,7 +673,7 @@
         <footer class="footer">
             <p>Closing in <span id="countdown">{{.CountdownSeconds}}</span> seconds...</p>
             <p class="github-link">
-                <a href="https://github.com/steipete/gogcli" target="_blank" rel="noopener noreferrer">
+                <a href="https://github.com/Robben-Media/gogcli" target="_blank" rel="noopener noreferrer">
                     <span class="icon-github"></span>
                     View on GitHub
                 </a>

--- a/internal/googleauth/token_check_test.go
+++ b/internal/googleauth/token_check_test.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 func TestCheckRefreshTokenSuccess(t *testing.T) {

--- a/internal/input/prompt.go
+++ b/internal/input/prompt.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func PromptLine(ctx context.Context, prompt string) (string, error) {

--- a/internal/input/prompt_test.go
+++ b/internal/input/prompt_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/ui"
+	"github.com/Robben-Media/gogcli/internal/ui"
 )
 
 func TestPromptLineFrom(t *testing.T) {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/steipete/gogcli/internal/authclient"
-	"github.com/steipete/gogcli/internal/config"
-	"github.com/steipete/gogcli/internal/googleapi"
-	"github.com/steipete/gogcli/internal/googleauth"
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/authclient"
+	"github.com/Robben-Media/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/googleapi"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 func integrationAccount(t *testing.T) string {

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -12,7 +12,7 @@ import (
 	"github.com/99designs/keyring"
 	"golang.org/x/term"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 type Store interface {
@@ -191,7 +191,7 @@ func openKeyring() (keyring.Keyring, error) {
 		// Homebrew upgrades install a new binary with a different hash, causing the
 		// new binary to lose access to existing keychain items. With false, users may
 		// see a one-time keychain prompt after upgrade (click "Always Allow"), but
-		// tokens survive across upgrades. See: https://github.com/steipete/gogcli/issues/86
+		// tokens survive across upgrades. See: https://github.com/Robben-Media/gogcli/issues/86
 		KeychainTrustApplication: false,
 		AllowedBackends:          backends,
 		FileDir:                  keyringDir,

--- a/internal/secrets/store_integration_test.go
+++ b/internal/secrets/store_integration_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/99designs/keyring"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 func setupKeyringEnv(t *testing.T) {

--- a/internal/secrets/store_more_test.go
+++ b/internal/secrets/store_more_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/99designs/keyring"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 var errTestKeychain = errors.New("test -25308 error")

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/99designs/keyring"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 var errKeyringOpenBlocked = errors.New("keyring open blocked")

--- a/internal/tracking/config.go
+++ b/internal/tracking/config.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/steipete/gogcli/internal/config"
+	"github.com/Robben-Media/gogcli/internal/config"
 )
 
 var errMissingAccount = errors.New("missing account")

--- a/internal/tracking/secrets.go
+++ b/internal/tracking/secrets.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/99designs/keyring"
 
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 var (

--- a/internal/tracking/secrets_test.go
+++ b/internal/tracking/secrets_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/Robben-Media/gogcli/internal/secrets"
 )
 
 func setupTrackingKeyringEnv(t *testing.T) {

--- a/scripts/gen-auth-services-md.go
+++ b/scripts/gen-auth-services-md.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/Robben-Media/gogcli/internal/googleauth"
 )
 
 const (

--- a/scripts/live-test.sh
+++ b/scripts/live-test.sh
@@ -31,7 +31,7 @@ Skip keys (base):
   tasks, contacts, people, groups, keep, classroom
 
 Env:
-  GOG_LIVE_EMAIL_TEST=steipete+gogtest@gmail.com
+  GOG_LIVE_EMAIL_TEST=jeremy+gogtest@robbenmedia.com
   GOG_LIVE_GROUP_EMAIL=<group@domain>
   GOG_LIVE_CLASSROOM_COURSE=<courseId>
   GOG_LIVE_CLASSROOM_CREATE=1
@@ -137,7 +137,7 @@ fi
 
 echo "Using account: $ACCOUNT"
 
-EMAIL_TEST="${GOG_LIVE_EMAIL_TEST:-steipete+gogtest@gmail.com}"
+EMAIL_TEST="${GOG_LIVE_EMAIL_TEST:-jeremy+gogtest@robbenmedia.com}"
 TS=$(date +%Y%m%d%H%M%S)
 LIVE_TMP=$(mktemp -d "${TMPDIR:-/tmp}/gog-live-$TS-XXXX")
 trap 'rm -rf "$LIVE_TMP"' EXIT

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -115,8 +115,8 @@ if [[ "$linux_arm64_formula" != "$linux_arm64_expected" ]]; then
 fi
 
 brew update >/dev/null
-brew upgrade gogcli || brew install steipete/tap/gogcli
-brew test steipete/tap/gogcli
+brew upgrade gogcli || brew install itsjeremyjohnson/tap/gogcli
+brew test itsjeremyjohnson/tap/gogcli
 gog --version
 
 rm -rf "$tmp_assets_dir"


### PR DESCRIPTION
## Summary

- Captures the local broad formatting-style normalization diff across gogcli.

- No functional cleanup was attempted beyond preserving the local state in GitHub for review.


## Validation

- `git diff --check` passed.
- `go test ./...` failed in `internal/cmd`: `TestDriveCommands_MoreCoverage` saw delete JSON `{"id":"file1","trashed":true}` where the existing test expected a different shape.




