### PR TITLE
fix(cli): correct shared --out flag help text for download/export commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- CLI: correct the shared `--out` flag help for download/export commands (sheets, docs, slides, drive, gmail attachments, chat media) to describe the derived default filename instead of an inaccurate "gogcli config dir". (#37)
 - CLI: make `--plain config list` and `--plain policy list` emit stable TSV for scriptable output. (#26)
 - Calendar: fix recurrence rules with BYDAY parameter (e.g., `BYDAY=MO,TU,WE,TH,FR`). (#120)
 - Docs: improve create-with-parent failure errors to include created document ID and target parent when move fails.

--- a/internal/cmd/flags_output.go
+++ b/internal/cmd/flags_output.go
@@ -1,7 +1,12 @@
 package cmd
 
+// OutputPathFlag is shared by download/export commands (sheets, docs, slides,
+// drive, gmail attachments, chat media). When --out is empty, each command derives
+// its own filename and writes to a command-specific download directory
+// (e.g. <config>/drive-downloads, <config>/gmail-attachments, or the current
+// directory for chat media), so the help text must not pin a single location.
 type OutputPathFlag struct {
-	Path string `name:"out" aliases:"output" help:"Output file path (default: gogcli config dir)"`
+	Path string `name:"out" aliases:"output" help:"Output file path (default: derived filename in the command's download directory)"`
 }
 
 type OutputPathRequiredFlag struct {

--- a/internal/cmd/flags_output_test.go
+++ b/internal/cmd/flags_output_test.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 type outputPathCmd struct {
 	Output OutputPathFlag `embed:""`
@@ -21,6 +24,25 @@ func TestOutputPathFlag_AcceptsOutputAlias(t *testing.T) {
 	if cmd.Output.Path != "file.txt" {
 		t.Fatalf("expected output path, got %q", cmd.Output.Path)
 	}
+}
+
+func TestOutputPathFlag_HelpDescribesDerivedDefault(t *testing.T) {
+	cmd := &outputPathCmd{}
+	kctx := parseKongContext(t, cmd, nil)
+
+	for _, f := range kctx.Flags() {
+		if f.Name != "out" {
+			continue
+		}
+		if strings.Contains(f.Help, "gogcli config dir") {
+			t.Fatalf("out flag help misleads about a single default dir: %q", f.Help)
+		}
+		if !strings.Contains(strings.ToLower(f.Help), "derived filename") {
+			t.Fatalf("out flag help does not describe the derived default filename: %q", f.Help)
+		}
+		return
+	}
+	t.Fatal("out flag not found on outputPathCmd")
 }
 
 func TestOutputPathFlag_AcceptsOut(t *testing.T) {


### PR DESCRIPTION
## Summary

The shared `OutputPathFlag` (`internal/cmd/flags_output.go`) is embedded by the sheets, docs, slides, drive, gmail attachment, and chat media download/export commands. Its help text claimed the default path is the **gogcli config dir**, but the commands actually derive their own default filenames and write to command-specific locations:

- **sheets / docs / slides / drive** → `<config>/drive-downloads/<id>_<name>`
- **gmail attachment** → `<config>/gmail-attachments/<msgId>_<shortId>_<filename>`
- **chat media** → current directory, derived from the resource name

The misleading help text caused confusion about where files are saved. This PR updates the shared help text to describe the real default and adds a regression test.

## Changes

- `internal/cmd/flags_output.go`: update `OutputPathFlag` help to `Output file path (default: derived filename in the command's download directory)`; add a doc comment explaining why the flag must not pin a single location.
- `internal/cmd/flags_output_test.go`: add `TestOutputPathFlag_HelpDescribesDerivedDefault`, which builds the Kong model and asserts the `out` flag help no longer claims `gogcli config dir` and does describe a derived filename.

## Validation

Verification contract (`make fmt-check lint test`) and full gate:

- `make fmt-check` — clean
- `make lint` — `0 issues.`
- `make test` — all packages pass
- `make ci` — all green
- Rendered help verified for `sheets export`, `gmail attachment download`, and `chat media download` — all now show `--out ... (default: derived filename in the command's download directory)`.

## User-facing changes

Help-text-only change. No behavior change; default download/export paths are unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes misleading help text on the shared `OutputPathFlag` struct, which previously claimed the default output path was the "gogcli config dir" when each consuming command actually derives its own filename and writes to a command-specific location. The fix updates the help string and adds a doc comment explaining the multi-command constraint, along with a regression test.

- **`flags_output.go`**: replaces the inaccurate `(default: gogcli config dir)` help text with `(default: derived filename in the command's download directory)` and adds a package-level doc comment explaining why the help text must stay generic.
- **`flags_output_test.go`**: adds `TestOutputPathFlag_HelpDescribesDerivedDefault` which builds the Kong flag model and asserts the old misleading string is absent and the new "derived filename" wording is present.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a help-text-only change with no behavioural impact and a targeted regression test.

The diff touches only a struct tag string and its doc comment, plus a new test that guards against regression. No logic paths are altered, no defaults change, and the new test correctly exercises the Kong flag model to pin the corrected wording.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/cmd/flags_output.go | Help text corrected from "gogcli config dir" to "derived filename in the command's download directory"; doc comment added to explain the multi-command constraint. No logic changes. |
| internal/cmd/flags_output_test.go | Adds TestOutputPathFlag_HelpDescribesDerivedDefault regression test; correctly builds the Kong context, locates the "out" flag by canonical name, and asserts both the old and new substrings. |
| CHANGELOG.md | Entry added for the --out flag help fix, correctly referencing PR #37 and the affected commands. No issues. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["--out flag provided?"] -->|Yes| B["Use supplied path"]
    A -->|No| C{Which command?}
    C -->|sheets / docs / slides / drive| D["config/drive-downloads/id_name"]
    C -->|gmail attachment| E["config/gmail-attachments/msgId_shortId_filename"]
    C -->|chat media| F["current directory / derived from resource name"]
    D --> G["Write output file"]
    E --> G
    F --> G
    B --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["--out flag provided?"] -->|Yes| B["Use supplied path"]
    A -->|No| C{Which command?}
    C -->|sheets / docs / slides / drive| D["config/drive-downloads/id_name"]
    C -->|gmail attachment| E["config/gmail-attachments/msgId_shortId_filename"]
    C -->|chat media| F["current directory / derived from resource name"]
    D --> G["Write output file"]
    E --> G
    F --> G
    B --> G
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): note --out flag help co..."](https://github.com/robben-media/gogcli/commit/7f284cb3ccb2ed7075060dcf10a2a6280ae2bc1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42849770)</sub>

<!-- /greptile_comment -->