### PR TITLE
feat(admin): manage Analytics and GTM user access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Docs: `gog docs create` now uses Docs API `documents.create`, returns full document metadata (including `revisionId`), and still supports `--parent` via Drive move.
+- Analytics: add account and property user access management with `gog analytics admin access-bindings`.
+- Tag Manager: add account user permission management with `gog gtm user-permissions`.
 - APIs: add Google BigQuery, Analytics (GA4), Search Console, Tag Manager, YouTube Data API v3, and Business Profile command groups.
 - Gmail: add `gog gmail trash` and `gog gmail labels delete`.
 - Sheets: add batch operations (`batch-get`, `batch-update`) and sheet tab management commands.

--- a/internal/cmd/analytics.go
+++ b/internal/cmd/analytics.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	newAnalyticsDataService  = googleapi.NewAnalyticsData
-	newAnalyticsAdminService = googleapi.NewAnalyticsAdmin
+	newAnalyticsDataService       = googleapi.NewAnalyticsData
+	newAnalyticsAdminService      = googleapi.NewAnalyticsAdmin
+	newAnalyticsAdminAlphaService = googleapi.NewAnalyticsAdminAlpha
 )
 
 type AnalyticsCmd struct {

--- a/internal/cmd/analytics_admin.go
+++ b/internal/cmd/analytics_admin.go
@@ -2,6 +2,7 @@ package cmd
 
 // AnalyticsAdminCmd groups all GA4 Admin API operations.
 type AnalyticsAdminCmd struct {
+	AccessBindings   AAAccessBindingsCmd   `cmd:"" name:"access-bindings" help:"Manage account and property user access"`
 	DataStreams      AADataStreamsCmd      `cmd:"" name:"data-streams" help:"Data stream operations"`
 	MpSecrets        AAMpSecretsCmd        `cmd:"" name:"mp-secrets" help:"Measurement Protocol secret operations"`
 	Accounts         AAAccountsCmd         `cmd:"" name:"accounts" help:"Account operations"`

--- a/internal/cmd/analytics_admin_access_bindings.go
+++ b/internal/cmd/analytics_admin_access_bindings.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	analyticsadmin "google.golang.org/api/analyticsadmin/v1alpha"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type AAAccessBindingsCmd struct {
+	List   AAAccessBindingsListCmd   `cmd:"" name:"list" help:"List access bindings"`
+	Create AAAccessBindingsCreateCmd `cmd:"" name:"create" help:"Grant a user access"`
+	Patch  AAAccessBindingsPatchCmd  `cmd:"" name:"patch" help:"Update an access binding's roles"`
+	Delete AAAccessBindingsDeleteCmd `cmd:"" name:"delete" help:"Delete an access binding"`
+}
+
+func analyticsAccessBindingParent(value string) (string, error) {
+	parent := strings.TrimSpace(value)
+	parts := strings.Split(parent, "/")
+	if len(parts) != 2 || (parts[0] != "accounts" && parts[0] != "properties") || strings.TrimSpace(parts[1]) == "" {
+		return "", usage("parent must be accounts/ACCOUNT_ID or properties/PROPERTY_ID")
+	}
+	return parent, nil
+}
+
+func analyticsAccessBindingName(value string) (string, error) {
+	name := strings.TrimSpace(value)
+	parts := strings.Split(name, "/")
+	if len(parts) != 4 || (parts[0] != "accounts" && parts[0] != "properties") || strings.TrimSpace(parts[1]) == "" || parts[2] != "accessBindings" || strings.TrimSpace(parts[3]) == "" {
+		return "", usage("name must be accounts/ACCOUNT_ID/accessBindings/BINDING_ID or properties/PROPERTY_ID/accessBindings/BINDING_ID")
+	}
+	return name, nil
+}
+
+func analyticsAccessBindingRoles(value string) ([]string, error) {
+	valid := map[string]string{
+		"viewer":          "predefinedRoles/viewer",
+		"analyst":         "predefinedRoles/analyst",
+		"editor":          "predefinedRoles/editor",
+		"admin":           "predefinedRoles/admin",
+		"no-cost-data":    "predefinedRoles/no-cost-data",
+		"no-revenue-data": "predefinedRoles/no-revenue-data",
+	}
+	parts := strings.Split(value, ",")
+	roles := make([]string, 0, len(parts))
+	for _, part := range parts {
+		role := strings.TrimSpace(part)
+		if role == "" {
+			return nil, usage("--roles must contain one or more comma-separated roles")
+		}
+		short := strings.TrimPrefix(role, "predefinedRoles/")
+		normalized, ok := valid[short]
+		if !ok {
+			return nil, usagef("unsupported role %q (expected viewer, analyst, editor, admin, no-cost-data, or no-revenue-data)", role)
+		}
+		roles = append(roles, normalized)
+	}
+	return roles, nil
+}
+
+func listAnalyticsAccessBindings(svc *analyticsadmin.Service, parent string, maxResults int64, page string) (*analyticsadmin.GoogleAnalyticsAdminV1alphaListAccessBindingsResponse, error) {
+	if strings.HasPrefix(parent, "accounts/") {
+		call := svc.Accounts.AccessBindings.List(parent).PageSize(maxResults)
+		if page != "" {
+			call = call.PageToken(page)
+		}
+		return call.Do()
+	}
+	call := svc.Properties.AccessBindings.List(parent).PageSize(maxResults)
+	if page != "" {
+		call = call.PageToken(page)
+	}
+	return call.Do()
+}
+
+type AAAccessBindingsListCmd struct {
+	Parent string `arg:"" name:"parent" help:"Parent resource (accounts/123 or properties/456)"`
+	Max    int64  `name:"max" aliases:"limit" help:"Max results" default:"100"`
+	Page   string `name:"page" help:"Page token"`
+}
+
+func (c *AAAccessBindingsListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	parent, err := analyticsAccessBindingParent(c.Parent)
+	if err != nil {
+		return err
+	}
+	svc, err := newAnalyticsAdminAlphaService(ctx, account)
+	if err != nil {
+		return err
+	}
+	resp, err := listAnalyticsAccessBindings(svc, parent, c.Max, strings.TrimSpace(c.Page))
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"accessBindings": resp.AccessBindings, "nextPageToken": resp.NextPageToken})
+	}
+	u := ui.FromContext(ctx)
+	if len(resp.AccessBindings) == 0 {
+		u.Err().Println("No access bindings")
+		return nil
+	}
+	w, flush := tableWriter(ctx)
+	defer flush()
+	fmt.Fprintln(w, "NAME\tUSER\tROLES")
+	for _, binding := range resp.AccessBindings {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", binding.Name, binding.User, strings.Join(binding.Roles, ","))
+	}
+	printNextPageHint(u, resp.NextPageToken)
+	return nil
+}
+
+type AAAccessBindingsCreateCmd struct {
+	Parent string `arg:"" name:"parent" help:"Parent resource (accounts/123 or properties/456)"`
+	Email  string `name:"email" required:"" help:"User email address"`
+	Roles  string `name:"roles" required:"" help:"Comma-separated roles: viewer, analyst, editor, admin, no-cost-data, no-revenue-data"`
+}
+
+func (c *AAAccessBindingsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	parent, err := analyticsAccessBindingParent(c.Parent)
+	if err != nil {
+		return err
+	}
+	email := strings.TrimSpace(c.Email)
+	if email == "" {
+		return usage("--email required")
+	}
+	roles, err := analyticsAccessBindingRoles(c.Roles)
+	if err != nil {
+		return err
+	}
+	svc, err := newAnalyticsAdminAlphaService(ctx, account)
+	if err != nil {
+		return err
+	}
+	binding := &analyticsadmin.GoogleAnalyticsAdminV1alphaAccessBinding{User: email, Roles: roles}
+	var created *analyticsadmin.GoogleAnalyticsAdminV1alphaAccessBinding
+	if strings.HasPrefix(parent, "accounts/") {
+		created, err = svc.Accounts.AccessBindings.Create(parent, binding).Do()
+	} else {
+		created, err = svc.Properties.AccessBindings.Create(parent, binding).Do()
+	}
+	if err != nil {
+		return err
+	}
+	return writeAnalyticsAccessBinding(ctx, "Created", created)
+}
+
+type AAAccessBindingsPatchCmd struct {
+	Name  string `arg:"" name:"name" help:"Access binding resource name"`
+	Roles string `name:"roles" required:"" help:"Comma-separated roles"`
+}
+
+func (c *AAAccessBindingsPatchCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	name, err := analyticsAccessBindingName(c.Name)
+	if err != nil {
+		return err
+	}
+	roles, err := analyticsAccessBindingRoles(c.Roles)
+	if err != nil {
+		return err
+	}
+	svc, err := newAnalyticsAdminAlphaService(ctx, account)
+	if err != nil {
+		return err
+	}
+	binding := &analyticsadmin.GoogleAnalyticsAdminV1alphaAccessBinding{Roles: roles}
+	var updated *analyticsadmin.GoogleAnalyticsAdminV1alphaAccessBinding
+	if strings.HasPrefix(name, "accounts/") {
+		updated, err = svc.Accounts.AccessBindings.Patch(name, binding).Do()
+	} else {
+		updated, err = svc.Properties.AccessBindings.Patch(name, binding).Do()
+	}
+	if err != nil {
+		return err
+	}
+	return writeAnalyticsAccessBinding(ctx, "Updated", updated)
+}
+
+type AAAccessBindingsDeleteCmd struct {
+	Name string `arg:"" name:"name" help:"Access binding resource name"`
+}
+
+func (c *AAAccessBindingsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	name, err := analyticsAccessBindingName(c.Name)
+	if err != nil {
+		return err
+	}
+	if err = confirmDestructive(ctx, flags, fmt.Sprintf("delete analytics access binding %s", name)); err != nil {
+		return err
+	}
+	svc, err := newAnalyticsAdminAlphaService(ctx, account)
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(name, "accounts/") {
+		_, err = svc.Accounts.AccessBindings.Delete(name).Do()
+	} else {
+		_, err = svc.Properties.AccessBindings.Delete(name).Do()
+	}
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "name": name})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "DELETED\tNAME")
+		fmt.Fprintf(w, "true\t%s\n", name)
+		return nil
+	}
+	ui.FromContext(ctx).Out().Printf("Deleted access binding: %s", name)
+	return nil
+}
+
+func writeAnalyticsAccessBinding(ctx context.Context, action string, binding *analyticsadmin.GoogleAnalyticsAdminV1alphaAccessBinding) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"accessBinding": binding})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "NAME\tUSER\tROLES")
+		fmt.Fprintf(w, "%s\t%s\t%s\n", binding.Name, binding.User, strings.Join(binding.Roles, ","))
+		return nil
+	}
+	ui.FromContext(ctx).Out().Printf("%s access binding: %s", action, binding.Name)
+	return nil
+}

--- a/internal/cmd/analytics_admin_access_bindings_test.go
+++ b/internal/cmd/analytics_admin_access_bindings_test.go
@@ -1,0 +1,198 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	analyticsadmin "google.golang.org/api/analyticsadmin/v1alpha"
+	"google.golang.org/api/option"
+)
+
+func setupAnalyticsAdminAlphaTest(t *testing.T, handler http.Handler) {
+	t.Helper()
+	original := newAnalyticsAdminAlphaService
+	t.Cleanup(func() { newAnalyticsAdminAlphaService = original })
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	service, err := analyticsadmin.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(server.Client()),
+		option.WithEndpoint(server.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newAnalyticsAdminAlphaService = func(context.Context, string) (*analyticsadmin.Service, error) {
+		return service, nil
+	}
+}
+
+func TestExecute_AAAccessBindingsCreate_NormalizesRoles(t *testing.T) {
+	setupAnalyticsAdminAlphaTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1alpha/properties/123/accessBindings" {
+			http.NotFound(w, r)
+			return
+		}
+		var body analyticsadmin.GoogleAnalyticsAdminV1alphaAccessBinding
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.User != "person@example.com" {
+			t.Fatalf("user = %q", body.User)
+		}
+		wantRoles := []string{"predefinedRoles/viewer", "predefinedRoles/no-cost-data"}
+		if strings.Join(body.Roles, ",") != strings.Join(wantRoles, ",") {
+			t.Fatalf("roles = %#v, want %#v", body.Roles, wantRoles)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name":  "properties/123/accessBindings/456",
+			"user":  body.User,
+			"roles": body.Roles,
+		})
+	}))
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com",
+				"analytics", "admin", "access-bindings", "create",
+				"properties/123", "--email", "person@example.com",
+				"--roles", "viewer,no-cost-data",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	var parsed struct {
+		AccessBinding struct {
+			Name string `json:"name"`
+		} `json:"accessBinding"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if parsed.AccessBinding.Name != "properties/123/accessBindings/456" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestExecute_AAAccessBindingsList_PropertyPagination(t *testing.T) {
+	setupAnalyticsAdminAlphaTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1alpha/properties/123/accessBindings" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("pageSize") != "25" || r.URL.Query().Get("pageToken") != "next" {
+			t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accessBindings":[{"name":"properties/123/accessBindings/456","user":"person@example.com","roles":["predefinedRoles/viewer"]}],"nextPageToken":"later"}`))
+	}))
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com",
+				"analytics", "admin", "access-bindings", "list", "properties/123",
+				"--max", "25", "--page", "next",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	var parsed struct {
+		AccessBindings []json.RawMessage `json:"accessBindings"`
+		NextPageToken  string            `json:"nextPageToken"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if len(parsed.AccessBindings) != 1 || parsed.NextPageToken != "later" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestExecute_AAAccessBindingsPatch_Account(t *testing.T) {
+	setupAnalyticsAdminAlphaTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || r.URL.Path != "/v1alpha/accounts/123/accessBindings/456" {
+			http.NotFound(w, r)
+			return
+		}
+		var body analyticsadmin.GoogleAnalyticsAdminV1alphaAccessBinding
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if strings.Join(body.Roles, ",") != "predefinedRoles/admin,predefinedRoles/no-revenue-data" {
+			t.Fatalf("unexpected roles: %#v", body.Roles)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"accounts/123/accessBindings/456","user":"person@example.com","roles":["predefinedRoles/admin","predefinedRoles/no-revenue-data"]}`))
+	}))
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "admin@example.com",
+				"analytics", "admin", "access-bindings", "patch",
+				"accounts/123/accessBindings/456", "--roles", "predefinedRoles/admin,no-revenue-data",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+}
+
+func TestExecute_AAAccessBindingsDelete_ConfirmationAndForce(t *testing.T) {
+	var deleteCalls int
+	setupAnalyticsAdminAlphaTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1alpha/properties/123/accessBindings/456" {
+			http.NotFound(w, r)
+			return
+		}
+		deleteCalls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+
+	err := Execute([]string{
+		"--account", "admin@example.com", "--no-input",
+		"analytics", "admin", "access-bindings", "delete", "properties/123/accessBindings/456",
+	})
+	if err == nil || !strings.Contains(err.Error(), "without --force") {
+		t.Fatalf("expected confirmation error, got %v", err)
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("delete called before confirmation")
+	}
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com", "--force",
+				"analytics", "admin", "access-bindings", "delete", "properties/123/accessBindings/456",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	if deleteCalls != 1 {
+		t.Fatalf("delete calls = %d", deleteCalls)
+	}
+}
+
+func TestExecute_AAAccessBindingsRejectsUnknownRole(t *testing.T) {
+	err := Execute([]string{
+		"--account", "admin@example.com",
+		"analytics", "admin", "access-bindings", "create", "accounts/123",
+		"--email", "person@example.com", "--roles", "owner",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported role") {
+		t.Fatalf("expected role validation error, got %v", err)
+	}
+}

--- a/internal/cmd/tagmanager.go
+++ b/internal/cmd/tagmanager.go
@@ -16,13 +16,14 @@ import (
 var newTagManagerService = googleapi.NewTagManager
 
 type TagManagerCmd struct {
-	Accounts   TagManagerAccountsCmd   `cmd:"" name:"accounts" group:"Read" help:"List GTM accounts"`
-	Containers TagManagerContainersCmd `cmd:"" name:"containers" group:"Read" help:"List containers in an account"`
-	Tags       TagManagerTagsCmd       `cmd:"" name:"tags" group:"Read" help:"List tags in a workspace"`
-	Tag        TagManagerTagCmd        `cmd:"" name:"tag" group:"Read" help:"Get a single tag by path"`
-	Triggers   TagManagerTriggersCmd   `cmd:"" name:"triggers" group:"Read" help:"List triggers in a workspace"`
-	Variables  TagManagerVariablesCmd  `cmd:"" name:"variables" group:"Read" help:"List variables in a workspace"`
-	Versions   TagManagerVersionsCmd   `cmd:"" name:"versions" group:"Read" help:"List container version headers"`
+	Accounts        TagManagerAccountsCmd        `cmd:"" name:"accounts" group:"Read" help:"List GTM accounts"`
+	Containers      TagManagerContainersCmd      `cmd:"" name:"containers" group:"Read" help:"List containers in an account"`
+	Tags            TagManagerTagsCmd            `cmd:"" name:"tags" group:"Read" help:"List tags in a workspace"`
+	Tag             TagManagerTagCmd             `cmd:"" name:"tag" group:"Read" help:"Get a single tag by path"`
+	Triggers        TagManagerTriggersCmd        `cmd:"" name:"triggers" group:"Read" help:"List triggers in a workspace"`
+	Variables       TagManagerVariablesCmd       `cmd:"" name:"variables" group:"Read" help:"List variables in a workspace"`
+	Versions        TagManagerVersionsCmd        `cmd:"" name:"versions" group:"Read" help:"List container version headers"`
+	UserPermissions TagManagerUserPermissionsCmd `cmd:"" name:"user-permissions" group:"Admin" help:"Manage GTM user permissions"`
 }
 
 func gtmWorkspacePath(accountID, containerID, workspaceID string) string {

--- a/internal/cmd/tagmanager_user_permissions.go
+++ b/internal/cmd/tagmanager_user_permissions.go
@@ -1,0 +1,309 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"google.golang.org/api/tagmanager/v2"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type TagManagerUserPermissionsCmd struct {
+	Create TagManagerUserPermissionsCreateCmd `cmd:"" name:"create" help:"Create a user permission"`
+	Delete TagManagerUserPermissionsDeleteCmd `cmd:"" name:"delete" help:"Delete a user permission"`
+	Get    TagManagerUserPermissionsGetCmd    `cmd:"" name:"get" help:"Get a user permission"`
+	List   TagManagerUserPermissionsListCmd   `cmd:"" name:"list" help:"List user permissions"`
+	Update TagManagerUserPermissionsUpdateCmd `cmd:"" name:"update" help:"Update a user permission"`
+}
+
+const (
+	tagManagerAccountAccessNoAccess = "noAccess"
+	tagManagerAccountAccessUser     = "user"
+	tagManagerAccountAccessAdmin    = "admin"
+)
+
+func tagManagerAccountParent(accountID string) (string, error) {
+	id := strings.TrimSpace(accountID)
+	if id == "" {
+		return "", usage("--account-id required")
+	}
+	if strings.Contains(id, "/") {
+		return "", usage("--account-id must be a GTM account ID")
+	}
+	return "accounts/" + id, nil
+}
+
+func tagManagerUserPermissionPath(value string) (string, error) {
+	path := strings.TrimSpace(value)
+	parts := strings.Split(path, "/")
+	if len(parts) != 4 || parts[0] != "accounts" || strings.TrimSpace(parts[1]) == "" || parts[2] != "user_permissions" || strings.TrimSpace(parts[3]) == "" {
+		return "", usage("path must be accounts/ACCOUNT_ID/user_permissions/PERMISSION_ID")
+	}
+	return path, nil
+}
+
+func tagManagerAccountAccess(value string) (*tagmanager.AccountAccess, error) {
+	permission := strings.TrimSpace(value)
+	switch permission {
+	case tagManagerAccountAccessNoAccess, tagManagerAccountAccessUser, tagManagerAccountAccessAdmin:
+		return &tagmanager.AccountAccess{Permission: permission}, nil
+	default:
+		return nil, usagef("invalid --account-access-type %q (expected noAccess, user, or admin)", permission)
+	}
+}
+
+func tagManagerContainerAccess(values []string) ([]*tagmanager.ContainerAccess, error) {
+	access := make([]*tagmanager.ContainerAccess, 0, len(values))
+	for _, value := range values {
+		var item tagmanager.ContainerAccess
+		if err := json.Unmarshal([]byte(value), &item); err != nil {
+			return nil, usagef("invalid --container-access JSON: %v", err)
+		}
+		if strings.TrimSpace(item.ContainerId) == "" {
+			return nil, usage("--container-access requires containerId")
+		}
+		access = append(access, &item)
+	}
+	return access, nil
+}
+
+type TagManagerUserPermissionsCreateCmd struct {
+	AccountID       string   `name:"account-id" required:"" help:"GTM account ID"`
+	Email           string   `name:"email" required:"" help:"User email address"`
+	AccountAccess   string   `name:"account-access-type" help:"Account access: noAccess, user, or admin"`
+	ContainerAccess []string `name:"container-access" sep:"none" help:"Container access JSON object (repeatable)"`
+}
+
+func (c *TagManagerUserPermissionsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	parent, err := tagManagerAccountParent(c.AccountID)
+	if err != nil {
+		return err
+	}
+	email := strings.TrimSpace(c.Email)
+	if email == "" {
+		return usage("--email required")
+	}
+	permission := &tagmanager.UserPermission{EmailAddress: email}
+	if strings.TrimSpace(c.AccountAccess) != "" {
+		permission.AccountAccess, err = tagManagerAccountAccess(c.AccountAccess)
+		if err != nil {
+			return err
+		}
+	}
+	if len(c.ContainerAccess) > 0 {
+		permission.ContainerAccess, err = tagManagerContainerAccess(c.ContainerAccess)
+		if err != nil {
+			return err
+		}
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	created, err := svc.Accounts.UserPermissions.Create(parent, permission).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerUserPermission(ctx, "Created", created)
+}
+
+type TagManagerUserPermissionsDeleteCmd struct {
+	Path string `arg:"" name:"path" help:"User permission path"`
+}
+
+func (c *TagManagerUserPermissionsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	path, err := tagManagerUserPermissionPath(c.Path)
+	if err != nil {
+		return err
+	}
+	if err = confirmDestructive(ctx, flags, fmt.Sprintf("delete GTM user permission %s", path)); err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	if err = svc.Accounts.UserPermissions.Delete(path).Context(ctx).Do(); err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "path": path})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "DELETED\tPATH")
+		fmt.Fprintf(w, "true\t%s\n", path)
+		return nil
+	}
+	ui.FromContext(ctx).Out().Printf("Deleted user permission: %s", path)
+	return nil
+}
+
+type TagManagerUserPermissionsGetCmd struct {
+	Path string `arg:"" name:"path" help:"User permission path"`
+}
+
+func (c *TagManagerUserPermissionsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	path, err := tagManagerUserPermissionPath(c.Path)
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	permission, err := svc.Accounts.UserPermissions.Get(path).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerUserPermission(ctx, "User", permission)
+}
+
+type TagManagerUserPermissionsListCmd struct {
+	AccountID string `name:"account-id" required:"" help:"GTM account ID"`
+	Page      string `name:"page" help:"Page token"`
+}
+
+func (c *TagManagerUserPermissionsListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	parent, err := tagManagerAccountParent(c.AccountID)
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	call := svc.Accounts.UserPermissions.List(parent).Context(ctx)
+	if page := strings.TrimSpace(c.Page); page != "" {
+		call = call.PageToken(page)
+	}
+	resp, err := call.Do()
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"userPermissions": resp.UserPermission, "nextPageToken": resp.NextPageToken})
+	}
+	u := ui.FromContext(ctx)
+	if len(resp.UserPermission) == 0 {
+		u.Err().Println("No user permissions")
+		return nil
+	}
+	w, flush := tableWriter(ctx)
+	defer flush()
+	fmt.Fprintln(w, "PERMISSION_ID\tEMAIL\tACCOUNT_ACCESS")
+	for _, permission := range resp.UserPermission {
+		accountAccess := ""
+		if permission.AccountAccess != nil {
+			accountAccess = permission.AccountAccess.Permission
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", tagManagerPermissionID(permission.Path), permission.EmailAddress, accountAccess)
+	}
+	printNextPageHint(u, resp.NextPageToken)
+	return nil
+}
+
+type TagManagerUserPermissionsUpdateCmd struct {
+	Path            string   `arg:"" name:"path" help:"User permission path"`
+	AccountAccess   string   `name:"account-access-type" help:"Account access: noAccess, user, or admin"`
+	ContainerAccess []string `name:"container-access" sep:"none" help:"Container access JSON object (repeatable)"`
+}
+
+func (c *TagManagerUserPermissionsUpdateCmd) Run(ctx context.Context, flags *RootFlags, kctx *kong.Context) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	path, err := tagManagerUserPermissionPath(c.Path)
+	if err != nil {
+		return err
+	}
+	var accountAccess *tagmanager.AccountAccess
+	var containerAccess []*tagmanager.ContainerAccess
+	changed := false
+	if flagProvided(kctx, "account-access-type") {
+		accountAccess, err = tagManagerAccountAccess(c.AccountAccess)
+		if err != nil {
+			return err
+		}
+		changed = true
+	}
+	if flagProvided(kctx, "container-access") {
+		containerAccess, err = tagManagerContainerAccess(c.ContainerAccess)
+		if err != nil {
+			return err
+		}
+		changed = true
+	}
+	if !changed {
+		return usage("at least one of --account-access-type or --container-access is required")
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	permission, err := svc.Accounts.UserPermissions.Get(path).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	if accountAccess != nil {
+		permission.AccountAccess = accountAccess
+	}
+	if containerAccess != nil {
+		permission.ContainerAccess = containerAccess
+	}
+	updated, err := svc.Accounts.UserPermissions.Update(path, permission).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerUserPermission(ctx, "Updated", updated)
+}
+
+func tagManagerPermissionID(path string) string {
+	if index := strings.LastIndex(path, "/"); index >= 0 {
+		return path[index+1:]
+	}
+	return path
+}
+
+func writeTagManagerUserPermission(ctx context.Context, action string, permission *tagmanager.UserPermission) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"userPermission": permission})
+	}
+	accountAccess := ""
+	if permission.AccountAccess != nil {
+		accountAccess = permission.AccountAccess.Permission
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "PATH\tEMAIL\tACCOUNT_ACCESS")
+		fmt.Fprintf(w, "%s\t%s\t%s\n", permission.Path, permission.EmailAddress, accountAccess)
+		return nil
+	}
+	ui.FromContext(ctx).Out().Printf("%s user permission: %s", action, permission.Path)
+	return nil
+}

--- a/internal/cmd/tagmanager_user_permissions_test.go
+++ b/internal/cmd/tagmanager_user_permissions_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/tagmanager/v2"
+)
+
+func setupTagManagerUserPermissionsTest(t *testing.T, handler http.Handler) {
+	t.Helper()
+	original := newTagManagerService
+	t.Cleanup(func() { newTagManagerService = original })
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	service, err := tagmanager.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(server.Client()),
+		option.WithEndpoint(server.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTagManagerService = func(context.Context, string) (*tagmanager.Service, error) { return service, nil }
+}
+
+func TestExecute_TagManagerUserPermissionsCreate(t *testing.T) {
+	setupTagManagerUserPermissionsTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/111/user_permissions" {
+			http.NotFound(w, r)
+			return
+		}
+		var body tagmanager.UserPermission
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.EmailAddress != "person@example.com" || body.AccountAccess == nil || body.AccountAccess.Permission != "user" {
+			t.Fatalf("unexpected permission: %#v", body)
+		}
+		if len(body.ContainerAccess) != 2 || body.ContainerAccess[0].ContainerId != "c1" || body.ContainerAccess[0].Permission != "publish" {
+			t.Fatalf("unexpected container access: %#v", body.ContainerAccess)
+		}
+		body.Path = "accounts/111/user_permissions/222"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&body)
+	}))
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com", "gtm", "user-permissions", "create",
+				"--account-id", "111", "--email", "person@example.com", "--account-access-type", "user",
+				"--container-access", `{"containerId":"c1","permission":"publish"}`,
+				"--container-access", `{"containerId":"c2","permission":"read"}`,
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(out, "accounts/111/user_permissions/222") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestExecute_TagManagerUserPermissionsDeleteRequiresForce(t *testing.T) {
+	err := Execute([]string{
+		"--json", "--account", "admin@example.com", "--no-input",
+		"gtm", "user-permissions", "delete", "accounts/111/user_permissions/222",
+	})
+	if err == nil || !strings.Contains(err.Error(), "without --force") {
+		t.Fatalf("expected confirmation error, got %v", err)
+	}
+}
+
+func TestExecute_TagManagerUserPermissionsListGetUpdateDelete(t *testing.T) {
+	var updateBody tagmanager.UserPermission
+	var deleteCalls int
+	setupTagManagerUserPermissionsTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/tagmanager/v2/accounts/111/user_permissions":
+			if r.URL.Query().Get("pageToken") != "next" {
+				t.Fatalf("pageToken = %q", r.URL.Query().Get("pageToken"))
+			}
+			_, _ = w.Write([]byte(`{"userPermission":[{"path":"accounts/111/user_permissions/222","emailAddress":"one@example.com","accountAccess":{"permission":"user"}},{"path":"accounts/111/user_permissions/333","emailAddress":"two@example.com","accountAccess":{"permission":"admin"}}],"nextPageToken":"later"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/tagmanager/v2/accounts/111/user_permissions/222":
+			_, _ = w.Write([]byte(`{"path":"accounts/111/user_permissions/222","emailAddress":"one@example.com","accountAccess":{"permission":"user"},"containerAccess":[{"containerId":"c1","permission":"approve"}]}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/tagmanager/v2/accounts/111/user_permissions/222":
+			if err := json.NewDecoder(r.Body).Decode(&updateBody); err != nil {
+				t.Fatalf("decode update: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"path":"accounts/111/user_permissions/222","emailAddress":"one@example.com","accountAccess":{"permission":"admin"},"containerAccess":[{"containerId":"c1","permission":"approve"}]}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/tagmanager/v2/accounts/111/user_permissions/222":
+			deleteCalls++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	listOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com", "gtm", "user-permissions", "list",
+				"--account-id", "111", "--page", "next",
+			}); err != nil {
+				t.Fatalf("list: %v", err)
+			}
+		})
+	})
+	var listResult struct {
+		UserPermissions []json.RawMessage `json:"userPermissions"`
+		NextPageToken   string            `json:"nextPageToken"`
+	}
+	if err := json.Unmarshal([]byte(listOut), &listResult); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listResult.UserPermissions) != 2 || listResult.NextPageToken != "later" {
+		t.Fatalf("unexpected list output: %q", listOut)
+	}
+
+	getOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "admin@example.com", "gtm", "user-permissions", "get",
+				"accounts/111/user_permissions/222",
+			}); err != nil {
+				t.Fatalf("get: %v", err)
+			}
+		})
+	})
+	if getOut != "PATH\tEMAIL\tACCOUNT_ACCESS\naccounts/111/user_permissions/222\tone@example.com\tuser\n" {
+		t.Fatalf("unexpected get output: %q", getOut)
+	}
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com", "gtm", "user-permissions", "update",
+				"accounts/111/user_permissions/222", "--account-access-type", "admin",
+			}); err != nil {
+				t.Fatalf("update: %v", err)
+			}
+		})
+	})
+	if updateBody.AccountAccess == nil || updateBody.AccountAccess.Permission != "admin" || len(updateBody.ContainerAccess) != 1 || updateBody.ContainerAccess[0].Permission != "approve" {
+		t.Fatalf("unexpected update body: %#v", updateBody)
+	}
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com", "--force", "gtm", "user-permissions", "delete",
+				"accounts/111/user_permissions/222",
+			}); err != nil {
+				t.Fatalf("delete: %v", err)
+			}
+		})
+	})
+	if deleteCalls != 1 {
+		t.Fatalf("delete calls = %d", deleteCalls)
+	}
+}
+
+func TestExecute_TagManagerUserPermissionsValidatesAccountAccess(t *testing.T) {
+	err := Execute([]string{
+		"--account", "admin@example.com", "gtm", "user-permissions", "create",
+		"--account-id", "111", "--email", "person@example.com", "--account-access-type", "owner",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid --account-access-type") {
+		t.Fatalf("expected account access validation error, got %v", err)
+	}
+}

--- a/internal/googleapi/analytics.go
+++ b/internal/googleapi/analytics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	analyticsadminalpha "google.golang.org/api/analyticsadmin/v1alpha"
 	analyticsadmin "google.golang.org/api/analyticsadmin/v1beta"
 	analyticsdata "google.golang.org/api/analyticsdata/v1beta"
 
@@ -15,6 +16,16 @@ func NewAnalyticsData(ctx context.Context, email string) (*analyticsdata.Service
 		return nil, fmt.Errorf("analytics data options: %w", err)
 	} else if svc, err := analyticsdata.NewService(ctx, opts...); err != nil {
 		return nil, fmt.Errorf("create analytics data service: %w", err)
+	} else {
+		return svc, nil
+	}
+}
+
+func NewAnalyticsAdminAlpha(ctx context.Context, email string) (*analyticsadminalpha.Service, error) {
+	if opts, err := optionsForAccount(ctx, googleauth.ServiceAnalytics, email); err != nil {
+		return nil, fmt.Errorf("analytics admin alpha options: %w", err)
+	} else if svc, err := analyticsadminalpha.NewService(ctx, opts...); err != nil {
+		return nil, fmt.Errorf("create analytics admin alpha service: %w", err)
 	} else {
 		return svc, nil
 	}

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -208,6 +208,7 @@ var serviceInfoByService = map[Service]serviceInfo{
 		scopes: []string{
 			"https://www.googleapis.com/auth/analytics.readonly",
 			"https://www.googleapis.com/auth/analytics.edit",
+			"https://www.googleapis.com/auth/analytics.manage.users",
 		},
 		user: true,
 		apis: []string{"Analytics Data API", "Analytics Admin API"},
@@ -221,9 +222,12 @@ var serviceInfoByService = map[Service]serviceInfo{
 		apis: []string{"Search Console API"},
 	},
 	ServiceTagManager: {
-		scopes: []string{"https://www.googleapis.com/auth/tagmanager.readonly"},
-		user:   true,
-		apis:   []string{"Tag Manager API v2"},
+		scopes: []string{
+			"https://www.googleapis.com/auth/tagmanager.readonly",
+			"https://www.googleapis.com/auth/tagmanager.manage.users",
+		},
+		user: true,
+		apis: []string{"Tag Manager API v2"},
 	},
 	ServiceBusinessProfile: {
 		scopes: []string{"https://www.googleapis.com/auth/business.manage"},
@@ -540,7 +544,10 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 		return Scopes(service)
 	case ServiceAnalytics:
 		if opts.Readonly {
-			return []string{"https://www.googleapis.com/auth/analytics.readonly"}, nil
+			return []string{
+				"https://www.googleapis.com/auth/analytics.readonly",
+				"https://www.googleapis.com/auth/analytics.manage.users.readonly",
+			}, nil
 		}
 
 		return Scopes(service)
@@ -551,6 +558,10 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 
 		return Scopes(service)
 	case ServiceTagManager:
+		if opts.Readonly {
+			return []string{"https://www.googleapis.com/auth/tagmanager.readonly"}, nil
+		}
+
 		return Scopes(service)
 	case ServiceBusinessProfile:
 		return Scopes(service)

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -312,6 +312,47 @@ func TestScopesForServiceWithOptions_ServiceKeep_Readonly(t *testing.T) {
 	}
 }
 
+func TestScopesForServiceWithOptions_TagManagerManageUsers(t *testing.T) {
+	writeScopes, err := scopesForServiceWithOptions(ServiceTagManager, ScopeOptions{})
+	if err != nil {
+		t.Fatalf("write scopes: %v", err)
+	}
+
+	if !containsScope(writeScopes, "https://www.googleapis.com/auth/tagmanager.manage.users") {
+		t.Fatalf("missing tagmanager.manage.users in %v", writeScopes)
+	}
+
+	readonlyScopes, err := scopesForServiceWithOptions(ServiceTagManager, ScopeOptions{Readonly: true})
+	if err != nil {
+		t.Fatalf("readonly scopes: %v", err)
+	}
+
+	if len(readonlyScopes) != 1 || readonlyScopes[0] != "https://www.googleapis.com/auth/tagmanager.readonly" {
+		t.Fatalf("unexpected readonly scopes: %v", readonlyScopes)
+	}
+}
+
+func TestScopesForServiceWithOptions_AnalyticsManageUsers(t *testing.T) {
+	writeScopes, err := scopesForServiceWithOptions(ServiceAnalytics, ScopeOptions{})
+	if err != nil {
+		t.Fatalf("write scopes: %v", err)
+	}
+
+	if !containsScope(writeScopes, "https://www.googleapis.com/auth/analytics.manage.users") {
+		t.Fatalf("missing analytics.manage.users in %v", writeScopes)
+	}
+
+	readonlyScopes, err := scopesForServiceWithOptions(ServiceAnalytics, ScopeOptions{Readonly: true})
+	if err != nil {
+		t.Fatalf("readonly scopes: %v", err)
+	}
+
+	if !containsScope(readonlyScopes, "https://www.googleapis.com/auth/analytics.readonly") ||
+		!containsScope(readonlyScopes, "https://www.googleapis.com/auth/analytics.manage.users.readonly") {
+		t.Fatalf("unexpected readonly scopes: %v", readonlyScopes)
+	}
+}
+
 func TestScopesForManageWithOptions_DriveScopeFile(t *testing.T) {
 	scopes, err := ScopesForManageWithOptions([]Service{ServiceDrive, ServiceDocs}, ScopeOptions{
 		DriveScope: DriveScopeFile,

--- a/specs/features/tagmanager-gaps.md
+++ b/specs/features/tagmanager-gaps.md
@@ -360,7 +360,7 @@ Many resources also accept a full `path` positional arg (e.g. `accounts/123/cont
 | **create** | `gog gtm user-permissions create` | `--account-id` (required); `--email` (required); `--account-access-type` (optional: noAccess, user, admin); `--container-access` (optional repeatable JSON) | JSON object |
 | **delete** | `gog gtm user-permissions delete <path>` | `path` (positional). `--force`. `confirmDestructive()`. | JSON `{"deleted": true}` |
 | **get** | `gog gtm user-permissions get <path>` | `path` (positional) | JSON object |
-| **list** | `gog gtm user-permissions list` | `--account-id` (required); `--max`, `--page` | JSON array, TSV: PERMISSION_ID, EMAIL, ACCOUNT_ACCESS |
+| **list** | `gog gtm user-permissions list` | `--account-id` (required); `--page` | JSON object with userPermissions array + nextPageToken, TSV: PERMISSION_ID, EMAIL, ACCOUNT_ACCESS |
 | **update** | `gog gtm user-permissions update <path>` | `path`; `--account-access-type`, `--container-access` (optional). Uses `flagProvided()`. | JSON object |
 
 **Test requirements:**


### PR DESCRIPTION
## Summary

- add GA4 account/property access-binding list, create, patch, and delete commands
- add GTM user-permission create, get, list, update, and delete commands
- request the supported Analytics and GTM user-management OAuth scopes while preserving explicit readonly auth
- make GTM updates fetch and merge existing permissions before the API full-replacement PUT

## Search Console

Google Search Console has no supported user/permission-management API. Its public sites methods only change the authenticated user own site set. This PR intentionally avoids private UI endpoints; Search Console sharing remains a UI operation.

## Verification

- CC=/usr/bin/clang CXX=/usr/bin/clang++ make ci
- focused command/help smoke tests
- two-axis code review against origin/main: standards/YAGNI/surgical scope clean; spec/correctness clean after accepted fixes

## User-facing changes

New commands:
- gog analytics admin access-bindings list|create|patch|delete
- gog gtm user-permissions create|delete|get|list|update

Existing write-capable Analytics/GTM users may need to re-run auth so stored tokens include the new user-management scopes.