### PR TITLE
feat(cli): self-update binary and companion Google skill pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- CLI: `gog update` self-updates the binary from GitHub Releases and refreshes the embedded companion Google skill pack (pack skills only).
+- CLI: `gog skills status|update|install` discovers pack skills under agent skill roots (`.agents`, `.claude`, `.codex`, etc.), skips locally edited skills by default, and never touches non-pack skills or `learnings/`.
+- CLI: throttled stderr notice when a newer release is available (`GOG_SKIP_UPDATE_CHECK=1` to disable).
+- Skills: ship 10 companion skills under `skills/pack/` (Gmail personal/workspace, Analytics, Business Profile, Calendar, Docs, Drive, Search Console, Sheets, Tag Manager).
 - Docs: `gog docs create` now uses Docs API `documents.create`, returns full document metadata (including `revisionId`), and still supports `--parent` via Drive move.
 - Analytics: add account and property user access management with `gog analytics admin access-bindings`.
 - Tag Manager: add account user permission management with `gog gtm user-permissions`.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ Run:
 ./bin/gog --help
 ```
 
+### Updates (binary + companion skills)
+
+This fork can pull newer binaries from GitHub Releases and refresh **only** the Google companion skills that ship with gog (not unrelated agent skills):
+
+```bash
+# Notice on use (stderr) when a newer release exists, or:
+gog update --check
+
+# Upgrade binary + refresh installed pack skills (skips local skill edits)
+gog update
+
+# Skills only
+gog skills status
+gog skills update
+gog skills install                 # ensure pack skills under ~/.agents/skills
+gog skills update --overwrite-local  # human: replace dirty pack skills
+```
+
+Agents: if output says `skills skipped (local edits)`, tell the user — do not force-overwrite unless asked.
+
+Disable background update checks: `GOG_SKIP_UPDATE_CHECK=1`.
+
 Help:
 
 - `gog --help` shows top-level command groups.

--- a/docs/plans/code-review-skill-pack-update.md
+++ b/docs/plans/code-review-skill-pack-update.md
@@ -1,0 +1,32 @@
+# Codex code-review disposition — feat/skill-pack-update
+
+**Fixed point:** `origin/main`  
+**Spec:** `docs/plans/gog-skill-pack-update-2026-08-07.html`  
+**Reviewer:** Codex `codex review --base origin/main` (2026-08-07)
+
+## Blocking (P1) — addressed
+
+| Finding | Fix |
+|---------|-----|
+| Skills refresh after binary update used old embed FS | Re-exec new binary with `gog update --skills-after-binary` after successful binary replace |
+| Current installs without state later classified dirty | On `skipped_current` with empty state, record baseline pack hash |
+| Stale skill commands (drive) | Corrected drive skill flags/commands; added “prefer live `--help`” note to pack skills |
+
+## P2 — addressed
+
+| Finding | Fix |
+|---------|-----|
+| Version inequality could downgrade | Semver-ish `versionLess` — update only when remote is greater |
+| Update check during `go test` | `testing.Testing()` short-circuit in `MaybeNotify` |
+| Install skipped when only project copy exists | Install mode always ensures canonical `~/.agents/skills` root |
+| Symlink privilege failures aborted install | Symlink creation is best-effort (errors ignored) |
+
+## Residual nits (non-blocking)
+
+- Full editorial pass of all 10 skills against every subcommand is larger than this PR; help-first note + drive fix covers the worst agent footgun. Follow-up: regenerate skill tables from `gog <cmd> --help`.
+- Windows binary replace still best-effort (rename dance).
+- Skill pack embeds Robben-local account conventions (existing practice on machine).
+
+## Merge recommendation
+
+**Approve after disposition commit** — P1/P2 from Codex addressed; residual skill editorial is follow-up.

--- a/docs/plans/gog-skill-pack-update-2026-08-07.html
+++ b/docs/plans/gog-skill-pack-update-2026-08-07.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>gog CLI — Skill Pack + Self-Update Plan</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #17202a;
+      --muted: #5f6b7a;
+      --line: #d8dee8;
+      --soft: #f5f7fa;
+      --accent: #146c7c;
+      --accent-soft: #e5f4f6;
+      --good: #23633a;
+      --good-soft: #e7f5eb;
+      --warn: #8a5a00;
+      --warn-soft: #fff5d8;
+      --bad: #8f2f2f;
+      --bad-soft: #fde8e8;
+    }
+    body { margin: 0; background: #fff; color: var(--ink); font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    main { max-width: 960px; margin: 0 auto; padding: 40px 24px 72px; }
+    header { border-bottom: 1px solid var(--line); margin-bottom: 28px; padding-bottom: 20px; }
+    h1 { font-size: 30px; line-height: 1.15; margin: 0 0 8px; }
+    h2 { font-size: 20px; margin: 32px 0 12px; }
+    h3 { font-size: 16px; margin: 24px 0 8px; }
+    p, li { color: var(--ink); }
+    .muted { color: var(--muted); }
+    .meta { display: flex; flex-wrap: wrap; gap: 8px 16px; color: var(--muted); font-size: 13px; }
+    .pill { display: inline-block; padding: 2px 10px; border-radius: 999px; background: var(--accent-soft); color: var(--accent); font-size: 12px; font-weight: 600; }
+    .box { background: var(--soft); border: 1px solid var(--line); border-radius: 10px; padding: 14px 16px; margin: 12px 0; }
+    .good { background: var(--good-soft); border-color: #c5e6cf; }
+    .warn { background: var(--warn-soft); border-color: #f0df9a; }
+    table { width: 100%; border-collapse: collapse; margin: 12px 0 20px; font-size: 14px; }
+    th, td { border: 1px solid var(--line); padding: 8px 10px; text-align: left; vertical-align: top; }
+    th { background: var(--soft); }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+    pre { background: #0f1720; color: #e8eef5; padding: 14px 16px; border-radius: 10px; overflow-x: auto; }
+    ul { padding-left: 1.25rem; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    @media (max-width: 720px) { .grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <div class="pill">Robben Media · gogcli</div>
+    <h1>Skill pack + self-update for gog CLI</h1>
+    <p class="muted">CLI-scoped companion skills update with the binary. Agents get a notice, can run update, skip dirty skills, and report skips to the user.</p>
+    <div class="meta">
+      <span>Date: 2026-08-07</span>
+      <span>Branch: <code>feat/skill-pack-update</code></span>
+      <span>Repo: <code>Robben-Media/gogcli</code></span>
+      <span>Spec for Codex <code>/code-review</code></span>
+    </div>
+  </header>
+
+  <section>
+    <h2>1. Goal</h2>
+    <p>When gog ships a release, machines that already use gog should be able to:</p>
+    <ol>
+      <li>Learn that a newer binary exists (notice on use / explicit check).</li>
+      <li>Upgrade the binary with one command.</li>
+      <li>Refresh <strong>only</strong> the Google/gog companion skills that ship with this CLI — never unrelated agent skills.</li>
+      <li>Find those skills wherever they already live (<code>.agents</code>, <code>.claude</code>, etc.).</li>
+      <li>If a skill was locally edited: <strong>skip</strong> by default (agent-safe); allow force overwrite for intentional human runs; always report skips so an agent can tell the user.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>2. Skill pack (in-repo source of truth)</h2>
+    <p>Canonical pack lives in the gogcli repo (not “whatever is on the machine”):</p>
+    <pre>skills/
+  manifest.json
+  embed.go              # go:embed pack + manifest
+  pack/
+    gmail-personal/SKILL.md
+    gmail-workspace/SKILL.md
+    google-analytics/SKILL.md
+    google-business-profile/SKILL.md
+    google-calendar/SKILL.md
+    google-docs/SKILL.md
+    google-drive/SKILL.md
+    google-search-console/SKILL.md
+    google-sheets/SKILL.md
+    google-tag-manager/SKILL.md</pre>
+
+    <div class="box">
+      <strong>Managed files only:</strong> <code>SKILL.md</code> per skill.<br>
+      <strong>Never managed:</strong> <code>learnings/</code>, local notes, agent memory files under the skill dir.
+    </div>
+
+    <h3>Manifest (names only — no other skills)</h3>
+    <pre>{
+  "name": "gogcli",
+  "skills": [
+    "gmail-personal",
+    "gmail-workspace",
+    "google-analytics",
+    "google-business-profile",
+    "google-calendar",
+    "google-docs",
+    "google-drive",
+    "google-search-console",
+    "google-sheets",
+    "google-tag-manager"
+  ],
+  "managed_files": ["SKILL.md"]
+}</pre>
+  </section>
+
+  <section>
+    <h2>3. Discovery</h2>
+    <p>For each manifest skill name, search known agent skill roots under the user home (and optional project cwd):</p>
+    <ul>
+      <li><code>~/.agents/skills/&lt;name&gt;</code></li>
+      <li><code>~/.claude/skills/&lt;name&gt;</code></li>
+      <li><code>~/.codex/skills/&lt;name&gt;</code></li>
+      <li><code>~/.cursor/skills/&lt;name&gt;</code></li>
+      <li><code>~/.grok/skills/&lt;name&gt;</code></li>
+      <li><code>~/.factory/skills/&lt;name&gt;</code></li>
+      <li><code>~/.config/agents/skills/&lt;name&gt;</code></li>
+      <li>Project: <code>&lt;cwd&gt;/.agents/skills/&lt;name&gt;</code>, <code>&lt;cwd&gt;/.claude/skills/&lt;name&gt;</code> when present</li>
+    </ul>
+    <p>Resolve symlinks to real paths and <strong>dedupe</strong> (Jeremy’s setup: <code>.claude/skills/*</code> → <code>.agents/skills/*</code>). Update the real directory once.</p>
+    <p>If a skill is not installed anywhere: leave it alone (no mass install unless <code>gog skills install</code>).</p>
+  </section>
+
+  <section>
+    <h2>4. Dirty / outdated detection</h2>
+    <p>State file: <code>~/.config/gogcli/skill-pack-state.json</code> records last content hash written per real path.</p>
+    <table>
+      <thead><tr><th>Condition</th><th>Status</th><th>Default action</th></tr></thead>
+      <tbody>
+        <tr><td>No install path</td><td><code>not_installed</code></td><td>Skip (unless install)</td></tr>
+        <tr><td>Disk hash == pack hash</td><td><code>current</code></td><td>No-op</td></tr>
+        <tr><td>Disk hash == last-written hash ≠ pack</td><td><code>outdated</code></td><td>Update</td></tr>
+        <tr><td>Disk hash ≠ pack and ≠ last-written (or no state)</td><td><code>dirty</code></td><td><strong>Skip</strong> unless <code>--force</code></td></tr>
+      </tbody>
+    </table>
+    <div class="box warn">
+      <strong>Agent policy:</strong> never force-overwrite dirty skills. Print skip lines so the agent can tell the user.<br>
+      <strong>Human policy:</strong> pass <code>--force</code> / <code>--force-skills</code> when pack should win.
+    </div>
+  </section>
+
+  <section>
+    <h2>5. CLI surface</h2>
+    <table>
+      <thead><tr><th>Command</th><th>Behavior</th></tr></thead>
+      <tbody>
+        <tr><td><code>gog update</code></td><td>Binary self-update from GitHub Releases + skill refresh (pack-only, skip dirty)</td></tr>
+        <tr><td><code>gog update --skills-only</code></td><td>Skills only</td></tr>
+        <tr><td><code>gog update --binary-only</code></td><td>Binary only</td></tr>
+        <tr><td><code>gog update --force-skills</code></td><td>Overwrite dirty pack skills</td></tr>
+        <tr><td><code>gog update --force-binary</code></td><td>Allow replacing dev/dirty binaries</td></tr>
+        <tr><td><code>gog skills status</code></td><td>List pack skills, install paths, current/outdated/dirty/not_installed</td></tr>
+        <tr><td><code>gog skills update</code></td><td>Refresh installed pack skills (skip dirty)</td></tr>
+        <tr><td><code>gog skills update --overwrite-local</code></td><td>Overwrite dirty (human)</td></tr>
+        <tr><td><code>gog skills install</code></td><td>Ensure pack skills exist under <code>~/.agents/skills</code> (and symlink into other existing agent skill roots if missing)</td></tr>
+        <tr><td><code>gog version</code> / use of any command</td><td>Throttled update check → stderr notice (optional skip via env)</td></tr>
+      </tbody>
+    </table>
+
+    <h3>Agent-parseable notices (stderr)</h3>
+    <pre>gog: update available 0.9.0 → 0.10.0; run: gog update
+gog: skills updated: google-calendar, google-drive
+gog: skills skipped (local edits): gmail-workspace @ /Users/…/.agents/skills/gmail-workspace
+     re-run with: gog skills update --overwrite-local
+gog: skills not installed: google-tag-manager — run: gog skills install</pre>
+  </section>
+
+  <section>
+    <h2>6. Binary self-update</h2>
+    <ul>
+      <li>Source: GitHub Releases for <code>Robben-Media/gogcli</code> (override with <code>GOG_UPDATE_REPO</code>).</li>
+      <li>Use existing GoReleaser asset naming: <code>gogcli_&lt;version&gt;_&lt;os&gt;_&lt;arch&gt;.tar.gz</code> (+ windows zip).</li>
+      <li>Verify against <code>checksums.txt</code> when present.</li>
+      <li>Atomic replace of the running binary path (<code>os.Executable()</code>).</li>
+      <li>Refuse auto-replace for obvious local-dev builds if version is empty/<code>dev</code> unless <code>--force</code>.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>7. Check-on-use (LLM notification)</h2>
+    <ul>
+      <li>At most once per 24h (state: <code>~/.config/gogcli/update-check.json</code>).</li>
+      <li>Non-fatal; network errors silent.</li>
+      <li>Disable: <code>GOG_SKIP_UPDATE_CHECK=1</code> or <code>--no-input</code> paths that must stay quiet can still show check only on successful version compare (prefer always stderr only).</li>
+      <li>Does not auto-upgrade; only prints the notice. Agent/skill text: if notice appears, run <code>gog update</code> then retry.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>8. Implementation layout</h2>
+    <div class="grid">
+      <div class="box">
+        <strong>packages</strong>
+        <ul>
+          <li><code>skills/</code> — embed + pack files</li>
+          <li><code>internal/skillpack/</code> — discover, hash, state, apply</li>
+          <li><code>internal/selfupdate/</code> — GitHub release check + apply</li>
+          <li><code>internal/cmd/update.go</code>, <code>skills.go</code></li>
+        </ul>
+      </div>
+      <div class="box">
+        <strong>docs / release</strong>
+        <ul>
+          <li>CHANGELOG Unreleased</li>
+          <li>RELEASING.md: skills ship in git + binary; no separate skill artifact required (embedded)</li>
+          <li>README install: mention <code>gog update</code> / <code>gog skills install</code></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>9. Phased delivery (this PR)</h2>
+    <ol>
+      <li>Import 10 SKILL.md files into <code>skills/pack/</code> + manifest + embed.</li>
+      <li><code>skillpack</code> library with unit tests (hash, dirty, discover, apply, symlink dedupe).</li>
+      <li><code>gog skills status|update|install</code>.</li>
+      <li><code>selfupdate</code> check + apply (tests with httptest fixtures).</li>
+      <li><code>gog update</code> composing both.</li>
+      <li>Throttled check-on-use wired from root execute path.</li>
+      <li>Focused tests + <code>make test</code> / package tests green.</li>
+      <li>Codex <code>/code-review</code> vs <code>main</code> using this plan as Spec; address blocking findings before merge.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>10. Explicit non-goals</h2>
+    <ul>
+      <li>Do not update Matt Pocock / Vercel / unrelated skills.</li>
+      <li>Do not reimplement skills.sh.</li>
+      <li>Do not overwrite <code>learnings/</code>.</li>
+      <li>Do not push updates to machines (pull-on-use only).</li>
+      <li>Do not publish personal keyring passwords as new secrets (existing skill examples may retain local conventions already on disk).</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>11. Acceptance criteria</h2>
+    <ul>
+      <li><code>gog skills status</code> lists all 10 pack skills and finds existing installs under <code>~/.agents</code> / <code>~/.claude</code>.</li>
+      <li>Editing a managed <code>SKILL.md</code> causes skip without <code>--force</code>; message names path.</li>
+      <li>Clean outdated skill is rewritten; <code>learnings/</code> untouched.</li>
+      <li><code>gog update --skills-only</code> never touches non-pack skill dirs.</li>
+      <li>Binary check returns structured “update available” line without upgrading when not asked.</li>
+      <li>Codex code-review completed against this plan; merge only after review disposition.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>12. Review gate</h2>
+    <div class="box good">
+      Before merge: run a Codex session with the repo’s <code>/code-review</code> skill against fixed point <code>main</code>, Spec = this document.
+      Fix blocking Standards/Spec findings; re-run or note residual nits.
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/steipete/gogcli/internal/googleauth"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/steipete/gogcli/internal/selfupdate"
 	"github.com/steipete/gogcli/internal/ui"
 )
 
@@ -68,6 +69,8 @@ type CLI struct {
 	BusinessProfile BusinessProfileCmd    `cmd:"" aliases:"gbp,business" help:"Google Business Profile"`
 	Config          ConfigCmd             `cmd:"" help:"Manage configuration"`
 	Policy          PolicyCmd             `cmd:"" help:"Manage command safety policies"`
+	Update          UpdateCmd             `cmd:"" help:"Update gog binary and companion Google skills"`
+	Skills          SkillsCmd             `cmd:"" help:"Manage companion Google skill pack (pack skills only)"`
 	VersionCmd      VersionCmd            `cmd:"" name:"version" help:"Print version"`
 	Completion      CompletionCmd         `cmd:"" help:"Generate shell completion scripts"`
 	Complete        CompletionInternalCmd `cmd:"" name:"__complete" hidden:"" help:"Internal completion helper"`
@@ -154,6 +157,14 @@ func Execute(args []string) (err error) {
 
 	kctx.BindTo(ctx, (*context.Context)(nil))
 	kctx.Bind(&cli.RootFlags)
+
+	// Throttled non-fatal update notice for humans and agents (stderr only).
+	if notice := selfupdate.MaybeNotify(ctx, &selfupdate.Client{
+		Repo:  strings.TrimSpace(os.Getenv("GOG_UPDATE_REPO")),
+		Token: envOr("GITHUB_TOKEN", envOr("GH_TOKEN", "")),
+	}, version, 0); notice != "" {
+		_, _ = fmt.Fprintln(os.Stderr, notice)
+	}
 
 	err = kctx.Run()
 	if err == nil {

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -13,8 +13,8 @@ import (
 
 // SkillsCmd manages the companion skill pack for this CLI.
 type SkillsCmd struct {
-	Status SkillsStatusCmd `cmd:"" help:"Show pack skill install status (pack skills only)"`
-	Update SkillsUpdateCmd `cmd:"" help:"Refresh installed pack skills (skip local edits unless --force)"`
+	Status  SkillsStatusCmd  `cmd:"" help:"Show pack skill install status (pack skills only)"`
+	Update  SkillsUpdateCmd  `cmd:"" help:"Refresh installed pack skills (skip local edits unless --force)"`
 	Install SkillsInstallCmd `cmd:"" help:"Install pack skills into ~/.agents/skills and link other agent roots"`
 }
 

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/skillpack"
+)
+
+// SkillsCmd manages the companion skill pack for this CLI.
+type SkillsCmd struct {
+	Status SkillsStatusCmd `cmd:"" help:"Show pack skill install status (pack skills only)"`
+	Update SkillsUpdateCmd `cmd:"" help:"Refresh installed pack skills (skip local edits unless --force)"`
+	Install SkillsInstallCmd `cmd:"" help:"Install pack skills into ~/.agents/skills and link other agent roots"`
+}
+
+// SkillsStatusCmd lists status for each pack skill.
+type SkillsStatusCmd struct{}
+
+func (c *SkillsStatusCmd) Run(ctx context.Context) error {
+	cwd, _ := os.Getwd()
+	rows, err := skillpack.EvaluateAll(VersionString(), skillpack.DiscoverOptions{ProjectDir: cwd})
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		type row struct {
+			Skill    string `json:"skill"`
+			Status   string `json:"status"`
+			Path     string `json:"path,omitempty"`
+			RealPath string `json:"real_path,omitempty"`
+		}
+		out := make([]row, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, row{
+				Skill:    r.Skill,
+				Status:   string(r.Kind),
+				Path:     r.Path,
+				RealPath: r.RealPath,
+			})
+		}
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"pack_version": VersionString(),
+			"skills":       out,
+		})
+	}
+	if outfmt.IsPlain(ctx) {
+		for _, r := range rows {
+			path := r.RealPath
+			if path == "" {
+				path = "-"
+			}
+			fmt.Fprintf(os.Stdout, "%s\t%s\t%s\n", r.Skill, r.Kind, path)
+		}
+		return nil
+	}
+	fmt.Fprintf(os.Stdout, "gog skill pack (version %s)\n", VersionString())
+	for _, r := range rows {
+		switch r.Kind {
+		case skillpack.StatusNotInstalled:
+			fmt.Fprintf(os.Stdout, "  %-28s  %s\n", r.Skill, r.Kind)
+		default:
+			fmt.Fprintf(os.Stdout, "  %-28s  %-16s  %s\n", r.Skill, r.Kind, r.RealPath)
+		}
+	}
+	return nil
+}
+
+// SkillsUpdateCmd refreshes installed pack skills.
+type SkillsUpdateCmd struct {
+	OverwriteLocal bool `name:"overwrite-local" help:"Overwrite pack skills that have local edits"`
+}
+
+func (c *SkillsUpdateCmd) Run(ctx context.Context) error {
+	return runSkillUpdate(ctx, c.OverwriteLocal, false)
+}
+
+// SkillsInstallCmd installs missing pack skills.
+type SkillsInstallCmd struct {
+	OverwriteLocal bool `name:"overwrite-local" help:"Overwrite pack skills that have local edits"`
+}
+
+func (c *SkillsInstallCmd) Run(ctx context.Context) error {
+	return runSkillUpdate(ctx, c.OverwriteLocal, true)
+}
+
+func runSkillUpdate(ctx context.Context, force, install bool) error {
+	cwd, _ := os.Getwd()
+	home, _ := os.UserHomeDir()
+	results, err := skillpack.UpdateInstalled(skillpack.UpdateOptions{
+		Discover: skillpack.DiscoverOptions{
+			HomeDir:    home,
+			ProjectDir: cwd,
+		},
+		Force:       force,
+		Install:     install,
+		InstallRoot: filepath.Join(home, ".agents", "skills"),
+		PackVersion: VersionString(),
+	})
+	if err != nil {
+		return err
+	}
+	return printSkillResults(ctx, results)
+}
+
+func printSkillResults(ctx context.Context, results []skillpack.ApplyResult) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"results": results})
+	}
+
+	var updated, installed, dirty, current, missing []string
+	for _, r := range results {
+		switch r.Action {
+		case "updated":
+			updated = append(updated, r.Skill)
+			fmt.Fprintf(os.Stderr, "gog: skills updated: %s @ %s\n", r.Skill, r.RealPath)
+		case "installed":
+			installed = append(installed, r.Skill)
+			fmt.Fprintf(os.Stderr, "gog: skills installed: %s @ %s\n", r.Skill, r.RealPath)
+		case "skipped_dirty":
+			dirty = append(dirty, r.Skill)
+			fmt.Fprintf(os.Stderr, "gog: skills skipped (local edits): %s @ %s\n", r.Skill, r.RealPath)
+			fmt.Fprintf(os.Stderr, "     re-run with: gog skills update --overwrite-local\n")
+		case "skipped_current":
+			current = append(current, r.Skill)
+		case "skipped_not_installed":
+			missing = append(missing, r.Skill)
+		}
+	}
+
+	if outfmt.IsPlain(ctx) {
+		for _, r := range results {
+			fmt.Fprintf(os.Stdout, "%s\t%s\t%s\n", r.Skill, r.Action, r.RealPath)
+		}
+		return nil
+	}
+
+	// Human summary on stdout
+	if len(updated) > 0 {
+		fmt.Fprintf(os.Stdout, "updated: %s\n", strings.Join(unique(updated), ", "))
+	}
+	if len(installed) > 0 {
+		fmt.Fprintf(os.Stdout, "installed: %s\n", strings.Join(unique(installed), ", "))
+	}
+	if len(dirty) > 0 {
+		fmt.Fprintf(os.Stdout, "skipped (local edits): %s\n", strings.Join(unique(dirty), ", "))
+		fmt.Fprintf(os.Stdout, "Tell the user which skills were skipped and their paths; do not force-overwrite unless they ask.\n")
+	}
+	if len(missing) > 0 {
+		fmt.Fprintf(os.Stdout, "not installed: %s — run: gog skills install\n", strings.Join(unique(missing), ", "))
+	}
+	if len(updated) == 0 && len(installed) == 0 && len(dirty) == 0 && len(missing) == 0 {
+		fmt.Fprintln(os.Stdout, "all installed pack skills are current")
+	}
+	_ = current
+	return nil
+}
+
+func unique(in []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -40,14 +41,17 @@ func (c *UpdateCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
 		if outfmt.IsJSON(ctx) {
 			return outfmt.WriteJSON(os.Stdout, res)
 		}
+
 		if res.Update {
 			fmt.Fprintf(os.Stdout, "gog: update available %s → %s; run: gog update\n", splitVersionBase(res.Current), res.Latest)
 		} else {
 			fmt.Fprintf(os.Stdout, "gog: up to date (%s)\n", res.Latest)
 		}
+
 		return nil
 	}
 
@@ -57,12 +61,14 @@ func (c *UpdateCmd) Run(ctx context.Context) error {
 	}
 
 	binaryUpdated := false
+
 	if !c.SkillsOnly {
 		updated, err := c.updateBinary(ctx, client)
 		if err != nil {
 			if c.BinaryOnly {
 				return err
 			}
+
 			fmt.Fprintf(os.Stderr, "gog: binary update skipped: %v\n", err)
 		} else {
 			binaryUpdated = updated
@@ -77,6 +83,7 @@ func (c *UpdateCmd) Run(ctx context.Context) error {
 	if binaryUpdated {
 		return reexecSkillsPhase(c.ForceSkills)
 	}
+
 	return c.updateSkills(ctx)
 }
 
@@ -85,10 +92,13 @@ func (c *UpdateCmd) updateBinary(ctx context.Context, client *selfupdate.Client)
 	if err != nil {
 		return false, err
 	}
+
 	if !res.Update && !c.ForceBinary {
 		fmt.Fprintf(os.Stderr, "gog: binary up to date (%s)\n", res.Latest)
+
 		return false, nil
 	}
+
 	applied, err := selfupdate.Apply(ctx, selfupdate.ApplyOptions{
 		Client:     client,
 		CurrentVer: version,
@@ -97,13 +107,16 @@ func (c *UpdateCmd) updateBinary(ctx context.Context, client *selfupdate.Client)
 	if err != nil {
 		return false, err
 	}
+
 	fmt.Fprintf(os.Stderr, "gog: binary updated %s → %s\n", splitVersionBase(applied.Current), applied.Latest)
+
 	return true, nil
 }
 
 func (c *UpdateCmd) updateSkills(ctx context.Context) error {
 	cwd, _ := os.Getwd()
 	home, _ := os.UserHomeDir()
+
 	results, err := skillpack.UpdateInstalled(skillpack.UpdateOptions{
 		Discover: skillpack.DiscoverOptions{
 			HomeDir:    home,
@@ -117,6 +130,7 @@ func (c *UpdateCmd) updateSkills(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	return printSkillResults(ctx, results)
 }
 
@@ -125,13 +139,16 @@ func reexecSkillsPhase(forceSkills bool) error {
 	if err != nil {
 		return fmt.Errorf("resolve executable for skills re-exec: %w", err)
 	}
-	if real, err := filepath.EvalSymlinks(exe); err == nil {
-		exe = real
+
+	if resolved, linkErr := filepath.EvalSymlinks(exe); linkErr == nil {
+		exe = resolved
 	}
+
 	args := []string{"update", "--skills-after-binary"}
 	if forceSkills {
 		args = append(args, "--force-skills")
 	}
+
 	// Preserve output mode flags if present in original argv (best-effort).
 	for _, a := range os.Args[1:] {
 		switch a {
@@ -139,19 +156,25 @@ func reexecSkillsPhase(forceSkills bool) error {
 			args = append(args, a)
 		}
 	}
+
+	//nolint:gosec // re-exec of the just-installed gog binary path
 	cmd := exec.Command(exe, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Env = os.Environ()
+
 	if err := cmd.Run(); err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			if status, ok := ee.Sys().(syscall.WaitStatus); ok {
 				return &ExitError{Code: status.ExitStatus(), Err: err}
 			}
 		}
+
 		return err
 	}
+
 	return nil
 }
 
@@ -161,6 +184,7 @@ func firstNonEmpty(vals ...string) string {
 			return strings.TrimSpace(v)
 		}
 	}
+
 	return ""
 }
 
@@ -169,5 +193,6 @@ func splitVersionBase(v string) string {
 	if i := strings.IndexByte(v, '-'); i >= 0 {
 		return v[:i]
 	}
+
 	return v
 }

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -81,7 +81,7 @@ func (c *UpdateCmd) Run(ctx context.Context) error {
 
 	// After replacing the binary, re-exec so skills come from the new embed FS.
 	if binaryUpdated {
-		return reexecSkillsPhase(c.ForceSkills)
+		return reexecSkillsPhase(ctx, c.ForceSkills)
 	}
 
 	return c.updateSkills(ctx)
@@ -134,7 +134,7 @@ func (c *UpdateCmd) updateSkills(ctx context.Context) error {
 	return printSkillResults(ctx, results)
 }
 
-func reexecSkillsPhase(forceSkills bool) error {
+func reexecSkillsPhase(ctx context.Context, forceSkills bool) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolve executable for skills re-exec: %w", err)
@@ -158,7 +158,7 @@ func reexecSkillsPhase(forceSkills bool) error {
 	}
 
 	//nolint:gosec // re-exec of the just-installed gog binary path
-	cmd := exec.CommandContext(context.Background(), exe, args...)
+	cmd := exec.CommandContext(ctx, exe, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/selfupdate"
+	"github.com/steipete/gogcli/internal/skillpack"
+)
+
+// UpdateCmd upgrades the gog binary and/or companion skill pack.
+type UpdateCmd struct {
+	SkillsOnly  bool `help:"Only refresh companion skills (no binary download)"`
+	BinaryOnly  bool `help:"Only update the gog binary (no skills)"`
+	ForceBinary bool `name:"force-binary" help:"Allow replacing dev/dirty binaries"`
+	ForceSkills bool `name:"force-skills" help:"Overwrite pack skills that have local edits"`
+	Check       bool `help:"Only check for a binary update; do not install"`
+}
+
+func (c *UpdateCmd) Run(ctx context.Context) error {
+	if c.SkillsOnly && c.BinaryOnly {
+		return fmt.Errorf("use only one of --skills-only or --binary-only")
+	}
+
+	client := &selfupdate.Client{
+		Repo:  strings.TrimSpace(os.Getenv("GOG_UPDATE_REPO")),
+		Token: firstNonEmpty(os.Getenv("GITHUB_TOKEN"), os.Getenv("GH_TOKEN")),
+	}
+
+	if c.Check {
+		res, err := selfupdate.Check(ctx, client, version)
+		if err != nil {
+			return err
+		}
+		if outfmt.IsJSON(ctx) {
+			return outfmt.WriteJSON(os.Stdout, res)
+		}
+		if res.Update {
+			fmt.Fprintf(os.Stdout, "gog: update available %s → %s; run: gog update\n", splitVersionBase(res.Current), res.Latest)
+		} else {
+			fmt.Fprintf(os.Stdout, "gog: up to date (%s)\n", res.Latest)
+		}
+		return nil
+	}
+
+	if !c.SkillsOnly {
+		if err := c.updateBinary(ctx, client); err != nil {
+			if c.BinaryOnly {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "gog: binary update skipped: %v\n", err)
+		}
+	}
+
+	if c.BinaryOnly {
+		return nil
+	}
+	return c.updateSkills(ctx)
+}
+
+func (c *UpdateCmd) updateBinary(ctx context.Context, client *selfupdate.Client) error {
+	res, err := selfupdate.Check(ctx, client, version)
+	if err != nil {
+		return err
+	}
+	if !res.Update && !c.ForceBinary {
+		fmt.Fprintf(os.Stderr, "gog: binary up to date (%s)\n", res.Latest)
+		return nil
+	}
+	applied, err := selfupdate.Apply(ctx, selfupdate.ApplyOptions{
+		Client:     client,
+		CurrentVer: version,
+		Force:      c.ForceBinary,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "gog: binary updated %s → %s\n", splitVersionBase(applied.Current), applied.Latest)
+	return nil
+}
+
+func (c *UpdateCmd) updateSkills(ctx context.Context) error {
+	cwd, _ := os.Getwd()
+	home, _ := os.UserHomeDir()
+	results, err := skillpack.UpdateInstalled(skillpack.UpdateOptions{
+		Discover: skillpack.DiscoverOptions{
+			HomeDir:    home,
+			ProjectDir: cwd,
+		},
+		Force:       c.ForceSkills,
+		Install:     false,
+		InstallRoot: filepath.Join(home, ".agents", "skills"),
+		PackVersion: VersionString(),
+	})
+	if err != nil {
+		return err
+	}
+	return printSkillResults(ctx, results)
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func splitVersionBase(v string) string {
+	v = selfupdate.NormalizeVersion(v)
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		return v[:i]
+	}
+	return v
+}

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -158,7 +158,7 @@ func reexecSkillsPhase(forceSkills bool) error {
 	}
 
 	//nolint:gosec // re-exec of the just-installed gog binary path
-	cmd := exec.Command(exe, args...)
+	cmd := exec.CommandContext(context.Background(), exe, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/selfupdate"
@@ -19,6 +21,8 @@ type UpdateCmd struct {
 	ForceBinary bool `name:"force-binary" help:"Allow replacing dev/dirty binaries"`
 	ForceSkills bool `name:"force-skills" help:"Overwrite pack skills that have local edits"`
 	Check       bool `help:"Only check for a binary update; do not install"`
+	// Internal: set when re-execing the new binary for the skills phase after binary replace.
+	SkillsAfterBinary bool `name:"skills-after-binary" hidden:"" help:"Internal: run skills refresh after binary update"`
 }
 
 func (c *UpdateCmd) Run(ctx context.Context) error {
@@ -47,29 +51,43 @@ func (c *UpdateCmd) Run(ctx context.Context) error {
 		return nil
 	}
 
+	// Skills phase after re-exec of the newly installed binary.
+	if c.SkillsAfterBinary || c.SkillsOnly {
+		return c.updateSkills(ctx)
+	}
+
+	binaryUpdated := false
 	if !c.SkillsOnly {
-		if err := c.updateBinary(ctx, client); err != nil {
+		updated, err := c.updateBinary(ctx, client)
+		if err != nil {
 			if c.BinaryOnly {
 				return err
 			}
 			fmt.Fprintf(os.Stderr, "gog: binary update skipped: %v\n", err)
+		} else {
+			binaryUpdated = updated
 		}
 	}
 
 	if c.BinaryOnly {
 		return nil
 	}
+
+	// After replacing the binary, re-exec so skills come from the new embed FS.
+	if binaryUpdated {
+		return reexecSkillsPhase(c.ForceSkills)
+	}
 	return c.updateSkills(ctx)
 }
 
-func (c *UpdateCmd) updateBinary(ctx context.Context, client *selfupdate.Client) error {
+func (c *UpdateCmd) updateBinary(ctx context.Context, client *selfupdate.Client) (updated bool, err error) {
 	res, err := selfupdate.Check(ctx, client, version)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if !res.Update && !c.ForceBinary {
 		fmt.Fprintf(os.Stderr, "gog: binary up to date (%s)\n", res.Latest)
-		return nil
+		return false, nil
 	}
 	applied, err := selfupdate.Apply(ctx, selfupdate.ApplyOptions{
 		Client:     client,
@@ -77,10 +95,10 @@ func (c *UpdateCmd) updateBinary(ctx context.Context, client *selfupdate.Client)
 		Force:      c.ForceBinary,
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	fmt.Fprintf(os.Stderr, "gog: binary updated %s → %s\n", splitVersionBase(applied.Current), applied.Latest)
-	return nil
+	return true, nil
 }
 
 func (c *UpdateCmd) updateSkills(ctx context.Context) error {
@@ -100,6 +118,41 @@ func (c *UpdateCmd) updateSkills(ctx context.Context) error {
 		return err
 	}
 	return printSkillResults(ctx, results)
+}
+
+func reexecSkillsPhase(forceSkills bool) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable for skills re-exec: %w", err)
+	}
+	if real, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = real
+	}
+	args := []string{"update", "--skills-after-binary"}
+	if forceSkills {
+		args = append(args, "--force-skills")
+	}
+	// Preserve output mode flags if present in original argv (best-effort).
+	for _, a := range os.Args[1:] {
+		switch a {
+		case "--json", "--plain":
+			args = append(args, a)
+		}
+	}
+	cmd := exec.Command(exe, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			if status, ok := ee.Sys().(syscall.WaitStatus); ok {
+				return &ExitError{Code: status.ExitStatus(), Err: err}
+			}
+		}
+		return err
+	}
+	return nil
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/internal/selfupdate/apply.go
+++ b/internal/selfupdate/apply.go
@@ -45,22 +45,62 @@ func Check(ctx context.Context, client *Client, current string) (CheckResult, er
 	cur := NormalizeVersion(current)
 	// strip dirty suffixes from git describe e.g. 0.9.0-52-gae841c6-dirty
 	curBase := strings.Split(cur, "-")[0]
-	update := latest != "" && curBase != latest && curBase != "dev" && cur != ""
-	// also treat equal base as no update when current is pure tag
-	if cur == latest {
-		update = false
-	}
-	// If current is newer-looking dirty describe of same base, still allow if tag differs
-	if curBase == latest {
-		update = false
-	}
+	update := versionLess(curBase, latest)
 	assetName := AssetNameFor(rel.TagName)
 	return CheckResult{
 		Current: current,
 		Latest:  latest,
-		Update:  update && latest != curBase,
+		Update:  update,
 		Asset:   assetName,
 	}, nil
+}
+
+// versionLess reports whether a is strictly older than b (semver-ish X.Y.Z).
+// Non-numeric / empty a is treated as older when b is a normal version.
+func versionLess(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if b == "" || a == b {
+		return false
+	}
+	if a == "" || a == "dev" {
+		return true
+	}
+	ap := parseVersionParts(a)
+	bp := parseVersionParts(b)
+	if ap == nil || bp == nil {
+		// Fall back to string inequality only when both parse fail.
+		return a != b && bp != nil
+	}
+	for i := 0; i < 3; i++ {
+		if ap[i] < bp[i] {
+			return true
+		}
+		if ap[i] > bp[i] {
+			return false
+		}
+	}
+	return false
+}
+
+func parseVersionParts(v string) []int {
+	v = strings.Split(v, "-")[0]
+	parts := strings.Split(v, ".")
+	if len(parts) < 1 || len(parts) > 4 {
+		return nil
+	}
+	out := make([]int, 3)
+	for i := 0; i < len(parts) && i < 3; i++ {
+		n := 0
+		for _, ch := range parts[i] {
+			if ch < '0' || ch > '9' {
+				return nil
+			}
+			n = n*10 + int(ch-'0')
+		}
+		out[i] = n
+	}
+	return out
 }
 
 // Apply downloads the latest release binary and replaces DestPath.

--- a/internal/selfupdate/apply.go
+++ b/internal/selfupdate/apply.go
@@ -8,12 +8,20 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+)
+
+var (
+	errRefuseDevDirty   = errors.New("refusing to self-update dev/dirty build")
+	errAlreadyLatest    = errors.New("already on latest version")
+	errChecksumMismatch = errors.New("checksum mismatch")
+	errArchiveNoBinary  = errors.New("archive missing gog binary")
 )
 
 // ApplyOptions controls binary replacement.
@@ -37,16 +45,18 @@ func Check(ctx context.Context, client *Client, current string) (CheckResult, er
 	if client == nil {
 		client = &Client{}
 	}
+
 	rel, err := client.LatestRelease(ctx)
 	if err != nil {
 		return CheckResult{}, err
 	}
+
 	latest := NormalizeVersion(rel.TagName)
 	cur := NormalizeVersion(current)
-	// strip dirty suffixes from git describe e.g. 0.9.0-52-gae841c6-dirty
 	curBase := strings.Split(cur, "-")[0]
 	update := versionLess(curBase, latest)
 	assetName := AssetNameFor(rel.TagName)
+
 	return CheckResult{
 		Current: current,
 		Latest:  latest,
@@ -56,50 +66,62 @@ func Check(ctx context.Context, client *Client, current string) (CheckResult, er
 }
 
 // versionLess reports whether a is strictly older than b (semver-ish X.Y.Z).
-// Non-numeric / empty a is treated as older when b is a normal version.
 func versionLess(a, b string) bool {
 	a = strings.TrimSpace(a)
 	b = strings.TrimSpace(b)
+
 	if b == "" || a == b {
 		return false
 	}
+
 	if a == "" || a == "dev" {
 		return true
 	}
+
 	ap := parseVersionParts(a)
 	bp := parseVersionParts(b)
+
 	if ap == nil || bp == nil {
-		// Fall back to string inequality only when both parse fail.
 		return a != b && bp != nil
 	}
+
 	for i := 0; i < 3; i++ {
 		if ap[i] < bp[i] {
 			return true
 		}
+
 		if ap[i] > bp[i] {
 			return false
 		}
 	}
+
 	return false
 }
 
 func parseVersionParts(v string) []int {
 	v = strings.Split(v, "-")[0]
 	parts := strings.Split(v, ".")
+
 	if len(parts) < 1 || len(parts) > 4 {
 		return nil
 	}
+
 	out := make([]int, 3)
+
 	for i := 0; i < len(parts) && i < 3; i++ {
 		n := 0
+
 		for _, ch := range parts[i] {
 			if ch < '0' || ch > '9' {
 				return nil
 			}
+
 			n = n*10 + int(ch-'0')
 		}
+
 		out[i] = n
 	}
+
 	return out
 }
 
@@ -109,21 +131,25 @@ func Apply(ctx context.Context, opts ApplyOptions) (CheckResult, error) {
 	if client == nil {
 		client = &Client{}
 	}
+
 	cur := NormalizeVersion(opts.CurrentVer)
 	if !opts.Force && (cur == "" || cur == "dev" || strings.Contains(opts.CurrentVer, "dirty")) {
-		return CheckResult{}, fmt.Errorf("refusing to self-update dev/dirty build %q (pass --force)", opts.CurrentVer)
+		return CheckResult{}, fmt.Errorf("%w %q (pass --force-binary)", errRefuseDevDirty, opts.CurrentVer)
 	}
 
 	rel, err := client.LatestRelease(ctx)
 	if err != nil {
 		return CheckResult{}, err
 	}
+
 	latest := NormalizeVersion(rel.TagName)
 	check := CheckResult{Current: opts.CurrentVer, Latest: latest, Update: true, Asset: AssetNameFor(rel.TagName)}
 	curBase := strings.Split(cur, "-")[0]
-	if curBase == latest && !opts.Force {
+
+	if !versionLess(curBase, latest) && !opts.Force {
 		check.Update = false
-		return check, fmt.Errorf("already on latest version %s", latest)
+
+		return check, fmt.Errorf("%w %s", errAlreadyLatest, latest)
 	}
 
 	asset, checksums, err := FindAsset(rel)
@@ -135,6 +161,7 @@ func Apply(ctx context.Context, opts ApplyOptions) (CheckResult, error) {
 	if err := client.Download(ctx, asset.BrowserDownloadURL, &buf); err != nil {
 		return check, err
 	}
+
 	raw := buf.Bytes()
 
 	if checksums.BrowserDownloadURL != "" {
@@ -142,10 +169,12 @@ func Apply(ctx context.Context, opts ApplyOptions) (CheckResult, error) {
 		if err := client.Download(ctx, checksums.BrowserDownloadURL, &cbuf); err != nil {
 			return check, fmt.Errorf("download checksums: %w", err)
 		}
+
 		sum := sha256.Sum256(raw)
 		want := hex.EncodeToString(sum[:])
+
 		if !checksumLineMatch(cbuf.String(), asset.Name, want) {
-			return check, fmt.Errorf("checksum mismatch for %s", asset.Name)
+			return check, fmt.Errorf("%w for %s", errChecksumMismatch, asset.Name)
 		}
 	}
 
@@ -156,19 +185,23 @@ func Apply(ctx context.Context, opts ApplyOptions) (CheckResult, error) {
 
 	dest := opts.DestPath
 	if dest == "" {
-		dest, err = os.Executable()
-		if err != nil {
-			return check, err
+		exe, exeErr := os.Executable()
+		if exeErr != nil {
+			return check, fmt.Errorf("resolve executable: %w", exeErr)
 		}
-		dest, err = filepath.EvalSymlinks(dest)
-		if err != nil {
-			return check, err
+
+		exe, linkErr := filepath.EvalSymlinks(exe)
+		if linkErr != nil {
+			return check, fmt.Errorf("resolve executable path: %w", linkErr)
 		}
+
+		dest = exe
 	}
 
 	if err := replaceExecutable(dest, bin); err != nil {
 		return check, err
 	}
+
 	return check, nil
 }
 
@@ -178,18 +211,21 @@ func checksumLineMatch(checksums, assetName, gotHex string) bool {
 		if line == "" {
 			continue
 		}
-		// format: <hex>  <filename>  or <hex> *filename
+
 		fields := strings.Fields(line)
 		if len(fields) < 2 {
 			continue
 		}
+
 		sum := fields[0]
 		name := fields[len(fields)-1]
 		name = strings.TrimPrefix(name, "*")
+
 		if name == assetName && strings.EqualFold(sum, gotHex) {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -197,6 +233,7 @@ func extractBinary(archive []byte, assetName string) ([]byte, error) {
 	if strings.HasSuffix(assetName, ".zip") {
 		return extractZipBinary(archive)
 	}
+
 	return extractTarGzBinary(archive)
 }
 
@@ -206,86 +243,119 @@ func extractTarGzBinary(archive []byte) ([]byte, error) {
 		return nil, fmt.Errorf("gzip: %w", err)
 	}
 	defer gr.Close()
+
 	tr := tar.NewReader(gr)
+
 	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
+		hdr, nextErr := tr.Next()
+		if nextErr == io.EOF {
 			break
 		}
-		if err != nil {
-			return nil, err
+
+		if nextErr != nil {
+			return nil, fmt.Errorf("tar next: %w", nextErr)
 		}
+
 		base := filepath.Base(hdr.Name)
 		if hdr.Typeflag == tar.TypeReg && (base == "gog" || base == "gog.exe") {
-			return io.ReadAll(tr)
+			b, readErr := io.ReadAll(tr)
+			if readErr != nil {
+				return nil, fmt.Errorf("read binary from tar: %w", readErr)
+			}
+
+			return b, nil
 		}
 	}
-	return nil, fmt.Errorf("archive missing gog binary")
+
+	return nil, errArchiveNoBinary
 }
 
 func extractZipBinary(archive []byte) ([]byte, error) {
 	r, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("zip: %w", err)
 	}
+
 	for _, f := range r.File {
 		base := filepath.Base(f.Name)
-		if base == "gog" || base == "gog.exe" {
-			rc, err := f.Open()
-			if err != nil {
-				return nil, err
-			}
-			defer rc.Close()
-			return io.ReadAll(rc)
+		if base != "gog" && base != "gog.exe" {
+			continue
 		}
+
+		rc, openErr := f.Open()
+		if openErr != nil {
+			return nil, fmt.Errorf("open zip entry: %w", openErr)
+		}
+
+		b, readErr := io.ReadAll(rc)
+		_ = rc.Close()
+
+		if readErr != nil {
+			return nil, fmt.Errorf("read zip entry: %w", readErr)
+		}
+
+		return b, nil
 	}
-	return nil, fmt.Errorf("zip missing gog binary")
+
+	return nil, errArchiveNoBinary
 }
 
 func replaceExecutable(dest string, data []byte) error {
 	dir := filepath.Dir(dest)
+
 	tmp, err := os.CreateTemp(dir, "gog-update-*")
 	if err != nil {
 		return fmt.Errorf("temp binary: %w", err)
 	}
+
 	tmpName := tmp.Name()
+
 	defer func() { _ = os.Remove(tmpName) }()
 
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Chmod(0o755); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
+
+		return fmt.Errorf("write temp binary: %w", err)
 	}
 
-	// On Windows, cannot replace running exe easily; still try rename dance.
+	if err := tmp.Chmod(0o755); err != nil {
+		_ = tmp.Close()
+
+		return fmt.Errorf("chmod temp binary: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp binary: %w", err)
+	}
+
 	backup := dest + ".bak"
 	_ = os.Remove(backup)
+
 	if runtime.GOOS == "windows" {
 		if err := os.Rename(dest, backup); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("backup current binary: %w", err)
 		}
+
 		if err := os.Rename(tmpName, dest); err != nil {
 			_ = os.Rename(backup, dest)
-			return err
+
+			return fmt.Errorf("replace binary: %w", err)
 		}
+
 		_ = os.Remove(backup)
+
 		return nil
 	}
 
 	if err := os.Rename(tmpName, dest); err != nil {
-		// If dest is busy, try replace via remove+rename
 		if err2 := os.Remove(dest); err2 == nil {
 			if err3 := os.Rename(tmpName, dest); err3 == nil {
 				return nil
 			}
 		}
+
 		return fmt.Errorf("replace binary: %w", err)
 	}
+
 	return nil
 }

--- a/internal/selfupdate/apply.go
+++ b/internal/selfupdate/apply.go
@@ -1,0 +1,251 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// ApplyOptions controls binary replacement.
+type ApplyOptions struct {
+	Client      *Client
+	CurrentVer  string
+	Force       bool // allow replacing dev/dirty builds
+	DestPath    string // default: os.Executable()
+}
+
+// CheckResult is a non-mutating version comparison.
+type CheckResult struct {
+	Current string
+	Latest  string
+	Update  bool
+	Asset   string
+}
+
+// Check reports whether a newer release exists.
+func Check(ctx context.Context, client *Client, current string) (CheckResult, error) {
+	if client == nil {
+		client = &Client{}
+	}
+	rel, err := client.LatestRelease(ctx)
+	if err != nil {
+		return CheckResult{}, err
+	}
+	latest := NormalizeVersion(rel.TagName)
+	cur := NormalizeVersion(current)
+	// strip dirty suffixes from git describe e.g. 0.9.0-52-gae841c6-dirty
+	curBase := strings.Split(cur, "-")[0]
+	update := latest != "" && curBase != latest && curBase != "dev" && cur != ""
+	// also treat equal base as no update when current is pure tag
+	if cur == latest {
+		update = false
+	}
+	// If current is newer-looking dirty describe of same base, still allow if tag differs
+	if curBase == latest {
+		update = false
+	}
+	assetName := AssetNameFor(rel.TagName)
+	return CheckResult{
+		Current: current,
+		Latest:  latest,
+		Update:  update && latest != curBase,
+		Asset:   assetName,
+	}, nil
+}
+
+// Apply downloads the latest release binary and replaces DestPath.
+func Apply(ctx context.Context, opts ApplyOptions) (CheckResult, error) {
+	client := opts.Client
+	if client == nil {
+		client = &Client{}
+	}
+	cur := NormalizeVersion(opts.CurrentVer)
+	if !opts.Force && (cur == "" || cur == "dev" || strings.Contains(opts.CurrentVer, "dirty")) {
+		return CheckResult{}, fmt.Errorf("refusing to self-update dev/dirty build %q (pass --force)", opts.CurrentVer)
+	}
+
+	rel, err := client.LatestRelease(ctx)
+	if err != nil {
+		return CheckResult{}, err
+	}
+	latest := NormalizeVersion(rel.TagName)
+	check := CheckResult{Current: opts.CurrentVer, Latest: latest, Update: true, Asset: AssetNameFor(rel.TagName)}
+	curBase := strings.Split(cur, "-")[0]
+	if curBase == latest && !opts.Force {
+		check.Update = false
+		return check, fmt.Errorf("already on latest version %s", latest)
+	}
+
+	asset, checksums, err := FindAsset(rel)
+	if err != nil {
+		return check, err
+	}
+
+	var buf bytes.Buffer
+	if err := client.Download(ctx, asset.BrowserDownloadURL, &buf); err != nil {
+		return check, err
+	}
+	raw := buf.Bytes()
+
+	if checksums.BrowserDownloadURL != "" {
+		var cbuf bytes.Buffer
+		if err := client.Download(ctx, checksums.BrowserDownloadURL, &cbuf); err != nil {
+			return check, fmt.Errorf("download checksums: %w", err)
+		}
+		sum := sha256.Sum256(raw)
+		want := hex.EncodeToString(sum[:])
+		if !checksumLineMatch(cbuf.String(), asset.Name, want) {
+			return check, fmt.Errorf("checksum mismatch for %s", asset.Name)
+		}
+	}
+
+	bin, err := extractBinary(raw, asset.Name)
+	if err != nil {
+		return check, err
+	}
+
+	dest := opts.DestPath
+	if dest == "" {
+		dest, err = os.Executable()
+		if err != nil {
+			return check, err
+		}
+		dest, err = filepath.EvalSymlinks(dest)
+		if err != nil {
+			return check, err
+		}
+	}
+
+	if err := replaceExecutable(dest, bin); err != nil {
+		return check, err
+	}
+	return check, nil
+}
+
+func checksumLineMatch(checksums, assetName, gotHex string) bool {
+	for _, line := range strings.Split(checksums, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// format: <hex>  <filename>  or <hex> *filename
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		sum := fields[0]
+		name := fields[len(fields)-1]
+		name = strings.TrimPrefix(name, "*")
+		if name == assetName && strings.EqualFold(sum, gotHex) {
+			return true
+		}
+	}
+	return false
+}
+
+func extractBinary(archive []byte, assetName string) ([]byte, error) {
+	if strings.HasSuffix(assetName, ".zip") {
+		return extractZipBinary(archive)
+	}
+	return extractTarGzBinary(archive)
+}
+
+func extractTarGzBinary(archive []byte) ([]byte, error) {
+	gr, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, fmt.Errorf("gzip: %w", err)
+	}
+	defer gr.Close()
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		base := filepath.Base(hdr.Name)
+		if hdr.Typeflag == tar.TypeReg && (base == "gog" || base == "gog.exe") {
+			return io.ReadAll(tr)
+		}
+	}
+	return nil, fmt.Errorf("archive missing gog binary")
+}
+
+func extractZipBinary(archive []byte) ([]byte, error) {
+	r, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range r.File {
+		base := filepath.Base(f.Name)
+		if base == "gog" || base == "gog.exe" {
+			rc, err := f.Open()
+			if err != nil {
+				return nil, err
+			}
+			defer rc.Close()
+			return io.ReadAll(rc)
+		}
+	}
+	return nil, fmt.Errorf("zip missing gog binary")
+}
+
+func replaceExecutable(dest string, data []byte) error {
+	dir := filepath.Dir(dest)
+	tmp, err := os.CreateTemp(dir, "gog-update-*")
+	if err != nil {
+		return fmt.Errorf("temp binary: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o755); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	// On Windows, cannot replace running exe easily; still try rename dance.
+	backup := dest + ".bak"
+	_ = os.Remove(backup)
+	if runtime.GOOS == "windows" {
+		if err := os.Rename(dest, backup); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("backup current binary: %w", err)
+		}
+		if err := os.Rename(tmpName, dest); err != nil {
+			_ = os.Rename(backup, dest)
+			return err
+		}
+		_ = os.Remove(backup)
+		return nil
+	}
+
+	if err := os.Rename(tmpName, dest); err != nil {
+		// If dest is busy, try replace via remove+rename
+		if err2 := os.Remove(dest); err2 == nil {
+			if err3 := os.Rename(tmpName, dest); err3 == nil {
+				return nil
+			}
+		}
+		return fmt.Errorf("replace binary: %w", err)
+	}
+	return nil
+}

--- a/internal/selfupdate/apply.go
+++ b/internal/selfupdate/apply.go
@@ -158,7 +158,7 @@ func Apply(ctx context.Context, opts ApplyOptions) (CheckResult, error) {
 	}
 
 	var buf bytes.Buffer
-	if err := client.Download(ctx, asset.BrowserDownloadURL, &buf); err != nil {
+	if err = client.Download(ctx, asset.BrowserDownloadURL, &buf); err != nil {
 		return check, err
 	}
 
@@ -166,7 +166,7 @@ func Apply(ctx context.Context, opts ApplyOptions) (CheckResult, error) {
 
 	if checksums.BrowserDownloadURL != "" {
 		var cbuf bytes.Buffer
-		if err := client.Download(ctx, checksums.BrowserDownloadURL, &cbuf); err != nil {
+		if err = client.Download(ctx, checksums.BrowserDownloadURL, &cbuf); err != nil {
 			return check, fmt.Errorf("download checksums: %w", err)
 		}
 

--- a/internal/selfupdate/apply.go
+++ b/internal/selfupdate/apply.go
@@ -18,10 +18,10 @@ import (
 
 // ApplyOptions controls binary replacement.
 type ApplyOptions struct {
-	Client      *Client
-	CurrentVer  string
-	Force       bool // allow replacing dev/dirty builds
-	DestPath    string // default: os.Executable()
+	Client     *Client
+	CurrentVer string
+	Force      bool   // allow replacing dev/dirty builds
+	DestPath   string // default: os.Executable()
 }
 
 // CheckResult is a non-mutating version comparison.

--- a/internal/selfupdate/check_cache.go
+++ b/internal/selfupdate/check_cache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"testing"
 	"time"
 
 	"github.com/steipete/gogcli/internal/config"
@@ -76,8 +77,8 @@ func MaybeNotify(ctx context.Context, client *Client, current string, interval t
 	if os.Getenv("GOG_SKIP_UPDATE_CHECK") == "1" || os.Getenv("GOG_SKIP_UPDATE_CHECK") == "true" {
 		return ""
 	}
-	// Avoid network during `go test`.
-	if os.Getenv("GOG_TEST") == "1" {
+	// Avoid network during `go test` and when callers set GOG_TEST=1.
+	if testing.Testing() || os.Getenv("GOG_TEST") == "1" {
 		return ""
 	}
 	cache, _ := LoadCheckCache()

--- a/internal/selfupdate/check_cache.go
+++ b/internal/selfupdate/check_cache.go
@@ -22,8 +22,9 @@ type CheckCache struct {
 func checkCachePath() (string, error) {
 	dir, err := config.Dir()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("resolve config dir: %w", err)
 	}
+
 	return filepath.Join(dir, "update-check.json"), nil
 }
 
@@ -33,39 +34,53 @@ func LoadCheckCache() (CheckCache, error) {
 	if err != nil {
 		return CheckCache{}, err
 	}
+
+	//nolint:gosec // path is under user config dir
 	b, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return CheckCache{}, nil
 		}
-		return CheckCache{}, err
+
+		return CheckCache{}, fmt.Errorf("read update check cache: %w", err)
 	}
+
 	var c CheckCache
 	if err := json.Unmarshal(b, &c); err != nil {
-		return CheckCache{}, err
+		return CheckCache{}, fmt.Errorf("parse update check cache: %w", err)
 	}
+
 	return c, nil
 }
 
 // SaveCheckCache writes the cache.
 func SaveCheckCache(c CheckCache) error {
 	if _, err := config.EnsureDir(); err != nil {
-		return err
+		return fmt.Errorf("ensure config dir: %w", err)
 	}
+
 	path, err := checkCachePath()
 	if err != nil {
 		return err
 	}
+
 	b, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
-		return err
+		return fmt.Errorf("encode update check cache: %w", err)
 	}
+
 	b = append(b, '\n')
 	tmp := path + ".tmp"
+
 	if err := os.WriteFile(tmp, b, 0o600); err != nil {
-		return err
+		return fmt.Errorf("write update check cache: %w", err)
 	}
-	return os.Rename(tmp, path)
+
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("commit update check cache: %w", err)
+	}
+
+	return nil
 }
 
 // MaybeNotify checks for updates at most every interval and returns a notice line if update available.
@@ -74,23 +89,25 @@ func MaybeNotify(ctx context.Context, client *Client, current string, interval t
 	if interval <= 0 {
 		interval = 24 * time.Hour
 	}
+
 	if os.Getenv("GOG_SKIP_UPDATE_CHECK") == "1" || os.Getenv("GOG_SKIP_UPDATE_CHECK") == "true" {
 		return ""
 	}
+
 	// Avoid network during `go test` and when callers set GOG_TEST=1.
 	if testing.Testing() || os.Getenv("GOG_TEST") == "1" {
 		return ""
 	}
+
 	cache, _ := LoadCheckCache()
 	if !cache.CheckedAt.IsZero() && time.Since(cache.CheckedAt) < interval {
-		// Re-use cached latest for notice without network.
 		if cache.Latest != "" {
-			curBase := NormalizeVersion(current)
-			curBase = splitBase(curBase)
-			if cache.Latest != curBase && curBase != "dev" && curBase != "" {
+			curBase := splitBase(NormalizeVersion(current))
+			if cache.Latest != curBase && curBase != "dev" && curBase != "" && versionLess(curBase, cache.Latest) {
 				return fmt.Sprintf("gog: update available %s → %s; run: gog update", curBase, cache.Latest)
 			}
 		}
+
 		return ""
 	}
 
@@ -98,14 +115,17 @@ func MaybeNotify(ctx context.Context, client *Client, current string, interval t
 	if err != nil {
 		return ""
 	}
+
 	_ = SaveCheckCache(CheckCache{
 		CheckedAt: time.Now().UTC(),
 		Latest:    res.Latest,
 		Current:   current,
 	})
+
 	if res.Update {
 		return fmt.Sprintf("gog: update available %s → %s; run: gog update", splitBase(NormalizeVersion(current)), res.Latest)
 	}
+
 	return ""
 }
 
@@ -113,6 +133,7 @@ func splitBase(v string) string {
 	if i := indexDash(v); i >= 0 {
 		return v[:i]
 	}
+
 	return v
 }
 
@@ -122,5 +143,6 @@ func indexDash(v string) int {
 			return i
 		}
 	}
+
 	return -1
 }

--- a/internal/selfupdate/check_cache.go
+++ b/internal/selfupdate/check_cache.go
@@ -1,0 +1,125 @@
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/steipete/gogcli/internal/config"
+)
+
+// CheckCache stores last successful remote version check.
+type CheckCache struct {
+	CheckedAt time.Time `json:"checked_at"`
+	Latest    string    `json:"latest"`
+	Current   string    `json:"current"`
+}
+
+func checkCachePath() (string, error) {
+	dir, err := config.Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "update-check.json"), nil
+}
+
+// LoadCheckCache returns the cache (zero if missing).
+func LoadCheckCache() (CheckCache, error) {
+	path, err := checkCachePath()
+	if err != nil {
+		return CheckCache{}, err
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return CheckCache{}, nil
+		}
+		return CheckCache{}, err
+	}
+	var c CheckCache
+	if err := json.Unmarshal(b, &c); err != nil {
+		return CheckCache{}, err
+	}
+	return c, nil
+}
+
+// SaveCheckCache writes the cache.
+func SaveCheckCache(c CheckCache) error {
+	if _, err := config.EnsureDir(); err != nil {
+		return err
+	}
+	path, err := checkCachePath()
+	if err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// MaybeNotify checks for updates at most every interval and returns a notice line if update available.
+// Errors and "up to date" return empty string.
+func MaybeNotify(ctx context.Context, client *Client, current string, interval time.Duration) string {
+	if interval <= 0 {
+		interval = 24 * time.Hour
+	}
+	if os.Getenv("GOG_SKIP_UPDATE_CHECK") == "1" || os.Getenv("GOG_SKIP_UPDATE_CHECK") == "true" {
+		return ""
+	}
+	// Avoid network during `go test`.
+	if os.Getenv("GOG_TEST") == "1" {
+		return ""
+	}
+	cache, _ := LoadCheckCache()
+	if !cache.CheckedAt.IsZero() && time.Since(cache.CheckedAt) < interval {
+		// Re-use cached latest for notice without network.
+		if cache.Latest != "" {
+			curBase := NormalizeVersion(current)
+			curBase = splitBase(curBase)
+			if cache.Latest != curBase && curBase != "dev" && curBase != "" {
+				return fmt.Sprintf("gog: update available %s → %s; run: gog update", curBase, cache.Latest)
+			}
+		}
+		return ""
+	}
+
+	res, err := Check(ctx, client, current)
+	if err != nil {
+		return ""
+	}
+	_ = SaveCheckCache(CheckCache{
+		CheckedAt: time.Now().UTC(),
+		Latest:    res.Latest,
+		Current:   current,
+	})
+	if res.Update {
+		return fmt.Sprintf("gog: update available %s → %s; run: gog update", splitBase(NormalizeVersion(current)), res.Latest)
+	}
+	return ""
+}
+
+func splitBase(v string) string {
+	if i := indexDash(v); i >= 0 {
+		return v[:i]
+	}
+	return v
+}
+
+func indexDash(v string) int {
+	for i := 0; i < len(v); i++ {
+		if v[i] == '-' {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/selfupdate/github.go
+++ b/internal/selfupdate/github.go
@@ -1,0 +1,146 @@
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const defaultRepo = "Robben-Media/gogcli"
+
+// Release is a subset of the GitHub release API payload.
+type Release struct {
+	TagName string  `json:"tag_name"`
+	Name    string  `json:"name"`
+	Assets  []Asset `json:"assets"`
+}
+
+// Asset is a release asset.
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+}
+
+// Client fetches release metadata.
+type Client struct {
+	HTTP    *http.Client
+	Repo    string
+	BaseURL string // default https://api.github.com
+	Token   string // optional GITHUB_TOKEN
+}
+
+func (c *Client) repo() string {
+	if strings.TrimSpace(c.Repo) != "" {
+		return strings.TrimSpace(c.Repo)
+	}
+	return defaultRepo
+}
+
+func (c *Client) base() string {
+	if strings.TrimSpace(c.BaseURL) != "" {
+		return strings.TrimSuffix(strings.TrimSpace(c.BaseURL), "/")
+	}
+	return "https://api.github.com"
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTP != nil {
+		return c.HTTP
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+// LatestRelease fetches /repos/{repo}/releases/latest.
+func (c *Client) LatestRelease(ctx context.Context) (Release, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", c.base(), c.repo())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return Release{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "gogcli-selfupdate")
+	if t := strings.TrimSpace(c.Token); t != "" {
+		req.Header.Set("Authorization", "Bearer "+t)
+	}
+	res, err := c.httpClient().Do(req)
+	if err != nil {
+		return Release{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(res.Body, 4<<10))
+		return Release{}, fmt.Errorf("github releases: %s: %s", res.Status, strings.TrimSpace(string(b)))
+	}
+	var rel Release
+	if err := json.NewDecoder(res.Body).Decode(&rel); err != nil {
+		return Release{}, fmt.Errorf("decode release: %w", err)
+	}
+	if strings.TrimSpace(rel.TagName) == "" {
+		return Release{}, fmt.Errorf("release missing tag_name")
+	}
+	return rel, nil
+}
+
+// NormalizeVersion strips a leading v from tags.
+func NormalizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	return strings.TrimPrefix(v, "v")
+}
+
+// AssetNameFor builds the GoReleaser asset name for this platform.
+func AssetNameFor(version string) string {
+	ver := NormalizeVersion(version)
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
+	ext := "tar.gz"
+	if goos == "windows" {
+		ext = "zip"
+	}
+	return fmt.Sprintf("gogcli_%s_%s_%s.%s", ver, goos, goarch, ext)
+}
+
+// FindAsset returns the platform asset and checksums asset if present.
+func FindAsset(rel Release) (asset Asset, checksums Asset, err error) {
+	want := AssetNameFor(rel.TagName)
+	for _, a := range rel.Assets {
+		switch {
+		case a.Name == want:
+			asset = a
+		case a.Name == "checksums.txt":
+			checksums = a
+		}
+	}
+	if asset.Name == "" {
+		return Asset{}, Asset{}, fmt.Errorf("no release asset for %s (looked for %s)", runtime.GOOS+"/"+runtime.GOARCH, want)
+	}
+	return asset, checksums, nil
+}
+
+// Download writes the URL body to w.
+func (c *Client) Download(ctx context.Context, url string, w io.Writer) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "gogcli-selfupdate")
+	if t := strings.TrimSpace(c.Token); t != "" {
+		req.Header.Set("Authorization", "Bearer "+t)
+	}
+	res, err := c.httpClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(res.Body, 4<<10))
+		return fmt.Errorf("download %s: %s: %s", url, res.Status, strings.TrimSpace(string(b)))
+	}
+	_, err = io.Copy(w, res.Body)
+	return err
+}

--- a/internal/selfupdate/github.go
+++ b/internal/selfupdate/github.go
@@ -3,6 +3,7 @@ package selfupdate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,13 @@ import (
 )
 
 const defaultRepo = "Robben-Media/gogcli"
+
+var (
+	errReleaseMissingTag = errors.New("release missing tag_name")
+	errNoReleaseAsset    = errors.New("no release asset for platform")
+	errGithubReleases    = errors.New("github releases request failed")
+	errDownloadFailed    = errors.New("download failed")
+)
 
 // Release is a subset of the GitHub release API payload.
 type Release struct {
@@ -39,6 +47,7 @@ func (c *Client) repo() string {
 	if strings.TrimSpace(c.Repo) != "" {
 		return strings.TrimSpace(c.Repo)
 	}
+
 	return defaultRepo
 }
 
@@ -46,6 +55,7 @@ func (c *Client) base() string {
 	if strings.TrimSpace(c.BaseURL) != "" {
 		return strings.TrimSuffix(strings.TrimSpace(c.BaseURL), "/")
 	}
+
 	return "https://api.github.com"
 }
 
@@ -53,43 +63,54 @@ func (c *Client) httpClient() *http.Client {
 	if c.HTTP != nil {
 		return c.HTTP
 	}
+
 	return &http.Client{Timeout: 30 * time.Second}
 }
 
 // LatestRelease fetches /repos/{repo}/releases/latest.
 func (c *Client) LatestRelease(ctx context.Context) (Release, error) {
 	url := fmt.Sprintf("%s/repos/%s/releases/latest", c.base(), c.repo())
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return Release{}, err
+		return Release{}, fmt.Errorf("build release request: %w", err)
 	}
+
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "gogcli-selfupdate")
+
 	if t := strings.TrimSpace(c.Token); t != "" {
 		req.Header.Set("Authorization", "Bearer "+t)
 	}
+
 	res, err := c.httpClient().Do(req)
 	if err != nil {
-		return Release{}, err
+		return Release{}, fmt.Errorf("fetch release: %w", err)
 	}
 	defer res.Body.Close()
+
 	if res.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(io.LimitReader(res.Body, 4<<10))
-		return Release{}, fmt.Errorf("github releases: %s: %s", res.Status, strings.TrimSpace(string(b)))
+
+		return Release{}, fmt.Errorf("%w: %s: %s", errGithubReleases, res.Status, strings.TrimSpace(string(b)))
 	}
+
 	var rel Release
 	if err := json.NewDecoder(res.Body).Decode(&rel); err != nil {
 		return Release{}, fmt.Errorf("decode release: %w", err)
 	}
+
 	if strings.TrimSpace(rel.TagName) == "" {
-		return Release{}, fmt.Errorf("release missing tag_name")
+		return Release{}, errReleaseMissingTag
 	}
+
 	return rel, nil
 }
 
 // NormalizeVersion strips a leading v from tags.
 func NormalizeVersion(v string) string {
 	v = strings.TrimSpace(v)
+
 	return strings.TrimPrefix(v, "v")
 }
 
@@ -99,26 +120,31 @@ func AssetNameFor(version string) string {
 	goos := runtime.GOOS
 	goarch := runtime.GOARCH
 	ext := "tar.gz"
+
 	if goos == "windows" {
 		ext = "zip"
 	}
+
 	return fmt.Sprintf("gogcli_%s_%s_%s.%s", ver, goos, goarch, ext)
 }
 
 // FindAsset returns the platform asset and checksums asset if present.
 func FindAsset(rel Release) (asset Asset, checksums Asset, err error) {
 	want := AssetNameFor(rel.TagName)
+
 	for _, a := range rel.Assets {
-		switch {
-		case a.Name == want:
+		switch a.Name {
+		case want:
 			asset = a
-		case a.Name == "checksums.txt":
+		case "checksums.txt":
 			checksums = a
 		}
 	}
+
 	if asset.Name == "" {
-		return Asset{}, Asset{}, fmt.Errorf("no release asset for %s (looked for %s)", runtime.GOOS+"/"+runtime.GOARCH, want)
+		return Asset{}, Asset{}, fmt.Errorf("%w: %s/%s (looked for %s)", errNoReleaseAsset, runtime.GOOS, runtime.GOARCH, want)
 	}
+
 	return asset, checksums, nil
 }
 
@@ -126,21 +152,30 @@ func FindAsset(rel Release) (asset Asset, checksums Asset, err error) {
 func (c *Client) Download(ctx context.Context, url string, w io.Writer) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("build download request: %w", err)
 	}
+
 	req.Header.Set("User-Agent", "gogcli-selfupdate")
+
 	if t := strings.TrimSpace(c.Token); t != "" {
 		req.Header.Set("Authorization", "Bearer "+t)
 	}
+
 	res, err := c.httpClient().Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("download: %w", err)
 	}
 	defer res.Body.Close()
+
 	if res.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(io.LimitReader(res.Body, 4<<10))
-		return fmt.Errorf("download %s: %s: %s", url, res.Status, strings.TrimSpace(string(b)))
+
+		return fmt.Errorf("%w: %s: %s: %s", errDownloadFailed, url, res.Status, strings.TrimSpace(string(b)))
 	}
-	_, err = io.Copy(w, res.Body)
-	return err
+
+	if _, err := io.Copy(w, res.Body); err != nil {
+		return fmt.Errorf("copy download body: %w", err)
+	}
+
+	return nil
 }

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -114,3 +114,18 @@ func TestChecksumLineMatch(t *testing.T) {
 		t.Fatal("unexpected match")
 	}
 }
+
+func TestVersionLess(t *testing.T) {
+	if !versionLess("0.9.0", "0.10.0") {
+		t.Fatal("0.9 < 0.10")
+	}
+	if versionLess("0.10.0", "0.9.0") {
+		t.Fatal("0.10 should not be < 0.9")
+	}
+	if versionLess("1.0.0", "1.0.0") {
+		t.Fatal("equal")
+	}
+	if !versionLess("dev", "1.0.0") {
+		t.Fatal("dev older")
+	}
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,116 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeAndAssetName(t *testing.T) {
+	if got := NormalizeVersion("v1.2.3"); got != "1.2.3" {
+		t.Fatalf("normalize: %s", got)
+	}
+	name := AssetNameFor("v1.2.3")
+	if !strings.Contains(name, "gogcli_1.2.3_") {
+		t.Fatalf("asset name: %s", name)
+	}
+	if runtime.GOOS == "windows" {
+		if !strings.HasSuffix(name, ".zip") {
+			t.Fatalf("windows asset should be zip: %s", name)
+		}
+	} else if !strings.HasSuffix(name, ".tar.gz") {
+		t.Fatalf("unix asset should be tar.gz: %s", name)
+	}
+}
+
+func TestCheckAndApply(t *testing.T) {
+	binaryPayload := []byte("#!/bin/sh\necho fake-gog\n")
+	var archive bytes.Buffer
+	gz := gzip.NewWriter(&archive)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{Name: "gog", Mode: 0o755, Size: int64(len(binaryPayload))}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(binaryPayload); err != nil {
+		t.Fatal(err)
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	raw := archive.Bytes()
+	sum := sha256.Sum256(raw)
+	sumHex := hex.EncodeToString(sum[:])
+	assetName := AssetNameFor("v9.9.9")
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			_ = json.NewEncoder(w).Encode(Release{
+				TagName: "v9.9.9",
+				Assets: []Asset{
+					{Name: assetName, BrowserDownloadURL: srv.URL + "/asset"},
+					{Name: "checksums.txt", BrowserDownloadURL: srv.URL + "/checksums"},
+				},
+			})
+		case r.URL.Path == "/asset":
+			_, _ = w.Write(raw)
+		case r.URL.Path == "/checksums":
+			_, _ = fmt.Fprintf(w, "%s  %s\n", sumHex, assetName)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL, HTTP: srv.Client()}
+	ctx := context.Background()
+	check, err := Check(ctx, c, "1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !check.Update || check.Latest != "9.9.9" {
+		t.Fatalf("check: %+v", check)
+	}
+
+	dest := filepath.Join(t.TempDir(), "gog")
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err = Apply(ctx, ApplyOptions{
+		Client:     c,
+		CurrentVer: "1.0.0",
+		DestPath:   dest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, binaryPayload) {
+		t.Fatalf("binary not replaced")
+	}
+}
+
+func TestChecksumLineMatch(t *testing.T) {
+	if !checksumLineMatch("abc  file.tar.gz\n", "file.tar.gz", "abc") {
+		t.Fatal("expected match")
+	}
+	if checksumLineMatch("abc  other\n", "file.tar.gz", "abc") {
+		t.Fatal("unexpected match")
+	}
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -85,6 +85,7 @@ func TestCheckAndApply(t *testing.T) {
 	assetName := AssetNameFor("v9.9.9")
 
 	var srv *httptest.Server
+
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/releases/latest"):

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -19,13 +19,17 @@ import (
 )
 
 func TestNormalizeAndAssetName(t *testing.T) {
+	t.Parallel()
+
 	if got := NormalizeVersion("v1.2.3"); got != "1.2.3" {
 		t.Fatalf("normalize: %s", got)
 	}
+
 	name := AssetNameFor("v1.2.3")
 	if !strings.Contains(name, "gogcli_1.2.3_") {
 		t.Fatalf("asset name: %s", name)
 	}
+
 	if runtime.GOOS == "windows" {
 		if !strings.HasSuffix(name, ".zip") {
 			t.Fatalf("windows asset should be zip: %s", name)
@@ -35,20 +39,46 @@ func TestNormalizeAndAssetName(t *testing.T) {
 	}
 }
 
+func TestVersionLess(t *testing.T) {
+	t.Parallel()
+
+	if !versionLess("0.9.0", "0.10.0") {
+		t.Fatal("0.9 < 0.10")
+	}
+
+	if versionLess("0.10.0", "0.9.0") {
+		t.Fatal("0.10 should not be < 0.9")
+	}
+
+	if versionLess("1.0.0", "1.0.0") {
+		t.Fatal("equal")
+	}
+
+	if !versionLess("dev", "1.0.0") {
+		t.Fatal("dev older")
+	}
+}
+
 func TestCheckAndApply(t *testing.T) {
 	binaryPayload := []byte("#!/bin/sh\necho fake-gog\n")
+
 	var archive bytes.Buffer
+
 	gz := gzip.NewWriter(&archive)
 	tw := tar.NewWriter(gz)
 	hdr := &tar.Header{Name: "gog", Mode: 0o755, Size: int64(len(binaryPayload))}
+
 	if err := tw.WriteHeader(hdr); err != nil {
 		t.Fatal(err)
 	}
+
 	if _, err := tw.Write(binaryPayload); err != nil {
 		t.Fatal(err)
 	}
+
 	_ = tw.Close()
 	_ = gz.Close()
+
 	raw := archive.Bytes()
 	sum := sha256.Sum256(raw)
 	sumHex := hex.EncodeToString(sum[:])
@@ -77,10 +107,12 @@ func TestCheckAndApply(t *testing.T) {
 
 	c := &Client{BaseURL: srv.URL, HTTP: srv.Client()}
 	ctx := context.Background()
-	check, err := Check(ctx, c, "1.0.0")
-	if err != nil {
-		t.Fatal(err)
+
+	check, checkErr := Check(ctx, c, "1.0.0")
+	if checkErr != nil {
+		t.Fatal(checkErr)
 	}
+
 	if !check.Update || check.Latest != "9.9.9" {
 		t.Fatalf("check: %+v", check)
 	}
@@ -89,43 +121,34 @@ func TestCheckAndApply(t *testing.T) {
 	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	_, err = Apply(ctx, ApplyOptions{
+
+	_, applyErr := Apply(ctx, ApplyOptions{
 		Client:     c,
 		CurrentVer: "1.0.0",
 		DestPath:   dest,
 	})
-	if err != nil {
-		t.Fatal(err)
+	if applyErr != nil {
+		t.Fatal(applyErr)
 	}
-	got, err := os.ReadFile(dest)
-	if err != nil {
-		t.Fatal(err)
+
+	got, readErr := os.ReadFile(dest)
+	if readErr != nil {
+		t.Fatal(readErr)
 	}
+
 	if !bytes.Equal(got, binaryPayload) {
 		t.Fatalf("binary not replaced")
 	}
 }
 
 func TestChecksumLineMatch(t *testing.T) {
+	t.Parallel()
+
 	if !checksumLineMatch("abc  file.tar.gz\n", "file.tar.gz", "abc") {
 		t.Fatal("expected match")
 	}
+
 	if checksumLineMatch("abc  other\n", "file.tar.gz", "abc") {
 		t.Fatal("unexpected match")
-	}
-}
-
-func TestVersionLess(t *testing.T) {
-	if !versionLess("0.9.0", "0.10.0") {
-		t.Fatal("0.9 < 0.10")
-	}
-	if versionLess("0.10.0", "0.9.0") {
-		t.Fatal("0.10 should not be < 0.9")
-	}
-	if versionLess("1.0.0", "1.0.0") {
-		t.Fatal("equal")
-	}
-	if !versionLess("dev", "1.0.0") {
-		t.Fatal("dev older")
 	}
 }

--- a/internal/skillpack/apply.go
+++ b/internal/skillpack/apply.go
@@ -1,0 +1,246 @@
+package skillpack
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/steipete/gogcli/skills"
+)
+
+// ApplyResult is the outcome of one skill path update attempt.
+type ApplyResult struct {
+	Skill    string
+	Path     string
+	RealPath string
+	Action   string // updated|skipped_current|skipped_dirty|installed|skipped_not_installed
+	Detail   string
+}
+
+// UpdateOptions controls skill pack application.
+type UpdateOptions struct {
+	Discover    DiscoverOptions
+	Force       bool   // overwrite dirty
+	Install     bool   // create missing under InstallRoot
+	InstallRoot string // default ~/.agents/skills
+	PackVersion string
+	// OnlySkills restricts to these names (empty = all pack skills).
+	OnlySkills []string
+}
+
+// UpdateInstalled refreshes pack skills that already exist on disk (and optionally installs missing).
+func UpdateInstalled(opts UpdateOptions) ([]ApplyResult, error) {
+	if err := VerifyPackPresent(); err != nil {
+		return nil, err
+	}
+	manifest, err := skills.LoadManifest()
+	if err != nil {
+		return nil, err
+	}
+	managed := manifest.ManagedFiles
+	skillFilter := map[string]struct{}{}
+	if len(opts.OnlySkills) > 0 {
+		for _, s := range opts.OnlySkills {
+			skillFilter[s] = struct{}{}
+		}
+	} else {
+		for _, s := range manifest.Skills {
+			skillFilter[s] = struct{}{}
+		}
+	}
+
+	state, err := LoadState()
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, s := range manifest.Skills {
+		if _, ok := skillFilter[s]; ok {
+			names = append(names, s)
+		}
+	}
+
+	installs, err := Discover(names, opts.Discover)
+	if err != nil {
+		return nil, err
+	}
+	bySkill := map[string][]InstallRef{}
+	for _, inst := range installs {
+		bySkill[inst.Skill] = append(bySkill[inst.Skill], inst)
+	}
+
+	var results []ApplyResult
+	stateDirty := false
+
+	for _, name := range names {
+		packHash, err := HashManagedFromFS(skills.FS(), "pack/"+name, managed)
+		if err != nil {
+			return nil, err
+		}
+		refs := bySkill[name]
+		if len(refs) == 0 {
+			if opts.Install {
+				root := opts.InstallRoot
+				if root == "" {
+					home := opts.Discover.HomeDir
+					if home == "" {
+						home, err = os.UserHomeDir()
+						if err != nil {
+							return nil, err
+						}
+					}
+					root = filepath.Join(home, ".agents", "skills")
+				}
+				dest := filepath.Join(root, name)
+				if err := writeSkill(dest, name, managed); err != nil {
+					return results, err
+				}
+				if err := linkIntoOtherRoots(name, dest, opts.Discover); err != nil {
+					return results, err
+				}
+				RecordWrite(&state, filepath.Clean(dest), name, packHash, opts.PackVersion)
+				stateDirty = true
+				results = append(results, ApplyResult{
+					Skill:    name,
+					Path:     dest,
+					RealPath: dest,
+					Action:   "installed",
+				})
+			} else {
+				results = append(results, ApplyResult{
+					Skill:  name,
+					Action: "skipped_not_installed",
+					Detail: "run: gog skills install",
+				})
+			}
+			continue
+		}
+
+		for _, ref := range refs {
+			diskHash, err := HashManagedFiles(ref.RealPath, managed)
+			if err != nil {
+				return results, err
+			}
+			stateHash := ""
+			if ps, ok := state.Paths[ref.RealPath]; ok {
+				stateHash = ps.ContentHash
+			}
+			kind := classify(diskHash, packHash, stateHash)
+			switch kind {
+			case StatusCurrent:
+				results = append(results, ApplyResult{
+					Skill:    name,
+					Path:     ref.Path,
+					RealPath: ref.RealPath,
+					Action:   "skipped_current",
+				})
+			case StatusDirty:
+				if !opts.Force {
+					results = append(results, ApplyResult{
+						Skill:    name,
+						Path:     ref.Path,
+						RealPath: ref.RealPath,
+						Action:   "skipped_dirty",
+						Detail:   "local edits; re-run with --overwrite-local or --force-skills",
+					})
+					continue
+				}
+				fallthrough
+			case StatusOutdated:
+				if err := writeSkill(ref.RealPath, name, managed); err != nil {
+					return results, err
+				}
+				RecordWrite(&state, ref.RealPath, name, packHash, opts.PackVersion)
+				stateDirty = true
+				results = append(results, ApplyResult{
+					Skill:    name,
+					Path:     ref.Path,
+					RealPath: ref.RealPath,
+					Action:   "updated",
+				})
+			}
+		}
+	}
+
+	if stateDirty {
+		if err := SaveState(state); err != nil {
+			return results, err
+		}
+	}
+	return results, nil
+}
+
+func writeSkill(destDir, skill string, managed []string) error {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", destDir, err)
+	}
+	// If destDir itself is a symlink, write through to the real path's files
+	// without replacing the symlink.
+	for _, rel := range managed {
+		b, err := skills.ReadManagedFile(skill, rel)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destDir, rel)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		tmp := target + ".tmp"
+		if err := os.WriteFile(tmp, b, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", target, err)
+		}
+		if err := os.Rename(tmp, target); err != nil {
+			_ = os.Remove(tmp)
+			return fmt.Errorf("commit %s: %w", target, err)
+		}
+	}
+	return nil
+}
+
+// linkIntoOtherRoots creates symlinks from other existing agent skill roots to the primary install.
+func linkIntoOtherRoots(skill, primary string, opts DiscoverOptions) error {
+	home := opts.HomeDir
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+	}
+	primaryReal, err := filepath.EvalSymlinks(primary)
+	if err != nil {
+		primaryReal = primary
+	}
+	primaryReal = filepath.Clean(primaryReal)
+
+	for _, rel := range DefaultHomeSkillRoots {
+		root := filepath.Join(home, rel)
+		// Only link into roots that already exist (user uses that agent).
+		if st, err := os.Stat(root); err != nil || !st.IsDir() {
+			continue
+		}
+		linkPath := filepath.Join(root, skill)
+		if linkPath == primary || filepath.Clean(linkPath) == primaryReal {
+			continue
+		}
+		if _, err := os.Lstat(linkPath); err == nil {
+			continue // already present
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		// Prefer relative symlink when possible.
+		relLink, err := filepath.Rel(root, primaryReal)
+		if err != nil {
+			relLink = primaryReal
+		}
+		if err := os.Symlink(relLink, linkPath); err != nil {
+			// Non-fatal if symlink unsupported; primary install still valid.
+			if !strings.Contains(err.Error(), "not supported") {
+				return fmt.Errorf("symlink %s -> %s: %w", linkPath, relLink, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/skillpack/apply.go
+++ b/internal/skillpack/apply.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/steipete/gogcli/skills"
 )
@@ -80,41 +79,58 @@ func UpdateInstalled(opts UpdateOptions) ([]ApplyResult, error) {
 			return nil, err
 		}
 		refs := bySkill[name]
-		if len(refs) == 0 {
-			if opts.Install {
-				root := opts.InstallRoot
-				if root == "" {
-					home := opts.Discover.HomeDir
-					if home == "" {
-						home, err = os.UserHomeDir()
-						if err != nil {
-							return nil, err
-						}
+		if opts.Install {
+			root := opts.InstallRoot
+			if root == "" {
+				home := opts.Discover.HomeDir
+				if home == "" {
+					home, err = os.UserHomeDir()
+					if err != nil {
+						return nil, err
 					}
-					root = filepath.Join(home, ".agents", "skills")
 				}
-				dest := filepath.Join(root, name)
+				root = filepath.Join(home, ".agents", "skills")
+			}
+			dest := filepath.Join(root, name)
+			needCanonical := true
+			for _, ref := range refs {
+				if filepath.Clean(ref.RealPath) == filepath.Clean(dest) {
+					needCanonical = false
+					break
+				}
+				// Also treat symlink into dest as present.
+				if real, err := filepath.EvalSymlinks(dest); err == nil && filepath.Clean(real) == filepath.Clean(ref.RealPath) {
+					needCanonical = false
+					break
+				}
+			}
+			if needCanonical {
 				if err := writeSkill(dest, name, managed); err != nil {
 					return results, err
 				}
-				if err := linkIntoOtherRoots(name, dest, opts.Discover); err != nil {
-					return results, err
+				_ = linkIntoOtherRoots(name, dest, opts.Discover) // best-effort; never fail install on symlink
+				destReal := dest
+				if real, err := filepath.EvalSymlinks(dest); err == nil {
+					destReal = filepath.Clean(real)
 				}
-				RecordWrite(&state, filepath.Clean(dest), name, packHash, opts.PackVersion)
+				RecordWrite(&state, destReal, name, packHash, opts.PackVersion)
 				stateDirty = true
 				results = append(results, ApplyResult{
 					Skill:    name,
 					Path:     dest,
-					RealPath: dest,
+					RealPath: destReal,
 					Action:   "installed",
 				})
-			} else {
-				results = append(results, ApplyResult{
-					Skill:  name,
-					Action: "skipped_not_installed",
-					Detail: "run: gog skills install",
-				})
+				// Re-discover is not required; continue to refresh other known refs below.
+				refs = append(refs, InstallRef{Skill: name, Path: dest, RealPath: destReal})
 			}
+		}
+		if len(refs) == 0 {
+			results = append(results, ApplyResult{
+				Skill:  name,
+				Action: "skipped_not_installed",
+				Detail: "run: gog skills install",
+			})
 			continue
 		}
 
@@ -130,6 +146,11 @@ func UpdateInstalled(opts UpdateOptions) ([]ApplyResult, error) {
 			kind := classify(diskHash, packHash, stateHash)
 			switch kind {
 			case StatusCurrent:
+				// Baseline ownership so the next pack change is "outdated", not "dirty".
+				if stateHash == "" {
+					RecordWrite(&state, ref.RealPath, name, packHash, opts.PackVersion)
+					stateDirty = true
+				}
 				results = append(results, ApplyResult{
 					Skill:    name,
 					Path:     ref.Path,
@@ -235,12 +256,8 @@ func linkIntoOtherRoots(skill, primary string, opts DiscoverOptions) error {
 		if err != nil {
 			relLink = primaryReal
 		}
-		if err := os.Symlink(relLink, linkPath); err != nil {
-			// Non-fatal if symlink unsupported; primary install still valid.
-			if !strings.Contains(err.Error(), "not supported") {
-				return fmt.Errorf("symlink %s -> %s: %w", linkPath, relLink, err)
-			}
-		}
+		// Symlinks are best-effort (Windows privilege errors, etc.).
+		_ = os.Symlink(relLink, linkPath)
 	}
 	return nil
 }

--- a/internal/skillpack/apply.go
+++ b/internal/skillpack/apply.go
@@ -76,6 +76,7 @@ func UpdateInstalled(opts UpdateOptions) ([]ApplyResult, error) {
 		}
 
 		results = append(results, installResults...)
+
 		if installStateDirty {
 			stateDirty = true
 		}
@@ -90,12 +91,16 @@ func UpdateInstalled(opts UpdateOptions) ([]ApplyResult, error) {
 			continue
 		}
 
-		pathResults, pathStateDirty, err := applyRefs(name, refs, packHash, managed, opts, &state)
+		var pathStateDirty bool
+		var pathResults []ApplyResult
+
+		pathResults, pathStateDirty, err = applyRefs(name, refs, packHash, managed, opts, &state)
 		if err != nil {
 			return results, err
 		}
 
 		results = append(results, pathResults...)
+
 		if pathStateDirty {
 			stateDirty = true
 		}
@@ -112,6 +117,7 @@ func UpdateInstalled(opts UpdateOptions) ([]ApplyResult, error) {
 
 func buildSkillFilter(all, only []string) map[string]struct{} {
 	skillFilter := map[string]struct{}{}
+
 	if len(only) > 0 {
 		for _, s := range only {
 			skillFilter[s] = struct{}{}
@@ -129,6 +135,7 @@ func buildSkillFilter(all, only []string) map[string]struct{} {
 
 func filteredNames(all []string, filter map[string]struct{}) []string {
 	var names []string
+
 	for _, s := range all {
 		if _, ok := filter[s]; ok {
 			names = append(names, s)
@@ -140,6 +147,7 @@ func filteredNames(all []string, filter map[string]struct{}) []string {
 
 func groupInstalls(installs []InstallRef) map[string][]InstallRef {
 	bySkill := map[string][]InstallRef{}
+
 	for _, inst := range installs {
 		bySkill[inst.Skill] = append(bySkill[inst.Skill], inst)
 	}
@@ -291,7 +299,6 @@ func applyRefs(
 }
 
 func writeSkill(destDir, skill string, managed []string) error {
-	//nolint:gosec // skill dirs are user agent skill roots
 	if err := os.MkdirAll(destDir, 0o750); err != nil {
 		return fmt.Errorf("mkdir %s: %w", destDir, err)
 	}
@@ -304,7 +311,6 @@ func writeSkill(destDir, skill string, managed []string) error {
 
 		target := filepath.Join(destDir, rel)
 
-		//nolint:gosec // parent of managed skill file
 		if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
 			return fmt.Errorf("mkdir parent: %w", err)
 		}
@@ -354,9 +360,9 @@ func linkIntoOtherRoots(skill, primary string, opts DiscoverOptions) error {
 			continue
 		}
 
-		if _, err := os.Lstat(linkPath); err == nil {
+		if _, lstatErr := os.Lstat(linkPath); lstatErr == nil {
 			continue
-		} else if !os.IsNotExist(err) {
+		} else if !os.IsNotExist(lstatErr) {
 			// Best-effort: ignore unexpected lstat errors for optional roots.
 			continue
 		}

--- a/internal/skillpack/apply.go
+++ b/internal/skillpack/apply.go
@@ -20,9 +20,9 @@ type ApplyResult struct {
 // UpdateOptions controls skill pack application.
 type UpdateOptions struct {
 	Discover    DiscoverOptions
-	Force       bool   // overwrite dirty
-	Install     bool   // create missing under InstallRoot
-	InstallRoot string // default ~/.agents/skills
+	Force       bool // overwrite dirty
+	Install     bool // create missing under InstallRoot
+	InstallRoot string
 	PackVersion string
 	// OnlySkills restricts to these names (empty = all pack skills).
 	OnlySkills []string
@@ -33,42 +33,28 @@ func UpdateInstalled(opts UpdateOptions) ([]ApplyResult, error) {
 	if err := VerifyPackPresent(); err != nil {
 		return nil, err
 	}
+
 	manifest, err := skills.LoadManifest()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load manifest: %w", err)
 	}
+
 	managed := manifest.ManagedFiles
-	skillFilter := map[string]struct{}{}
-	if len(opts.OnlySkills) > 0 {
-		for _, s := range opts.OnlySkills {
-			skillFilter[s] = struct{}{}
-		}
-	} else {
-		for _, s := range manifest.Skills {
-			skillFilter[s] = struct{}{}
-		}
-	}
+	skillFilter := buildSkillFilter(manifest.Skills, opts.OnlySkills)
 
 	state, err := LoadState()
 	if err != nil {
 		return nil, err
 	}
 
-	var names []string
-	for _, s := range manifest.Skills {
-		if _, ok := skillFilter[s]; ok {
-			names = append(names, s)
-		}
-	}
+	names := filteredNames(manifest.Skills, skillFilter)
 
 	installs, err := Discover(names, opts.Discover)
 	if err != nil {
 		return nil, err
 	}
-	bySkill := map[string][]InstallRef{}
-	for _, inst := range installs {
-		bySkill[inst.Skill] = append(bySkill[inst.Skill], inst)
-	}
+
+	bySkill := groupInstalls(installs)
 
 	var results []ApplyResult
 	stateDirty := false
@@ -78,110 +64,40 @@ func UpdateInstalled(opts UpdateOptions) ([]ApplyResult, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		refs := bySkill[name]
-		if opts.Install {
-			root := opts.InstallRoot
-			if root == "" {
-				home := opts.Discover.HomeDir
-				if home == "" {
-					home, err = os.UserHomeDir()
-					if err != nil {
-						return nil, err
-					}
-				}
-				root = filepath.Join(home, ".agents", "skills")
-			}
-			dest := filepath.Join(root, name)
-			needCanonical := true
-			for _, ref := range refs {
-				if filepath.Clean(ref.RealPath) == filepath.Clean(dest) {
-					needCanonical = false
-					break
-				}
-				// Also treat symlink into dest as present.
-				if real, err := filepath.EvalSymlinks(dest); err == nil && filepath.Clean(real) == filepath.Clean(ref.RealPath) {
-					needCanonical = false
-					break
-				}
-			}
-			if needCanonical {
-				if err := writeSkill(dest, name, managed); err != nil {
-					return results, err
-				}
-				_ = linkIntoOtherRoots(name, dest, opts.Discover) // best-effort; never fail install on symlink
-				destReal := dest
-				if real, err := filepath.EvalSymlinks(dest); err == nil {
-					destReal = filepath.Clean(real)
-				}
-				RecordWrite(&state, destReal, name, packHash, opts.PackVersion)
-				stateDirty = true
-				results = append(results, ApplyResult{
-					Skill:    name,
-					Path:     dest,
-					RealPath: destReal,
-					Action:   "installed",
-				})
-				// Re-discover is not required; continue to refresh other known refs below.
-				refs = append(refs, InstallRef{Skill: name, Path: dest, RealPath: destReal})
-			}
+
+		var installResults []ApplyResult
+		var installStateDirty bool
+
+		refs, installResults, installStateDirty, err = maybeInstallCanonical(name, refs, packHash, managed, opts, &state)
+		if err != nil {
+			return results, err
 		}
+
+		results = append(results, installResults...)
+		if installStateDirty {
+			stateDirty = true
+		}
+
 		if len(refs) == 0 {
 			results = append(results, ApplyResult{
 				Skill:  name,
 				Action: "skipped_not_installed",
 				Detail: "run: gog skills install",
 			})
+
 			continue
 		}
 
-		for _, ref := range refs {
-			diskHash, err := HashManagedFiles(ref.RealPath, managed)
-			if err != nil {
-				return results, err
-			}
-			stateHash := ""
-			if ps, ok := state.Paths[ref.RealPath]; ok {
-				stateHash = ps.ContentHash
-			}
-			kind := classify(diskHash, packHash, stateHash)
-			switch kind {
-			case StatusCurrent:
-				// Baseline ownership so the next pack change is "outdated", not "dirty".
-				if stateHash == "" {
-					RecordWrite(&state, ref.RealPath, name, packHash, opts.PackVersion)
-					stateDirty = true
-				}
-				results = append(results, ApplyResult{
-					Skill:    name,
-					Path:     ref.Path,
-					RealPath: ref.RealPath,
-					Action:   "skipped_current",
-				})
-			case StatusDirty:
-				if !opts.Force {
-					results = append(results, ApplyResult{
-						Skill:    name,
-						Path:     ref.Path,
-						RealPath: ref.RealPath,
-						Action:   "skipped_dirty",
-						Detail:   "local edits; re-run with --overwrite-local or --force-skills",
-					})
-					continue
-				}
-				fallthrough
-			case StatusOutdated:
-				if err := writeSkill(ref.RealPath, name, managed); err != nil {
-					return results, err
-				}
-				RecordWrite(&state, ref.RealPath, name, packHash, opts.PackVersion)
-				stateDirty = true
-				results = append(results, ApplyResult{
-					Skill:    name,
-					Path:     ref.Path,
-					RealPath: ref.RealPath,
-					Action:   "updated",
-				})
-			}
+		pathResults, pathStateDirty, err := applyRefs(name, refs, packHash, managed, opts, &state)
+		if err != nil {
+			return results, err
+		}
+
+		results = append(results, pathResults...)
+		if pathStateDirty {
+			stateDirty = true
 		}
 	}
 
@@ -190,33 +106,221 @@ func UpdateInstalled(opts UpdateOptions) ([]ApplyResult, error) {
 			return results, err
 		}
 	}
+
 	return results, nil
 }
 
+func buildSkillFilter(all, only []string) map[string]struct{} {
+	skillFilter := map[string]struct{}{}
+	if len(only) > 0 {
+		for _, s := range only {
+			skillFilter[s] = struct{}{}
+		}
+
+		return skillFilter
+	}
+
+	for _, s := range all {
+		skillFilter[s] = struct{}{}
+	}
+
+	return skillFilter
+}
+
+func filteredNames(all []string, filter map[string]struct{}) []string {
+	var names []string
+	for _, s := range all {
+		if _, ok := filter[s]; ok {
+			names = append(names, s)
+		}
+	}
+
+	return names
+}
+
+func groupInstalls(installs []InstallRef) map[string][]InstallRef {
+	bySkill := map[string][]InstallRef{}
+	for _, inst := range installs {
+		bySkill[inst.Skill] = append(bySkill[inst.Skill], inst)
+	}
+
+	return bySkill
+}
+
+func maybeInstallCanonical(
+	name string,
+	refs []InstallRef,
+	packHash string,
+	managed []string,
+	opts UpdateOptions,
+	state *State,
+) ([]InstallRef, []ApplyResult, bool, error) {
+	if !opts.Install {
+		return refs, nil, false, nil
+	}
+
+	root := opts.InstallRoot
+	if root == "" {
+		home := opts.Discover.HomeDir
+		if home == "" {
+			h, err := os.UserHomeDir()
+			if err != nil {
+				return refs, nil, false, fmt.Errorf("resolve home dir: %w", err)
+			}
+
+			home = h
+		}
+
+		root = filepath.Join(home, ".agents", "skills")
+	}
+
+	dest := filepath.Join(root, name)
+	if hasCanonical(refs, dest) {
+		return refs, nil, false, nil
+	}
+
+	if err := writeSkill(dest, name, managed); err != nil {
+		return refs, nil, false, err
+	}
+
+	_ = linkIntoOtherRoots(name, dest, opts.Discover)
+
+	destReal := dest
+	if resolved, err := filepath.EvalSymlinks(dest); err == nil {
+		destReal = filepath.Clean(resolved)
+	}
+
+	RecordWrite(state, destReal, name, packHash, opts.PackVersion)
+
+	result := ApplyResult{
+		Skill:    name,
+		Path:     dest,
+		RealPath: destReal,
+		Action:   "installed",
+	}
+
+	refs = append(refs, InstallRef{Skill: name, Path: dest, RealPath: destReal})
+
+	return refs, []ApplyResult{result}, true, nil
+}
+
+func hasCanonical(refs []InstallRef, dest string) bool {
+	destClean := filepath.Clean(dest)
+	for _, ref := range refs {
+		if filepath.Clean(ref.RealPath) == destClean {
+			return true
+		}
+
+		if resolved, err := filepath.EvalSymlinks(dest); err == nil && filepath.Clean(resolved) == filepath.Clean(ref.RealPath) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func applyRefs(
+	name string,
+	refs []InstallRef,
+	packHash string,
+	managed []string,
+	opts UpdateOptions,
+	state *State,
+) ([]ApplyResult, bool, error) {
+	var results []ApplyResult
+	stateDirty := false
+
+	for _, ref := range refs {
+		diskHash, err := HashManagedFiles(ref.RealPath, managed)
+		if err != nil {
+			return results, stateDirty, err
+		}
+
+		stateHash := ""
+		if ps, ok := state.Paths[ref.RealPath]; ok {
+			stateHash = ps.ContentHash
+		}
+
+		kind := classify(diskHash, packHash, stateHash)
+
+		switch kind {
+		case StatusCurrent:
+			if stateHash == "" {
+				RecordWrite(state, ref.RealPath, name, packHash, opts.PackVersion)
+				stateDirty = true
+			}
+
+			results = append(results, ApplyResult{
+				Skill:    name,
+				Path:     ref.Path,
+				RealPath: ref.RealPath,
+				Action:   "skipped_current",
+			})
+		case StatusDirty:
+			if !opts.Force {
+				results = append(results, ApplyResult{
+					Skill:    name,
+					Path:     ref.Path,
+					RealPath: ref.RealPath,
+					Action:   "skipped_dirty",
+					Detail:   "local edits; re-run with --overwrite-local or --force-skills",
+				})
+
+				continue
+			}
+
+			fallthrough
+		case StatusOutdated:
+			if err := writeSkill(ref.RealPath, name, managed); err != nil {
+				return results, stateDirty, err
+			}
+
+			RecordWrite(state, ref.RealPath, name, packHash, opts.PackVersion)
+			stateDirty = true
+
+			results = append(results, ApplyResult{
+				Skill:    name,
+				Path:     ref.Path,
+				RealPath: ref.RealPath,
+				Action:   "updated",
+			})
+		}
+	}
+
+	return results, stateDirty, nil
+}
+
 func writeSkill(destDir, skill string, managed []string) error {
-	if err := os.MkdirAll(destDir, 0o755); err != nil {
+	//nolint:gosec // skill dirs are user agent skill roots
+	if err := os.MkdirAll(destDir, 0o750); err != nil {
 		return fmt.Errorf("mkdir %s: %w", destDir, err)
 	}
-	// If destDir itself is a symlink, write through to the real path's files
-	// without replacing the symlink.
+
 	for _, rel := range managed {
 		b, err := skills.ReadManagedFile(skill, rel)
 		if err != nil {
-			return err
+			return fmt.Errorf("read pack file: %w", err)
 		}
+
 		target := filepath.Join(destDir, rel)
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return err
+
+		//nolint:gosec // parent of managed skill file
+		if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+			return fmt.Errorf("mkdir parent: %w", err)
 		}
+
 		tmp := target + ".tmp"
-		if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		if err := os.WriteFile(tmp, b, 0o600); err != nil {
 			return fmt.Errorf("write %s: %w", target, err)
 		}
+
 		if err := os.Rename(tmp, target); err != nil {
 			_ = os.Remove(tmp)
+
 			return fmt.Errorf("commit %s: %w", target, err)
 		}
 	}
+
 	return nil
 }
 
@@ -224,40 +328,47 @@ func writeSkill(destDir, skill string, managed []string) error {
 func linkIntoOtherRoots(skill, primary string, opts DiscoverOptions) error {
 	home := opts.HomeDir
 	if home == "" {
-		var err error
-		home, err = os.UserHomeDir()
+		h, err := os.UserHomeDir()
 		if err != nil {
-			return err
+			return fmt.Errorf("resolve home dir: %w", err)
 		}
+
+		home = h
 	}
-	primaryReal, err := filepath.EvalSymlinks(primary)
-	if err != nil {
-		primaryReal = primary
+
+	primaryReal := primary
+	if resolved, err := filepath.EvalSymlinks(primary); err == nil {
+		primaryReal = filepath.Clean(resolved)
 	}
-	primaryReal = filepath.Clean(primaryReal)
 
 	for _, rel := range DefaultHomeSkillRoots {
 		root := filepath.Join(home, rel)
-		// Only link into roots that already exist (user uses that agent).
-		if st, err := os.Stat(root); err != nil || !st.IsDir() {
+
+		st, err := os.Stat(root)
+		if err != nil || !st.IsDir() {
 			continue
 		}
+
 		linkPath := filepath.Join(root, skill)
 		if linkPath == primary || filepath.Clean(linkPath) == primaryReal {
 			continue
 		}
+
 		if _, err := os.Lstat(linkPath); err == nil {
-			continue // already present
+			continue
 		} else if !os.IsNotExist(err) {
-			return err
+			// Best-effort: ignore unexpected lstat errors for optional roots.
+			continue
 		}
-		// Prefer relative symlink when possible.
+
 		relLink, err := filepath.Rel(root, primaryReal)
 		if err != nil {
 			relLink = primaryReal
 		}
+
 		// Symlinks are best-effort (Windows privilege errors, etc.).
 		_ = os.Symlink(relLink, linkPath)
 	}
+
 	return nil
 }

--- a/internal/skillpack/discover.go
+++ b/internal/skillpack/discover.go
@@ -40,9 +40,9 @@ type InstallRef struct {
 
 // DiscoverOptions controls where we look for pack skills.
 type DiscoverOptions struct {
-	HomeDir     string
-	ProjectDir  string
-	HomeRoots   []string
+	HomeDir      string
+	ProjectDir   string
+	HomeRoots    []string
 	ProjectRoots []string
 }
 

--- a/internal/skillpack/discover.go
+++ b/internal/skillpack/discover.go
@@ -1,6 +1,7 @@
 package skillpack
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -53,14 +54,17 @@ func Discover(skillNames []string, opts DiscoverOptions) ([]InstallRef, error) {
 	if home == "" {
 		h, err := os.UserHomeDir()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("resolve home dir: %w", err)
 		}
+
 		home = h
 	}
+
 	homeRoots := opts.HomeRoots
 	if len(homeRoots) == 0 {
 		homeRoots = DefaultHomeSkillRoots
 	}
+
 	projectRoots := opts.ProjectRoots
 	if len(projectRoots) == 0 {
 		projectRoots = DefaultProjectSkillRoots
@@ -70,24 +74,26 @@ func Discover(skillNames []string, opts DiscoverOptions) ([]InstallRef, error) {
 	var out []InstallRef
 
 	add := func(skill, path, root, kind string) {
-		real, err := filepath.EvalSymlinks(path)
+		resolved, err := filepath.EvalSymlinks(path)
 		if err != nil {
-			real = path
+			resolved = path
 		}
-		real = filepath.Clean(real)
-		if _, ok := seen[real]; ok {
+
+		resolved = filepath.Clean(resolved)
+		if _, ok := seen[resolved]; ok {
 			return
 		}
-		// Must look like a skill dir (directory exists).
+
 		st, err := os.Stat(path)
 		if err != nil || !st.IsDir() {
 			return
 		}
-		seen[real] = struct{}{}
+
+		seen[resolved] = struct{}{}
 		out = append(out, InstallRef{
 			Skill:    skill,
 			Path:     path,
-			RealPath: real,
+			RealPath: resolved,
 			RootKind: kind,
 			Root:     root,
 		})
@@ -98,6 +104,7 @@ func Discover(skillNames []string, opts DiscoverOptions) ([]InstallRef, error) {
 			root := filepath.Join(home, rel)
 			add(skill, filepath.Join(root, skill), root, "home")
 		}
+
 		if opts.ProjectDir != "" {
 			for _, rel := range projectRoots {
 				root := filepath.Join(opts.ProjectDir, rel)
@@ -110,7 +117,9 @@ func Discover(skillNames []string, opts DiscoverOptions) ([]InstallRef, error) {
 		if out[i].Skill != out[j].Skill {
 			return out[i].Skill < out[j].Skill
 		}
+
 		return out[i].RealPath < out[j].RealPath
 	})
+
 	return out, nil
 }

--- a/internal/skillpack/discover.go
+++ b/internal/skillpack/discover.go
@@ -1,0 +1,116 @@
+package skillpack
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// DefaultHomeSkillRoots are relative to the user home directory.
+var DefaultHomeSkillRoots = []string{
+	".agents/skills",
+	".claude/skills",
+	".codex/skills",
+	".cursor/skills",
+	".grok/skills",
+	".factory/skills",
+	".config/agents/skills",
+	".config/opencode/skills",
+	".gemini/antigravity/skills",
+}
+
+// DefaultProjectSkillRoots are relative to a project working directory.
+var DefaultProjectSkillRoots = []string{
+	".agents/skills",
+	".claude/skills",
+	".codex/skills",
+	".cursor/skills",
+	".grok/skills",
+	".factory/skills",
+}
+
+// InstallRef is one discovered install location for a pack skill.
+type InstallRef struct {
+	Skill    string
+	Path     string // path as found (may be symlink)
+	RealPath string // resolved path
+	RootKind string // home|project
+	Root     string // skills parent root
+}
+
+// DiscoverOptions controls where we look for pack skills.
+type DiscoverOptions struct {
+	HomeDir     string
+	ProjectDir  string
+	HomeRoots   []string
+	ProjectRoots []string
+}
+
+// Discover finds existing install directories for the given skill names.
+// Results are deduped by RealPath (first wins).
+func Discover(skillNames []string, opts DiscoverOptions) ([]InstallRef, error) {
+	home := opts.HomeDir
+	if home == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		home = h
+	}
+	homeRoots := opts.HomeRoots
+	if len(homeRoots) == 0 {
+		homeRoots = DefaultHomeSkillRoots
+	}
+	projectRoots := opts.ProjectRoots
+	if len(projectRoots) == 0 {
+		projectRoots = DefaultProjectSkillRoots
+	}
+
+	seen := map[string]struct{}{}
+	var out []InstallRef
+
+	add := func(skill, path, root, kind string) {
+		real, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			real = path
+		}
+		real = filepath.Clean(real)
+		if _, ok := seen[real]; ok {
+			return
+		}
+		// Must look like a skill dir (directory exists).
+		st, err := os.Stat(path)
+		if err != nil || !st.IsDir() {
+			return
+		}
+		seen[real] = struct{}{}
+		out = append(out, InstallRef{
+			Skill:    skill,
+			Path:     path,
+			RealPath: real,
+			RootKind: kind,
+			Root:     root,
+		})
+	}
+
+	for _, skill := range skillNames {
+		for _, rel := range homeRoots {
+			root := filepath.Join(home, rel)
+			add(skill, filepath.Join(root, skill), root, "home")
+		}
+		if opts.ProjectDir != "" {
+			for _, rel := range projectRoots {
+				root := filepath.Join(opts.ProjectDir, rel)
+				add(skill, filepath.Join(root, skill), root, "project")
+			}
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Skill != out[j].Skill {
+			return out[i].Skill < out[j].Skill
+		}
+		return out[i].RealPath < out[j].RealPath
+	})
+	return out, nil
+}

--- a/internal/skillpack/hash.go
+++ b/internal/skillpack/hash.go
@@ -1,0 +1,75 @@
+package skillpack
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// HashManagedFiles hashes the concatenation of managed relative paths and contents.
+// Missing files contribute an empty content segment so absence is visible in the hash.
+func HashManagedFiles(root string, managedFiles []string) (string, error) {
+	files := normalizeManaged(managedFiles)
+	h := sha256.New()
+	for _, rel := range files {
+		fmt.Fprintf(h, "%s\n", rel)
+		b, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			if os.IsNotExist(err) {
+				h.Write([]byte{0})
+				continue
+			}
+			return "", fmt.Errorf("read %s: %w", rel, err)
+		}
+		h.Write(b)
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// HashManagedFromFS hashes managed files from an fs.FS under baseDir (e.g. "pack/google-calendar").
+func HashManagedFromFS(fsys fs.FS, baseDir string, managedFiles []string) (string, error) {
+	files := normalizeManaged(managedFiles)
+	h := sha256.New()
+	for _, rel := range files {
+		fmt.Fprintf(h, "%s\n", rel)
+		path := pathJoin(baseDir, rel)
+		b, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			if os.IsNotExist(err) || errorsIsNotExist(err) {
+				h.Write([]byte{0})
+				continue
+			}
+			return "", fmt.Errorf("read pack %s: %w", path, err)
+		}
+		h.Write(b)
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func normalizeManaged(managedFiles []string) []string {
+	if len(managedFiles) == 0 {
+		return []string{"SKILL.md"}
+	}
+	out := append([]string(nil), managedFiles...)
+	sort.Strings(out)
+	return out
+}
+
+func pathJoin(base, rel string) string {
+	base = strings.TrimSuffix(base, "/")
+	if base == "" || base == "." {
+		return rel
+	}
+	return base + "/" + rel
+}
+
+func errorsIsNotExist(err error) bool {
+	return err != nil && (os.IsNotExist(err) || strings.Contains(err.Error(), "file does not exist"))
+}

--- a/internal/skillpack/hash.go
+++ b/internal/skillpack/hash.go
@@ -16,19 +16,26 @@ import (
 func HashManagedFiles(root string, managedFiles []string) (string, error) {
 	files := normalizeManaged(managedFiles)
 	h := sha256.New()
+
 	for _, rel := range files {
 		fmt.Fprintf(h, "%s\n", rel)
+
+		//nolint:gosec // managed skill path under discovered skill root
 		b, err := os.ReadFile(filepath.Join(root, rel))
 		if err != nil {
 			if os.IsNotExist(err) {
 				h.Write([]byte{0})
+
 				continue
 			}
+
 			return "", fmt.Errorf("read %s: %w", rel, err)
 		}
+
 		h.Write(b)
 		h.Write([]byte{0})
 	}
+
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
@@ -36,20 +43,27 @@ func HashManagedFiles(root string, managedFiles []string) (string, error) {
 func HashManagedFromFS(fsys fs.FS, baseDir string, managedFiles []string) (string, error) {
 	files := normalizeManaged(managedFiles)
 	h := sha256.New()
+
 	for _, rel := range files {
 		fmt.Fprintf(h, "%s\n", rel)
+
 		path := pathJoin(baseDir, rel)
+
 		b, err := fs.ReadFile(fsys, path)
 		if err != nil {
 			if os.IsNotExist(err) || errorsIsNotExist(err) {
 				h.Write([]byte{0})
+
 				continue
 			}
+
 			return "", fmt.Errorf("read pack %s: %w", path, err)
 		}
+
 		h.Write(b)
 		h.Write([]byte{0})
 	}
+
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
@@ -57,8 +71,10 @@ func normalizeManaged(managedFiles []string) []string {
 	if len(managedFiles) == 0 {
 		return []string{"SKILL.md"}
 	}
+
 	out := append([]string(nil), managedFiles...)
 	sort.Strings(out)
+
 	return out
 }
 
@@ -67,6 +83,7 @@ func pathJoin(base, rel string) string {
 	if base == "" || base == "." {
 		return rel
 	}
+
 	return base + "/" + rel
 }
 

--- a/internal/skillpack/skillpack_test.go
+++ b/internal/skillpack/skillpack_test.go
@@ -80,8 +80,8 @@ func TestDirtySkipAndForce(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), packBytes, 0o644); err != nil {
-		t.Fatal(err)
+	if writeErr := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), packBytes, 0o644); writeErr != nil {
+		t.Fatal(writeErr)
 	}
 
 	res, err := UpdateInstalled(UpdateOptions{
@@ -96,25 +96,25 @@ func TestDirtySkipAndForce(t *testing.T) {
 		t.Fatalf("expected skipped_current, got %s (%+v)", got, res)
 	}
 
-	packHash, err := PackHashFor("google-docs")
-	if err != nil {
-		t.Fatal(err)
+	packHash, hashErr := PackHashFor("google-docs")
+	if hashErr != nil {
+		t.Fatal(hashErr)
 	}
 
-	st, err := LoadState()
-	if err != nil {
-		t.Fatal(err)
+	st, loadErr := LoadState()
+	if loadErr != nil {
+		t.Fatal(loadErr)
 	}
 
 	resolved, _ := filepath.EvalSymlinks(skillDir)
 	RecordWrite(&st, filepath.Clean(resolved), "google-docs", packHash, "test")
 
-	if err := SaveState(st); err != nil {
-		t.Fatal(err)
+	if saveErr := SaveState(st); saveErr != nil {
+		t.Fatal(saveErr)
 	}
 
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: google-docs\ndescription: local edit\n---\n# edited\n"), 0o644); err != nil {
-		t.Fatal(err)
+	if writeErr := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: google-docs\ndescription: local edit\n---\n# edited\n"), 0o644); writeErr != nil {
+		t.Fatal(writeErr)
 	}
 
 	res, err = UpdateInstalled(UpdateOptions{
@@ -207,8 +207,8 @@ func TestOutdatedUpdatesWithoutForce(t *testing.T) {
 
 	RecordWrite(&st, realDir, "google-sheets", oldHash, "old")
 
-	if err := SaveState(st); err != nil {
-		t.Fatal(err)
+	if saveErr := SaveState(st); saveErr != nil {
+		t.Fatal(saveErr)
 	}
 
 	res, err := UpdateInstalled(UpdateOptions{

--- a/internal/skillpack/skillpack_test.go
+++ b/internal/skillpack/skillpack_test.go
@@ -65,7 +65,7 @@ func TestDirtySkipAndForce(t *testing.T) {
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// Write pack content first via Update with empty state treating as dirty... 
+	// Write pack content first via Update with empty state treating as dirty...
 	// Seed with pack content and record state, then edit.
 	packBytes, err := skills.ReadManagedFile("google-docs", "SKILL.md")
 	if err != nil {

--- a/internal/skillpack/skillpack_test.go
+++ b/internal/skillpack/skillpack_test.go
@@ -12,18 +12,22 @@ func TestPackManifestAndEmbed(t *testing.T) {
 	if err := VerifyPackPresent(); err != nil {
 		t.Fatal(err)
 	}
+
 	m, err := skills.LoadManifest()
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if len(m.Skills) != 10 {
 		t.Fatalf("expected 10 skills, got %d", len(m.Skills))
 	}
+
 	for _, name := range m.Skills {
-		b, err := skills.ReadManagedFile(name, "SKILL.md")
-		if err != nil {
-			t.Fatalf("%s: %v", name, err)
+		b, readErr := skills.ReadManagedFile(name, "SKILL.md")
+		if readErr != nil {
+			t.Fatalf("%s: %v", name, readErr)
 		}
+
 		if len(b) < 20 {
 			t.Fatalf("%s: SKILL.md too short", name)
 		}
@@ -34,15 +38,19 @@ func TestDiscoverDedupeSymlink(t *testing.T) {
 	home := t.TempDir()
 	agents := filepath.Join(home, ".agents", "skills", "google-calendar")
 	claudeRoot := filepath.Join(home, ".claude", "skills")
+
 	if err := os.MkdirAll(agents, 0o755); err != nil {
 		t.Fatal(err)
 	}
+
 	if err := os.WriteFile(filepath.Join(agents, "SKILL.md"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+
 	if err := os.MkdirAll(claudeRoot, 0o755); err != nil {
 		t.Fatal(err)
 	}
+
 	// relative symlink like real machine
 	if err := os.Symlink(filepath.Join("..", "..", ".agents", "skills", "google-calendar"), filepath.Join(claudeRoot, "google-calendar")); err != nil {
 		t.Fatal(err)
@@ -52,6 +60,7 @@ func TestDiscoverDedupeSymlink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if len(refs) != 1 {
 		t.Fatalf("expected 1 deduped ref, got %d: %+v", len(refs), refs)
 	}
@@ -60,22 +69,21 @@ func TestDiscoverDedupeSymlink(t *testing.T) {
 func TestDirtySkipAndForce(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
-	// HOME for InstallRoot paths unused; we use Discover HomeDir
+
 	skillDir := filepath.Join(home, ".agents", "skills", "google-docs")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// Write pack content first via Update with empty state treating as dirty...
-	// Seed with pack content and record state, then edit.
+
 	packBytes, err := skills.ReadManagedFile("google-docs", "SKILL.md")
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), packBytes, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// First update should see current or dirty without state:
-	// no state + disk==pack => current
+
 	res, err := UpdateInstalled(UpdateOptions{
 		Discover:    DiscoverOptions{HomeDir: home},
 		PackVersion: "test",
@@ -83,25 +91,28 @@ func TestDirtySkipAndForce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if got := actionFor(res, "google-docs"); got != "skipped_current" {
 		t.Fatalf("expected skipped_current, got %s (%+v)", got, res)
 	}
 
-	// Force install path to record state by writing via update outdated:
-	// Manually record state as pack hash then change disk to dirty.
 	packHash, err := PackHashFor("google-docs")
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	st, err := LoadState()
 	if err != nil {
 		t.Fatal(err)
 	}
-	real, _ := filepath.EvalSymlinks(skillDir)
-	RecordWrite(&st, filepath.Clean(real), "google-docs", packHash, "test")
+
+	resolved, _ := filepath.EvalSymlinks(skillDir)
+	RecordWrite(&st, filepath.Clean(resolved), "google-docs", packHash, "test")
+
 	if err := SaveState(st); err != nil {
 		t.Fatal(err)
 	}
+
 	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: google-docs\ndescription: local edit\n---\n# edited\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -113,6 +124,7 @@ func TestDirtySkipAndForce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if got := actionFor(res, "google-docs"); got != "skipped_dirty" {
 		t.Fatalf("expected skipped_dirty, got %s", got)
 	}
@@ -125,24 +137,29 @@ func TestDirtySkipAndForce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if got := actionFor(res, "google-docs"); got != "updated" {
 		t.Fatalf("expected updated, got %s", got)
 	}
+
 	got, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if string(got) != string(packBytes) {
 		t.Fatalf("skill not restored to pack content")
 	}
-	// learnings must not be required / not deleted
+
 	if err := os.MkdirAll(filepath.Join(skillDir, "learnings"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+
 	if err := os.WriteFile(filepath.Join(skillDir, "learnings", "LEARNINGS.md"), []byte("keep me"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	res, err = UpdateInstalled(UpdateOptions{
+
+	_, err = UpdateInstalled(UpdateOptions{
 		Discover:    DiscoverOptions{HomeDir: home},
 		Force:       true,
 		PackVersion: "test",
@@ -150,7 +167,7 @@ func TestDirtySkipAndForce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = res
+
 	b, err := os.ReadFile(filepath.Join(skillDir, "learnings", "LEARNINGS.md"))
 	if err != nil || string(b) != "keep me" {
 		t.Fatalf("learnings clobbered: %v %q", err, b)
@@ -160,29 +177,36 @@ func TestDirtySkipAndForce(t *testing.T) {
 func TestOutdatedUpdatesWithoutForce(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
 	skillDir := filepath.Join(home, ".agents", "skills", "google-sheets")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+
 	old := []byte("---\nname: google-sheets\ndescription: old\n---\n# old\n")
 	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), old, 0o644); err != nil {
 		t.Fatal(err)
 	}
+
 	realDir, err := filepath.EvalSymlinks(skillDir)
 	if err != nil {
 		realDir = skillDir
 	}
+
 	realDir = filepath.Clean(realDir)
-	// Record state as matching old content (simulates previous pack install).
+
 	oldHash, err := HashManagedFiles(realDir, []string{"SKILL.md"})
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	st, err := LoadState()
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	RecordWrite(&st, realDir, "google-sheets", oldHash, "old")
+
 	if err := SaveState(st); err != nil {
 		t.Fatal(err)
 	}
@@ -194,6 +218,7 @@ func TestOutdatedUpdatesWithoutForce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if got := actionFor(res, "google-sheets"); got != "updated" {
 		t.Fatalf("expected updated for outdated, got %s (%+v)", got, res)
 	}
@@ -202,10 +227,11 @@ func TestOutdatedUpdatesWithoutForce(t *testing.T) {
 func TestInstallMissing(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
-	// create another agent root so symlink is attempted
+
 	if err := os.MkdirAll(filepath.Join(home, ".claude", "skills"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+
 	res, err := UpdateInstalled(UpdateOptions{
 		Discover:    DiscoverOptions{HomeDir: home},
 		Install:     true,
@@ -216,9 +242,11 @@ func TestInstallMissing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if got := actionFor(res, "google-calendar"); got != "installed" {
 		t.Fatalf("expected installed, got %s", got)
 	}
+
 	if _, err := os.Stat(filepath.Join(home, ".agents", "skills", "google-calendar", "SKILL.md")); err != nil {
 		t.Fatal(err)
 	}
@@ -230,5 +258,6 @@ func actionFor(results []ApplyResult, skill string) string {
 			return r.Action
 		}
 	}
+
 	return ""
 }

--- a/internal/skillpack/skillpack_test.go
+++ b/internal/skillpack/skillpack_test.go
@@ -1,0 +1,234 @@
+package skillpack
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steipete/gogcli/skills"
+)
+
+func TestPackManifestAndEmbed(t *testing.T) {
+	if err := VerifyPackPresent(); err != nil {
+		t.Fatal(err)
+	}
+	m, err := skills.LoadManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Skills) != 10 {
+		t.Fatalf("expected 10 skills, got %d", len(m.Skills))
+	}
+	for _, name := range m.Skills {
+		b, err := skills.ReadManagedFile(name, "SKILL.md")
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(b) < 20 {
+			t.Fatalf("%s: SKILL.md too short", name)
+		}
+	}
+}
+
+func TestDiscoverDedupeSymlink(t *testing.T) {
+	home := t.TempDir()
+	agents := filepath.Join(home, ".agents", "skills", "google-calendar")
+	claudeRoot := filepath.Join(home, ".claude", "skills")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agents, "SKILL.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(claudeRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// relative symlink like real machine
+	if err := os.Symlink(filepath.Join("..", "..", ".agents", "skills", "google-calendar"), filepath.Join(claudeRoot, "google-calendar")); err != nil {
+		t.Fatal(err)
+	}
+
+	refs, err := Discover([]string{"google-calendar"}, DiscoverOptions{HomeDir: home})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 deduped ref, got %d: %+v", len(refs), refs)
+	}
+}
+
+func TestDirtySkipAndForce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	// HOME for InstallRoot paths unused; we use Discover HomeDir
+	skillDir := filepath.Join(home, ".agents", "skills", "google-docs")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write pack content first via Update with empty state treating as dirty... 
+	// Seed with pack content and record state, then edit.
+	packBytes, err := skills.ReadManagedFile("google-docs", "SKILL.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), packBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// First update should see current or dirty without state:
+	// no state + disk==pack => current
+	res, err := UpdateInstalled(UpdateOptions{
+		Discover:    DiscoverOptions{HomeDir: home},
+		PackVersion: "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := actionFor(res, "google-docs"); got != "skipped_current" {
+		t.Fatalf("expected skipped_current, got %s (%+v)", got, res)
+	}
+
+	// Force install path to record state by writing via update outdated:
+	// Manually record state as pack hash then change disk to dirty.
+	packHash, err := PackHashFor("google-docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	real, _ := filepath.EvalSymlinks(skillDir)
+	RecordWrite(&st, filepath.Clean(real), "google-docs", packHash, "test")
+	if err := SaveState(st); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: google-docs\ndescription: local edit\n---\n# edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err = UpdateInstalled(UpdateOptions{
+		Discover:    DiscoverOptions{HomeDir: home},
+		PackVersion: "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := actionFor(res, "google-docs"); got != "skipped_dirty" {
+		t.Fatalf("expected skipped_dirty, got %s", got)
+	}
+
+	res, err = UpdateInstalled(UpdateOptions{
+		Discover:    DiscoverOptions{HomeDir: home},
+		Force:       true,
+		PackVersion: "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := actionFor(res, "google-docs"); got != "updated" {
+		t.Fatalf("expected updated, got %s", got)
+	}
+	got, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(packBytes) {
+		t.Fatalf("skill not restored to pack content")
+	}
+	// learnings must not be required / not deleted
+	if err := os.MkdirAll(filepath.Join(skillDir, "learnings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "learnings", "LEARNINGS.md"), []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err = UpdateInstalled(UpdateOptions{
+		Discover:    DiscoverOptions{HomeDir: home},
+		Force:       true,
+		PackVersion: "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = res
+	b, err := os.ReadFile(filepath.Join(skillDir, "learnings", "LEARNINGS.md"))
+	if err != nil || string(b) != "keep me" {
+		t.Fatalf("learnings clobbered: %v %q", err, b)
+	}
+}
+
+func TestOutdatedUpdatesWithoutForce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	skillDir := filepath.Join(home, ".agents", "skills", "google-sheets")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := []byte("---\nname: google-sheets\ndescription: old\n---\n# old\n")
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), old, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	realDir, err := filepath.EvalSymlinks(skillDir)
+	if err != nil {
+		realDir = skillDir
+	}
+	realDir = filepath.Clean(realDir)
+	// Record state as matching old content (simulates previous pack install).
+	oldHash, err := HashManagedFiles(realDir, []string{"SKILL.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	RecordWrite(&st, realDir, "google-sheets", oldHash, "old")
+	if err := SaveState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := UpdateInstalled(UpdateOptions{
+		Discover:    DiscoverOptions{HomeDir: home},
+		PackVersion: "new",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := actionFor(res, "google-sheets"); got != "updated" {
+		t.Fatalf("expected updated for outdated, got %s (%+v)", got, res)
+	}
+}
+
+func TestInstallMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	// create another agent root so symlink is attempted
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	res, err := UpdateInstalled(UpdateOptions{
+		Discover:    DiscoverOptions{HomeDir: home},
+		Install:     true,
+		InstallRoot: filepath.Join(home, ".agents", "skills"),
+		OnlySkills:  []string{"google-calendar"},
+		PackVersion: "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := actionFor(res, "google-calendar"); got != "installed" {
+		t.Fatalf("expected installed, got %s", got)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".agents", "skills", "google-calendar", "SKILL.md")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func actionFor(results []ApplyResult, skill string) string {
+	for _, r := range results {
+		if r.Skill == skill {
+			return r.Action
+		}
+	}
+	return ""
+}

--- a/internal/skillpack/skillpack_test.go
+++ b/internal/skillpack/skillpack_test.go
@@ -151,26 +151,25 @@ func TestDirtySkipAndForce(t *testing.T) {
 		t.Fatalf("skill not restored to pack content")
 	}
 
-	if err := os.MkdirAll(filepath.Join(skillDir, "learnings"), 0o755); err != nil {
-		t.Fatal(err)
+	if mkdirErr := os.MkdirAll(filepath.Join(skillDir, "learnings"), 0o755); mkdirErr != nil {
+		t.Fatal(mkdirErr)
 	}
 
-	if err := os.WriteFile(filepath.Join(skillDir, "learnings", "LEARNINGS.md"), []byte("keep me"), 0o644); err != nil {
-		t.Fatal(err)
+	if writeErr := os.WriteFile(filepath.Join(skillDir, "learnings", "LEARNINGS.md"), []byte("keep me"), 0o644); writeErr != nil {
+		t.Fatal(writeErr)
 	}
 
-	_, err = UpdateInstalled(UpdateOptions{
+	if _, updateErr := UpdateInstalled(UpdateOptions{
 		Discover:    DiscoverOptions{HomeDir: home},
 		Force:       true,
 		PackVersion: "test",
-	})
-	if err != nil {
-		t.Fatal(err)
+	}); updateErr != nil {
+		t.Fatal(updateErr)
 	}
 
-	b, err := os.ReadFile(filepath.Join(skillDir, "learnings", "LEARNINGS.md"))
-	if err != nil || string(b) != "keep me" {
-		t.Fatalf("learnings clobbered: %v %q", err, b)
+	b, readErr := os.ReadFile(filepath.Join(skillDir, "learnings", "LEARNINGS.md"))
+	if readErr != nil || string(b) != "keep me" {
+		t.Fatalf("learnings clobbered: %v %q", readErr, b)
 	}
 }
 

--- a/internal/skillpack/state.go
+++ b/internal/skillpack/state.go
@@ -1,0 +1,99 @@
+package skillpack
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/steipete/gogcli/internal/config"
+)
+
+// State tracks last-written pack hashes so we can detect local edits.
+type State struct {
+	Version int                    `json:"version"`
+	Paths   map[string]PathState   `json:"paths"`
+	Updated time.Time              `json:"updated_at"`
+}
+
+// PathState is the last install record for one real skill directory.
+type PathState struct {
+	Skill       string    `json:"skill"`
+	ContentHash string    `json:"content_hash"`
+	PackVersion string    `json:"pack_version,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func statePath() (string, error) {
+	dir, err := config.Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "skill-pack-state.json"), nil
+}
+
+// LoadState reads skill pack state (empty if missing).
+func LoadState() (State, error) {
+	path, err := statePath()
+	if err != nil {
+		return State{}, err
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return State{Version: 1, Paths: map[string]PathState{}}, nil
+		}
+		return State{}, fmt.Errorf("read skill pack state: %w", err)
+	}
+	var s State
+	if err := json.Unmarshal(b, &s); err != nil {
+		return State{}, fmt.Errorf("parse skill pack state: %w", err)
+	}
+	if s.Paths == nil {
+		s.Paths = map[string]PathState{}
+	}
+	if s.Version == 0 {
+		s.Version = 1
+	}
+	return s, nil
+}
+
+// SaveState writes skill pack state atomically.
+func SaveState(s State) error {
+	if _, err := config.EnsureDir(); err != nil {
+		return err
+	}
+	path, err := statePath()
+	if err != nil {
+		return err
+	}
+	s.Version = 1
+	s.Updated = time.Now().UTC()
+	b, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode skill pack state: %w", err)
+	}
+	b = append(b, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return fmt.Errorf("write skill pack state: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("commit skill pack state: %w", err)
+	}
+	return nil
+}
+
+// RecordWrite updates state after a successful skill write.
+func RecordWrite(s *State, realPath, skillName, contentHash, packVersion string) {
+	if s.Paths == nil {
+		s.Paths = map[string]PathState{}
+	}
+	s.Paths[realPath] = PathState{
+		Skill:       skillName,
+		ContentHash: contentHash,
+		PackVersion: packVersion,
+		UpdatedAt:   time.Now().UTC(),
+	}
+}

--- a/internal/skillpack/state.go
+++ b/internal/skillpack/state.go
@@ -28,8 +28,9 @@ type PathState struct {
 func statePath() (string, error) {
 	dir, err := config.Dir()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("resolve config dir: %w", err)
 	}
+
 	return filepath.Join(dir, "skill-pack-state.json"), nil
 }
 
@@ -39,49 +40,63 @@ func LoadState() (State, error) {
 	if err != nil {
 		return State{}, err
 	}
+
+	//nolint:gosec // path is under user config dir
 	b, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return State{Version: 1, Paths: map[string]PathState{}}, nil
 		}
+
 		return State{}, fmt.Errorf("read skill pack state: %w", err)
 	}
+
 	var s State
 	if err := json.Unmarshal(b, &s); err != nil {
 		return State{}, fmt.Errorf("parse skill pack state: %w", err)
 	}
+
 	if s.Paths == nil {
 		s.Paths = map[string]PathState{}
 	}
+
 	if s.Version == 0 {
 		s.Version = 1
 	}
+
 	return s, nil
 }
 
 // SaveState writes skill pack state atomically.
 func SaveState(s State) error {
 	if _, err := config.EnsureDir(); err != nil {
-		return err
+		return fmt.Errorf("ensure config dir: %w", err)
 	}
+
 	path, err := statePath()
 	if err != nil {
 		return err
 	}
+
 	s.Version = 1
 	s.Updated = time.Now().UTC()
+
 	b, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode skill pack state: %w", err)
 	}
+
 	b = append(b, '\n')
 	tmp := path + ".tmp"
+
 	if err := os.WriteFile(tmp, b, 0o600); err != nil {
 		return fmt.Errorf("write skill pack state: %w", err)
 	}
+
 	if err := os.Rename(tmp, path); err != nil {
 		return fmt.Errorf("commit skill pack state: %w", err)
 	}
+
 	return nil
 }
 
@@ -90,6 +105,7 @@ func RecordWrite(s *State, realPath, skillName, contentHash, packVersion string)
 	if s.Paths == nil {
 		s.Paths = map[string]PathState{}
 	}
+
 	s.Paths[realPath] = PathState{
 		Skill:       skillName,
 		ContentHash: contentHash,

--- a/internal/skillpack/state.go
+++ b/internal/skillpack/state.go
@@ -12,9 +12,9 @@ import (
 
 // State tracks last-written pack hashes so we can detect local edits.
 type State struct {
-	Version int                    `json:"version"`
-	Paths   map[string]PathState   `json:"paths"`
-	Updated time.Time              `json:"updated_at"`
+	Version int                  `json:"version"`
+	Paths   map[string]PathState `json:"paths"`
+	Updated time.Time            `json:"updated_at"`
 }
 
 // PathState is the last install record for one real skill directory.

--- a/internal/skillpack/status.go
+++ b/internal/skillpack/status.go
@@ -34,12 +34,14 @@ type SkillStatus struct {
 func EvaluateAll(packVersion string, opts DiscoverOptions) ([]SkillStatus, error) {
 	manifest, err := skills.LoadManifest()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load manifest: %w", err)
 	}
+
 	state, err := LoadState()
 	if err != nil {
 		return nil, err
 	}
+
 	installs, err := Discover(manifest.Skills, opts)
 	if err != nil {
 		return nil, err
@@ -51,11 +53,13 @@ func EvaluateAll(packVersion string, opts DiscoverOptions) ([]SkillStatus, error
 	}
 
 	var out []SkillStatus
+
 	for _, name := range manifest.Skills {
 		packHash, err := HashManagedFromFS(skills.FS(), "pack/"+name, manifest.ManagedFiles)
 		if err != nil {
 			return nil, err
 		}
+
 		refs := bySkill[name]
 		if len(refs) == 0 {
 			out = append(out, SkillStatus{
@@ -64,16 +68,20 @@ func EvaluateAll(packVersion string, opts DiscoverOptions) ([]SkillStatus, error
 				PackHash:    packHash,
 				PackVersion: packVersion,
 			})
+
 			continue
 		}
+
 		for _, ref := range refs {
 			st, err := evaluateInstall(name, ref, packHash, packVersion, state, manifest.ManagedFiles)
 			if err != nil {
 				return nil, err
 			}
+
 			out = append(out, st)
 		}
 	}
+
 	return out, nil
 }
 
@@ -82,11 +90,14 @@ func evaluateInstall(skill string, ref InstallRef, packHash, packVersion string,
 	if err != nil {
 		return SkillStatus{}, err
 	}
+
 	stateHash := ""
 	if ps, ok := state.Paths[ref.RealPath]; ok {
 		stateHash = ps.ContentHash
 	}
+
 	kind := classify(diskHash, packHash, stateHash)
+
 	return SkillStatus{
 		Skill:       skill,
 		Kind:        kind,
@@ -103,10 +114,12 @@ func classify(diskHash, packHash, stateHash string) StatusKind {
 	if diskHash == packHash {
 		return StatusCurrent
 	}
+
 	// Last write matches disk but pack moved on → safe auto-update.
 	if stateHash != "" && diskHash == stateHash {
 		return StatusOutdated
 	}
+
 	// No state, or disk diverged from both pack and last write → treat as local edits.
 	return StatusDirty
 }
@@ -115,10 +128,12 @@ func classify(diskHash, packHash, stateHash string) StatusKind {
 func PackSkillNames() ([]string, error) {
 	m, err := skills.LoadManifest()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load manifest: %w", err)
 	}
+
 	out := append([]string(nil), m.Skills...)
 	sort.Strings(out)
+
 	return out, nil
 }
 
@@ -126,36 +141,45 @@ func PackSkillNames() ([]string, error) {
 func PackHashFor(skill string) (string, error) {
 	m, err := skills.LoadManifest()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("load manifest: %w", err)
 	}
+
 	return HashManagedFromFS(skills.FS(), "pack/"+skill, m.ManagedFiles)
 }
 
-// Ensure skill name is in pack.
+// IsPackSkill reports whether name is in the pack manifest.
 func IsPackSkill(name string) (bool, error) {
 	m, err := skills.LoadManifest()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("load manifest: %w", err)
 	}
+
 	for _, s := range m.Skills {
 		if s == name {
 			return true, nil
 		}
 	}
+
 	return false, nil
 }
 
 // ReadPackFile reads a managed file from the embed pack.
 func ReadPackFile(skill, file string) ([]byte, error) {
-	return skills.ReadManagedFile(skill, file)
+	b, err := skills.ReadManagedFile(skill, file)
+	if err != nil {
+		return nil, fmt.Errorf("read pack file: %w", err)
+	}
+
+	return b, nil
 }
 
 // ManagedFiles returns managed relative paths from the manifest.
 func ManagedFiles() ([]string, error) {
 	m, err := skills.LoadManifest()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load manifest: %w", err)
 	}
+
 	return append([]string(nil), m.ManagedFiles...), nil
 }
 
@@ -163,8 +187,9 @@ func ManagedFiles() ([]string, error) {
 func VerifyPackPresent() error {
 	m, err := skills.LoadManifest()
 	if err != nil {
-		return err
+		return fmt.Errorf("load manifest: %w", err)
 	}
+
 	for _, skill := range m.Skills {
 		for _, f := range m.ManagedFiles {
 			if _, err := fs.Stat(skills.FS(), pathJoin("pack/"+skill, f)); err != nil {
@@ -172,5 +197,6 @@ func VerifyPackPresent() error {
 			}
 		}
 	}
+
 	return nil
 }

--- a/internal/skillpack/status.go
+++ b/internal/skillpack/status.go
@@ -1,0 +1,176 @@
+package skillpack
+
+import (
+	"fmt"
+	"io/fs"
+	"sort"
+
+	"github.com/steipete/gogcli/skills"
+)
+
+// StatusKind classifies a pack skill install.
+type StatusKind string
+
+const (
+	StatusNotInstalled StatusKind = "not_installed"
+	StatusCurrent      StatusKind = "current"
+	StatusOutdated     StatusKind = "outdated"
+	StatusDirty        StatusKind = "dirty"
+)
+
+// SkillStatus is the evaluation of one install (or absence) for a pack skill.
+type SkillStatus struct {
+	Skill       string
+	Kind        StatusKind
+	Path        string
+	RealPath    string
+	PackHash    string
+	DiskHash    string
+	StateHash   string
+	PackVersion string
+}
+
+// EvaluateAll returns status rows for every pack skill (installs + not_installed).
+func EvaluateAll(packVersion string, opts DiscoverOptions) ([]SkillStatus, error) {
+	manifest, err := skills.LoadManifest()
+	if err != nil {
+		return nil, err
+	}
+	state, err := LoadState()
+	if err != nil {
+		return nil, err
+	}
+	installs, err := Discover(manifest.Skills, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	bySkill := map[string][]InstallRef{}
+	for _, inst := range installs {
+		bySkill[inst.Skill] = append(bySkill[inst.Skill], inst)
+	}
+
+	var out []SkillStatus
+	for _, name := range manifest.Skills {
+		packHash, err := HashManagedFromFS(skills.FS(), "pack/"+name, manifest.ManagedFiles)
+		if err != nil {
+			return nil, err
+		}
+		refs := bySkill[name]
+		if len(refs) == 0 {
+			out = append(out, SkillStatus{
+				Skill:       name,
+				Kind:        StatusNotInstalled,
+				PackHash:    packHash,
+				PackVersion: packVersion,
+			})
+			continue
+		}
+		for _, ref := range refs {
+			st, err := evaluateInstall(name, ref, packHash, packVersion, state, manifest.ManagedFiles)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, st)
+		}
+	}
+	return out, nil
+}
+
+func evaluateInstall(skill string, ref InstallRef, packHash, packVersion string, state State, managed []string) (SkillStatus, error) {
+	diskHash, err := HashManagedFiles(ref.RealPath, managed)
+	if err != nil {
+		return SkillStatus{}, err
+	}
+	stateHash := ""
+	if ps, ok := state.Paths[ref.RealPath]; ok {
+		stateHash = ps.ContentHash
+	}
+	kind := classify(diskHash, packHash, stateHash)
+	return SkillStatus{
+		Skill:       skill,
+		Kind:        kind,
+		Path:        ref.Path,
+		RealPath:    ref.RealPath,
+		PackHash:    packHash,
+		DiskHash:    diskHash,
+		StateHash:   stateHash,
+		PackVersion: packVersion,
+	}, nil
+}
+
+func classify(diskHash, packHash, stateHash string) StatusKind {
+	if diskHash == packHash {
+		return StatusCurrent
+	}
+	// Last write matches disk but pack moved on → safe auto-update.
+	if stateHash != "" && diskHash == stateHash {
+		return StatusOutdated
+	}
+	// No state, or disk diverged from both pack and last write → treat as local edits.
+	return StatusDirty
+}
+
+// PackSkillNames returns the embedded pack skill names.
+func PackSkillNames() ([]string, error) {
+	m, err := skills.LoadManifest()
+	if err != nil {
+		return nil, err
+	}
+	out := append([]string(nil), m.Skills...)
+	sort.Strings(out)
+	return out, nil
+}
+
+// PackHashFor returns the pack content hash for a skill.
+func PackHashFor(skill string) (string, error) {
+	m, err := skills.LoadManifest()
+	if err != nil {
+		return "", err
+	}
+	return HashManagedFromFS(skills.FS(), "pack/"+skill, m.ManagedFiles)
+}
+
+// Ensure skill name is in pack.
+func IsPackSkill(name string) (bool, error) {
+	m, err := skills.LoadManifest()
+	if err != nil {
+		return false, err
+	}
+	for _, s := range m.Skills {
+		if s == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ReadPackFile reads a managed file from the embed pack.
+func ReadPackFile(skill, file string) ([]byte, error) {
+	return skills.ReadManagedFile(skill, file)
+}
+
+// ManagedFiles returns managed relative paths from the manifest.
+func ManagedFiles() ([]string, error) {
+	m, err := skills.LoadManifest()
+	if err != nil {
+		return nil, err
+	}
+	return append([]string(nil), m.ManagedFiles...), nil
+}
+
+// VerifyPackPresent ensures every skill has SKILL.md in the embed FS.
+func VerifyPackPresent() error {
+	m, err := skills.LoadManifest()
+	if err != nil {
+		return err
+	}
+	for _, skill := range m.Skills {
+		for _, f := range m.ManagedFiles {
+			if _, err := fs.Stat(skills.FS(), pathJoin("pack/"+skill, f)); err != nil {
+				return fmt.Errorf("pack missing %s/%s: %w", skill, f, err)
+			}
+		}
+	}
+	return nil
+}

--- a/skills/embed.go
+++ b/skills/embed.go
@@ -1,0 +1,53 @@
+// Package skills embeds the gog companion skill pack shipped with this CLI.
+package skills
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+)
+
+//go:embed manifest.json pack/*/SKILL.md
+var packFS embed.FS
+
+// Manifest describes which skills this CLI owns and which files are managed.
+type Manifest struct {
+	Name         string   `json:"name"`
+	Skills       []string `json:"skills"`
+	ManagedFiles []string `json:"managed_files"`
+}
+
+// LoadManifest reads the embedded pack manifest.
+func LoadManifest() (Manifest, error) {
+	b, err := packFS.ReadFile("manifest.json")
+	if err != nil {
+		return Manifest{}, fmt.Errorf("read skill manifest: %w", err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return Manifest{}, fmt.Errorf("parse skill manifest: %w", err)
+	}
+	if len(m.Skills) == 0 {
+		return Manifest{}, fmt.Errorf("skill manifest has no skills")
+	}
+	if len(m.ManagedFiles) == 0 {
+		m.ManagedFiles = []string{"SKILL.md"}
+	}
+	return m, nil
+}
+
+// FS returns the embedded skill pack filesystem.
+func FS() fs.FS {
+	return packFS
+}
+
+// ReadManagedFile returns a managed file for a pack skill (e.g. "google-calendar", "SKILL.md").
+func ReadManagedFile(skillName, fileName string) ([]byte, error) {
+	path := fmt.Sprintf("pack/%s/%s", skillName, fileName)
+	b, err := packFS.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read pack file %s: %w", path, err)
+	}
+	return b, nil
+}

--- a/skills/embed.go
+++ b/skills/embed.go
@@ -4,12 +4,20 @@ package skills
 import (
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 )
 
 //go:embed manifest.json pack/*/SKILL.md
 var packFS embed.FS
+
+var (
+	errNoSkills      = errors.New("skill manifest has no skills")
+	errReadManifest  = errors.New("read skill manifest")
+	errParseManifest = errors.New("parse skill manifest")
+	errReadPackFile  = errors.New("read pack file")
+)
 
 // Manifest describes which skills this CLI owns and which files are managed.
 type Manifest struct {
@@ -22,18 +30,22 @@ type Manifest struct {
 func LoadManifest() (Manifest, error) {
 	b, err := packFS.ReadFile("manifest.json")
 	if err != nil {
-		return Manifest{}, fmt.Errorf("read skill manifest: %w", err)
+		return Manifest{}, fmt.Errorf("%w: %w", errReadManifest, err)
 	}
+
 	var m Manifest
 	if err := json.Unmarshal(b, &m); err != nil {
-		return Manifest{}, fmt.Errorf("parse skill manifest: %w", err)
+		return Manifest{}, fmt.Errorf("%w: %w", errParseManifest, err)
 	}
+
 	if len(m.Skills) == 0 {
-		return Manifest{}, fmt.Errorf("skill manifest has no skills")
+		return Manifest{}, errNoSkills
 	}
+
 	if len(m.ManagedFiles) == 0 {
 		m.ManagedFiles = []string{"SKILL.md"}
 	}
+
 	return m, nil
 }
 
@@ -45,9 +57,11 @@ func FS() fs.FS {
 // ReadManagedFile returns a managed file for a pack skill (e.g. "google-calendar", "SKILL.md").
 func ReadManagedFile(skillName, fileName string) ([]byte, error) {
 	path := fmt.Sprintf("pack/%s/%s", skillName, fileName)
+
 	b, err := packFS.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read pack file %s: %w", path, err)
+		return nil, fmt.Errorf("%w %s: %w", errReadPackFile, path, err)
 	}
+
 	return b, nil
 }

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "gogcli",
+  "skills": [
+    "gmail-personal",
+    "gmail-workspace",
+    "google-analytics",
+    "google-business-profile",
+    "google-calendar",
+    "google-docs",
+    "google-drive",
+    "google-search-console",
+    "google-sheets",
+    "google-tag-manager"
+  ],
+  "managed_files": ["SKILL.md"]
+}

--- a/skills/pack/gmail-personal/SKILL.md
+++ b/skills/pack/gmail-personal/SKILL.md
@@ -55,6 +55,11 @@ gog --json --no-input --account jdjb78@gmail.com gmail get MESSAGE_ID
 
 ## Study @learnings/LEARNINGS.md
 
+
+## Command accuracy
+
+Prefer `gog <group> --help` and subcommand `--help` when flags are uncertain; the live binary is the source of truth over any table in this skill.
+
 ## Keeping this skill current
 
 This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:

--- a/skills/pack/gmail-personal/SKILL.md
+++ b/skills/pack/gmail-personal/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: gmail-personal
+description: "Personal Gmail (jdjb78@gmail.com) via gogcli — readonly by default."
+allowed-tools: "Bash(gog:*)"
+---
+
+# Gmail Personal
+
+Use `gog gmail` for **personal** mail only: `jdjb78@gmail.com`.
+
+## Non-negotiables
+
+- Always pass an explicit account: `--account jdjb78@gmail.com` or verified alias `--account personal`
+- Never rely on bare `gog` / ambient default for personal mail
+- Never set personal as the gog default account
+- Do **not** set `GOG_ACCOUNT=personal` globally
+- Auth backend is **encrypted file keyring** (`keyring_backend: file`). Env needs `GOG_KEYRING_PASSWORD` (same as business). Do **not** use macOS Keychain for gog tokens.
+- Current OAuth scope is **Gmail readonly**. Do not send/draft until scopes are widened (Phase 5)
+
+## Quick Start
+
+```bash
+# Search inbox threads
+gog --json --no-input --account jdjb78@gmail.com gmail search "is:unread" --max 20
+
+# Alias (after verified)
+gog --json --no-input --account personal gmail search "is:unread" --max 20
+
+# Read a message
+gog --json --no-input --account jdjb78@gmail.com gmail get MESSAGE_ID
+```
+
+## Available Commands (readonly phase)
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `search <query>` | Search threads | `--max` |
+| `get <messageId>` | Read an email by ID | `--format` |
+| `messages list` | List messages | `--max`, `--label` |
+| `labels list` | List labels | |
+| `thread get <threadId>` | Get thread | |
+
+## Out of scope until Phase 5
+
+- `gmail send`
+- `drafts create` / send draft
+- any write that needs full Gmail scope
+
+## Configuration
+
+- Account: `jdjb78@gmail.com`
+- Alias: `personal` → `jdjb78@gmail.com`
+- Keyring: gogcli encrypted file backend (`keyring_backend: file`; `GOG_KEYRING_PASSWORD` required)
+- Business default must remain `jeremy@robbenmedia.com` (set via `gog auth manage` → Set default)
+
+## Study @learnings/LEARNINGS.md
+
+## Keeping this skill current
+
+This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:
+
+```bash
+gog update
+```
+
+That refreshes the binary and any installed pack skills. Locally edited skills are skipped (agent-safe). If a skill is skipped, tell the user the path; only overwrite with `gog skills update --overwrite-local` or `gog update --force-skills` when they ask.

--- a/skills/pack/gmail-workspace/SKILL.md
+++ b/skills/pack/gmail-workspace/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: gmail-workspace
+description: "Manage workspace Gmail (jeremy@robbenmedia.com). Search, read, send, and triage emails via gogcli."
+allowed-tools: "Bash(gog:*)"
+---
+
+# Gmail (Workspace)
+
+Use `gog gmail` for workspace email operations (`jeremy@robbenmedia.com`).
+
+## Non-negotiables
+
+- Prefer explicit account on every command: `--account jeremy@robbenmedia.com` or verified alias `--account business`
+- Bare `gog` default is **business continuity-critical**. Never set personal as default / `GOG_ACCOUNT`
+- Auth backend is **encrypted file keyring** (`keyring_backend: file`). Shell/agent env should have `GOG_KEYRING_PASSWORD` (from `~/.config/gogcli/keyring_password` or existing env). Do **not** use macOS Keychain for gog tokens.
+- Dual-account is live: personal exists as `jdjb78@gmail.com` / alias `personal` — keep it out of workspace workflows
+
+## Quick Start
+
+```bash
+# Search inbox threads
+gog --json --no-input --account jeremy@robbenmedia.com gmail search "is:unread" --max 10
+
+# Alias (after verified)
+gog --json --no-input --account business gmail search "is:unread" --max 10
+
+# Read specific message
+gog --json --no-input --account jeremy@robbenmedia.com gmail get MESSAGE_ID
+
+# Send email
+gog --json --no-input --account jeremy@robbenmedia.com gmail send --to "user@example.com" --subject "Re: Quote" --body "Hi, here's the quote..."
+
+# List labels
+gog --json --no-input --account jeremy@robbenmedia.com gmail labels list
+```
+
+## Available Commands
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `search <query>` | Search threads using Gmail query syntax | `--max`, `--page` |
+| `get <messageId>` | Get a message (full/metadata/raw) | `--format` |
+| `messages list` | List messages | `--max`, `--label`, `--query` |
+| `send` | Send an email | `--to`, `--subject`, `--body`, `--cc`, `--bcc`, `--html`, `--thread` |
+| `labels list` | List all labels | |
+| `labels create <name>` | Create a label | |
+| `thread get <threadId>` | Get full thread | |
+| `thread modify <threadId>` | Modify thread labels | `--add-labels`, `--remove-labels` |
+| `batch archive` | Archive messages in batch | `--query` |
+| `drafts list` | List drafts | `--max` |
+| `drafts create` | Create a draft | `--to`, `--subject`, `--body` |
+| `attachment <msgId> <attachId>` | Download attachment | `--output` |
+
+## Gmail Search Syntax
+
+```
+is:unread                     Unread messages
+from:user@example.com         From specific sender
+subject:"invoice"             Subject contains word
+has:attachment                Has attachments
+newer_than:7d                 Last 7 days
+after:2024/01/01              After date
+label:important               Has label
+```
+
+## Output Format
+
+With `--json` flag, gog outputs raw Google API JSON (not our `{success, data, error, meta}` wrapper).
+
+Output modes: `--json` (scripting), `--plain` (TSV), or default (human-readable table).
+
+## Common Workflows
+
+### Email Triage
+```bash
+gog --json --no-input --account jeremy@robbenmedia.com gmail search "is:unread" --max 20
+gog --no-input --account jeremy@robbenmedia.com gmail thread modify THREAD_ID --remove-labels INBOX
+```
+
+### Reply to Client Thread
+```bash
+gog --json --no-input --account jeremy@robbenmedia.com gmail search "from:client@example.com"
+gog --json --no-input --account jeremy@robbenmedia.com gmail thread get THREAD_ID
+gog --no-input --account jeremy@robbenmedia.com gmail send --to "client@example.com" --subject "Re: Project" --body "..." --thread THREAD_ID
+```
+
+## Configuration
+
+- Account: `jeremy@robbenmedia.com`
+- Alias: `business` → `jeremy@robbenmedia.com`
+- Keyring: gogcli encrypted file backend (`keyring_backend: file`; `GOG_KEYRING_PASSWORD` required)
+- Default account must remain business (set via `gog auth manage` → Set default).  
+  Note: `gog auth alias set default ...` is **reserved/invalid** on current gog build.
+
+## Study @learnings/LEARNINGS.md
+
+## Keeping this skill current
+
+This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:
+
+```bash
+gog update
+```
+
+That refreshes the binary and any installed pack skills. Locally edited skills are skipped (agent-safe). If a skill is skipped, tell the user the path; only overwrite with `gog skills update --overwrite-local` or `gog update --force-skills` when they ask.

--- a/skills/pack/gmail-workspace/SKILL.md
+++ b/skills/pack/gmail-workspace/SKILL.md
@@ -94,6 +94,11 @@ gog --no-input --account jeremy@robbenmedia.com gmail send --to "client@example.
 
 ## Study @learnings/LEARNINGS.md
 
+
+## Command accuracy
+
+Prefer `gog <group> --help` and subcommand `--help` when flags are uncertain; the live binary is the source of truth over any table in this skill.
+
 ## Keeping this skill current
 
 This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:

--- a/skills/pack/google-analytics/SKILL.md
+++ b/skills/pack/google-analytics/SKILL.md
@@ -1,0 +1,60 @@
+---
+
+name: google-analytics
+description: "Google Analytics reporting CLI"
+allowed-tools: "Bash(gog:*)"
+
+---
+
+# Google Analytics
+
+Use `gog analytics` (aliases: `gog ga`, `gog ga4`) for querying GA4 reports, metrics, and dimensions.
+
+## Quick Start
+
+```bash
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com analytics properties
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com analytics report --property 12345 --metrics "sessions,users" --start-date 28daysAgo --end-date today
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com analytics realtime --property 12345
+```
+
+## Available Commands
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `report` | Run a GA4 report | `--property`, `--metrics`, `--dimensions`, `--start-date`, `--end-date`, `--limit` |
+| `realtime` | Get realtime active users | `--property`, `--metrics`, `--dimensions` |
+| `properties` | List available GA4 properties | `--page-size` |
+| `accounts` | List GA4 accounts | `--page-size` |
+| `dimensions` | List available dimensions for a property | `--property` |
+| `metrics` | List available metrics for a property | `--property` |
+
+## Property ID Format
+
+Property IDs can be passed with or without prefix:
+- `--property 12345` (bare number)
+- `--property properties/12345` (full format)
+
+## Output Modes
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Raw Google API JSON output |
+| `--plain` | TSV for piping to other tools |
+| (default) | Human-readable table |
+
+## Configuration
+
+Auth: `GOG_KEYRING_PASSWORD=cli-tools` with `--account jeremy@robbenmedia.com`
+
+## Study @learnings/LEARNINGS.md
+
+## Keeping this skill current
+
+This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:
+
+```bash
+gog update
+```
+
+That refreshes the binary and any installed pack skills. Locally edited skills are skipped (agent-safe). If a skill is skipped, tell the user the path; only overwrite with `gog skills update --overwrite-local` or `gog update --force-skills` when they ask.

--- a/skills/pack/google-analytics/SKILL.md
+++ b/skills/pack/google-analytics/SKILL.md
@@ -49,6 +49,11 @@ Auth: `GOG_KEYRING_PASSWORD=cli-tools` with `--account jeremy@robbenmedia.com`
 
 ## Study @learnings/LEARNINGS.md
 
+
+## Command accuracy
+
+Prefer `gog <group> --help` and subcommand `--help` when flags are uncertain; the live binary is the source of truth over any table in this skill.
+
 ## Keeping this skill current
 
 This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:

--- a/skills/pack/google-business-profile/SKILL.md
+++ b/skills/pack/google-business-profile/SKILL.md
@@ -1,0 +1,51 @@
+---
+
+name: google-business-profile
+description: "Google Business Profile management CLI"
+allowed-tools: "Bash(gog:*)"
+
+---
+
+# Google Business Profile
+
+Use `gog business-profile` (aliases: `gog gbp`, `gog business`) for managing Google Business Profile listings.
+
+## Quick Start
+
+```bash
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com business-profile accounts
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com business-profile locations "accounts/12345"
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com business-profile get "locations/67890"
+```
+
+## Available Commands
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `accounts` | List GBP accounts | |
+| `locations` | List business locations for an account | `<account>` (positional), `--page-size`, `--read-mask` |
+| `get` | Get a specific location | `<locationName>` (positional), `--read-mask` |
+
+## Output Modes
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Raw Google API JSON output |
+| `--plain` | TSV for piping to other tools |
+| (default) | Human-readable table |
+
+## Configuration
+
+Auth: `GOG_KEYRING_PASSWORD=cli-tools` with `--account jeremy@robbenmedia.com`
+
+## Study @learnings/LEARNINGS.md
+
+## Keeping this skill current
+
+This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:
+
+```bash
+gog update
+```
+
+That refreshes the binary and any installed pack skills. Locally edited skills are skipped (agent-safe). If a skill is skipped, tell the user the path; only overwrite with `gog skills update --overwrite-local` or `gog update --force-skills` when they ask.

--- a/skills/pack/google-business-profile/SKILL.md
+++ b/skills/pack/google-business-profile/SKILL.md
@@ -40,6 +40,11 @@ Auth: `GOG_KEYRING_PASSWORD=cli-tools` with `--account jeremy@robbenmedia.com`
 
 ## Study @learnings/LEARNINGS.md
 
+
+## Command accuracy
+
+Prefer `gog <group> --help` and subcommand `--help` when flags are uncertain; the live binary is the source of truth over any table in this skill.
+
 ## Keeping this skill current
 
 This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:

--- a/skills/pack/google-calendar/SKILL.md
+++ b/skills/pack/google-calendar/SKILL.md
@@ -55,6 +55,11 @@ Auth: gogcli file keyring (`GOG_KEYRING_PASSWORD=cli-tools`). Account: `--accoun
 
 ## Study @learnings/LEARNINGS.md
 
+
+## Command accuracy
+
+Prefer `gog <group> --help` and subcommand `--help` when flags are uncertain; the live binary is the source of truth over any table in this skill.
+
 ## Keeping this skill current
 
 This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:

--- a/skills/pack/google-calendar/SKILL.md
+++ b/skills/pack/google-calendar/SKILL.md
@@ -1,0 +1,66 @@
+---
+
+name: google-calendar
+description: "Google Calendar event management via gogcli"
+allowed-tools: "Bash(gog:*)"
+
+---
+
+# Google Calendar
+
+Use `gog calendar` for managing calendar events, scheduling, and availability.
+
+**Requires**: `GOG_KEYRING_PASSWORD=cli-tools` env var for all commands.
+
+## Quick Start
+
+```bash
+# List upcoming events (today)
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com calendar events --today
+
+# List next 7 days
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com calendar events --days 7
+
+# Create an event
+GOG_KEYRING_PASSWORD=cli-tools gog --no-input --account jeremy@robbenmedia.com calendar create primary --summary "Meeting" --start "2026-02-10T10:00:00" --end "2026-02-10T11:00:00"
+
+# Check free/busy
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com calendar freebusy primary --from "2026-02-10" --to "2026-02-11"
+```
+
+## Available Commands
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `events [calendarId]` | List events | `--today`, `--tomorrow`, `--week`, `--days`, `--from`, `--to`, `--max`, `--all` |
+| `event <calendarId> <eventId>` | Get event details | |
+| `create <calendarId>` | Create a new event | `--summary`, `--start`, `--end`, `--location`, `--description` |
+| `update <calendarId> <eventId>` | Update an event | `--summary`, `--start`, `--end` |
+| `delete <calendarId> <eventId>` | Delete an event | |
+| `search <query>` | Search events | `--from`, `--to` |
+| `freebusy <calendarIds>` | Check free/busy times | `--from`, `--to` |
+| `calendars` | List available calendars | |
+| `conflicts` | Find scheduling conflicts | `--from`, `--to` |
+| `respond <calendarId> <eventId>` | RSVP to an event | `--status` (accepted/declined/tentative) |
+
+Default calendarId is `primary`.
+
+## Output Format
+
+With `--json`: raw Google Calendar API JSON. With `--plain`: TSV. Default: human-readable table with times.
+
+## Configuration
+
+Auth: gogcli file keyring (`GOG_KEYRING_PASSWORD=cli-tools`). Account: `--account jeremy@robbenmedia.com`.
+
+## Study @learnings/LEARNINGS.md
+
+## Keeping this skill current
+
+This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:
+
+```bash
+gog update
+```
+
+That refreshes the binary and any installed pack skills. Locally edited skills are skipped (agent-safe). If a skill is skipped, tell the user the path; only overwrite with `gog skills update --overwrite-local` or `gog update --force-skills` when they ask.

--- a/skills/pack/google-docs/SKILL.md
+++ b/skills/pack/google-docs/SKILL.md
@@ -1,0 +1,59 @@
+---
+
+name: google-docs
+description: "Google Docs document management via gogcli"
+allowed-tools: "Bash(gog:*)"
+
+---
+
+# Google Docs
+
+Use `gog docs` for reading, creating, and exporting Google Docs documents.
+
+**Requires**: `GOG_KEYRING_PASSWORD=cli-tools` env var for all commands.
+
+## Quick Start
+
+```bash
+# Export doc as text
+GOG_KEYRING_PASSWORD=cli-tools gog --no-input --account jeremy@robbenmedia.com docs export DOC_ID --format txt
+
+# Export as PDF
+GOG_KEYRING_PASSWORD=cli-tools gog --no-input --account jeremy@robbenmedia.com docs export DOC_ID --format pdf --output ./doc.pdf
+
+# Get doc metadata
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com docs info DOC_ID
+
+# Create a new doc
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com docs create "New Document"
+```
+
+## Available Commands
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `export <docId>` | Export to PDF/DOCX/TXT | `--format` (pdf/docx/txt), `--output` |
+| `info <docId>` | Get document metadata | |
+| `create <title>` | Create a new document | `--folder` |
+
+Note: gogcli exports Docs via Drive API. For reading content, use `export --format txt` to stdout.
+
+## Output Format
+
+With `--json`: raw Google API JSON metadata. Export outputs file content directly.
+
+## Configuration
+
+Auth: gogcli file keyring (`GOG_KEYRING_PASSWORD=cli-tools`). Account: `--account jeremy@robbenmedia.com`.
+
+## Study @learnings/LEARNINGS.md
+
+## Keeping this skill current
+
+This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:
+
+```bash
+gog update
+```
+
+That refreshes the binary and any installed pack skills. Locally edited skills are skipped (agent-safe). If a skill is skipped, tell the user the path; only overwrite with `gog skills update --overwrite-local` or `gog update --force-skills` when they ask.

--- a/skills/pack/google-docs/SKILL.md
+++ b/skills/pack/google-docs/SKILL.md
@@ -48,6 +48,11 @@ Auth: gogcli file keyring (`GOG_KEYRING_PASSWORD=cli-tools`). Account: `--accoun
 
 ## Study @learnings/LEARNINGS.md
 
+
+## Command accuracy
+
+Prefer `gog <group> --help` and subcommand `--help` when flags are uncertain; the live binary is the source of truth over any table in this skill.
+
 ## Keeping this skill current
 
 This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:

--- a/skills/pack/google-drive/SKILL.md
+++ b/skills/pack/google-drive/SKILL.md
@@ -19,7 +19,7 @@ Use `gog drive` for managing Google Drive files, folders, and permissions.
 GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com drive ls --max 20
 
 # List files in a folder
-GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com drive ls --folder FOLDER_ID
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com drive ls --parent FOLDER_ID
 
 # Search for files
 GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com drive search "quarterly report"
@@ -28,23 +28,25 @@ GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedi
 GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com drive get FILE_ID
 
 # Upload a file
-GOG_KEYRING_PASSWORD=cli-tools gog --no-input --account jeremy@robbenmedia.com drive upload ./report.pdf --folder FOLDER_ID
+GOG_KEYRING_PASSWORD=cli-tools gog --no-input --account jeremy@robbenmedia.com drive upload ./report.pdf --parent FOLDER_ID
 ```
 
 ## Available Commands
 
 | Command | Description | Key Flags |
 |---------|-------------|-----------|
-| `ls` | List files and folders | `--folder`, `--max`, `--type`, `--page` |
-| `search <query>` | Full-text search | `--max`, `--type` |
+| `ls` | List files and folders | `--parent`, `--max`, `--page` |
+| `search <query>` | Full-text search | `--max` |
 | `get <fileId>` | Get file metadata | |
-| `upload <file>` | Upload a file | `--folder`, `--name` |
-| `download <fileId>` | Download a file | `--output` |
+| `upload <file>` | Upload a file | `--parent`, `--name` |
+| `download <fileId>` | Download a file | `--out` |
 | `mkdir <name>` | Create a folder | `--parent` |
-| `mv <fileId> <folderId>` | Move a file | |
-| `cp <fileId>` | Copy a file | `--name` |
-| `rm <fileId>` | Move to trash | |
-| `share <fileId>` | Manage permissions | `--email`, `--role` |
+| `move <fileId>` | Move a file | `--parent` (required) |
+| `copy <fileId>` | Copy a file | `--name`, `--parent` |
+| `delete <fileId>` / `rm` | Trash or delete | see `gog drive --help` |
+| `permissions` | Manage sharing | see `gog drive permissions --help` |
+
+Prefer `gog drive --help` and subcommand `--help` when unsure — flags drift less often than skill tables.
 
 ## Output Format
 

--- a/skills/pack/google-drive/SKILL.md
+++ b/skills/pack/google-drive/SKILL.md
@@ -1,0 +1,67 @@
+---
+
+name: google-drive
+description: "Google Drive file management via gogcli"
+allowed-tools: "Bash(gog:*)"
+
+---
+
+# Google Drive
+
+Use `gog drive` for managing Google Drive files, folders, and permissions.
+
+**Requires**: `GOG_KEYRING_PASSWORD=cli-tools` env var for all commands.
+
+## Quick Start
+
+```bash
+# List files in root
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com drive ls --max 20
+
+# List files in a folder
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com drive ls --folder FOLDER_ID
+
+# Search for files
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com drive search "quarterly report"
+
+# Get file info
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com drive get FILE_ID
+
+# Upload a file
+GOG_KEYRING_PASSWORD=cli-tools gog --no-input --account jeremy@robbenmedia.com drive upload ./report.pdf --folder FOLDER_ID
+```
+
+## Available Commands
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `ls` | List files and folders | `--folder`, `--max`, `--type`, `--page` |
+| `search <query>` | Full-text search | `--max`, `--type` |
+| `get <fileId>` | Get file metadata | |
+| `upload <file>` | Upload a file | `--folder`, `--name` |
+| `download <fileId>` | Download a file | `--output` |
+| `mkdir <name>` | Create a folder | `--parent` |
+| `mv <fileId> <folderId>` | Move a file | |
+| `cp <fileId>` | Copy a file | `--name` |
+| `rm <fileId>` | Move to trash | |
+| `share <fileId>` | Manage permissions | `--email`, `--role` |
+
+## Output Format
+
+With `--json`: raw Google Drive API JSON. With `--plain`: TSV. Default: human-readable table.
+
+## Configuration
+
+Auth: gogcli file keyring (`GOG_KEYRING_PASSWORD=cli-tools`). Account: `--account jeremy@robbenmedia.com`.
+
+## Study @learnings/LEARNINGS.md
+
+## Keeping this skill current
+
+This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:
+
+```bash
+gog update
+```
+
+That refreshes the binary and any installed pack skills. Locally edited skills are skipped (agent-safe). If a skill is skipped, tell the user the path; only overwrite with `gog skills update --overwrite-local` or `gog update --force-skills` when they ask.

--- a/skills/pack/google-search-console/SKILL.md
+++ b/skills/pack/google-search-console/SKILL.md
@@ -1,0 +1,53 @@
+---
+
+name: google-search-console
+description: "Google Search Console performance and indexing CLI"
+allowed-tools: "Bash(gog:*)"
+
+---
+
+# Google Search Console
+
+Use `gog search-console` (aliases: `gog gsc`, `gog sc`) for search performance data, indexing status, and URL inspection.
+
+## Quick Start
+
+```bash
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com search-console sites
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com search-console query --site-url "sc-domain:example.com" --start-date 2026-01-01 --end-date 2026-01-31 --dimensions query,page
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com search-console inspect --site-url "sc-domain:example.com" --url "https://example.com/page"
+```
+
+## Available Commands
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `sites` | List verified sites | |
+| `query` | Query search analytics data | `--site-url`, `--start-date`, `--end-date`, `--dimensions`, `--row-limit` |
+| `sitemaps` | List sitemaps for a site | `--site-url` |
+| `submit-sitemap` | Submit a sitemap | `--site-url`, `--sitemap-url` |
+| `inspect` | Inspect URL indexing status | `--site-url`, `--url` |
+
+## Output Modes
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Raw Google API JSON output |
+| `--plain` | TSV for piping to other tools |
+| (default) | Human-readable table |
+
+## Configuration
+
+Auth: `GOG_KEYRING_PASSWORD=cli-tools` with `--account jeremy@robbenmedia.com`
+
+## Study @learnings/LEARNINGS.md
+
+## Keeping this skill current
+
+This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:
+
+```bash
+gog update
+```
+
+That refreshes the binary and any installed pack skills. Locally edited skills are skipped (agent-safe). If a skill is skipped, tell the user the path; only overwrite with `gog skills update --overwrite-local` or `gog update --force-skills` when they ask.

--- a/skills/pack/google-search-console/SKILL.md
+++ b/skills/pack/google-search-console/SKILL.md
@@ -42,6 +42,11 @@ Auth: `GOG_KEYRING_PASSWORD=cli-tools` with `--account jeremy@robbenmedia.com`
 
 ## Study @learnings/LEARNINGS.md
 
+
+## Command accuracy
+
+Prefer `gog <group> --help` and subcommand `--help` when flags are uncertain; the live binary is the source of truth over any table in this skill.
+
 ## Keeping this skill current
 
 This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:

--- a/skills/pack/google-sheets/SKILL.md
+++ b/skills/pack/google-sheets/SKILL.md
@@ -47,6 +47,11 @@ Auth: gogcli file keyring (`GOG_KEYRING_PASSWORD=cli-tools`). Account: `--accoun
 
 ## Study @learnings/LEARNINGS.md
 
+
+## Command accuracy
+
+Prefer `gog <group> --help` and subcommand `--help` when flags are uncertain; the live binary is the source of truth over any table in this skill.
+
 ## Keeping this skill current
 
 This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:

--- a/skills/pack/google-sheets/SKILL.md
+++ b/skills/pack/google-sheets/SKILL.md
@@ -1,0 +1,58 @@
+---
+
+name: google-sheets
+description: "Google Sheets spreadsheet management via gogcli"
+allowed-tools: "Bash(gog:*)"
+
+---
+
+# Google Sheets
+
+Use `gog sheets` for reading, writing, and managing Google Sheets spreadsheets.
+
+**Requires**: `GOG_KEYRING_PASSWORD=cli-tools` env var for all commands.
+
+## Quick Start
+
+```bash
+# Read cell values
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com sheets get SPREADSHEET_ID "Sheet1!A1:D10"
+
+# Write/update values
+GOG_KEYRING_PASSWORD=cli-tools gog --no-input --account jeremy@robbenmedia.com sheets update SPREADSHEET_ID "A1:B2" '["val1","val2"]' '["val3","val4"]'
+
+# Append rows
+GOG_KEYRING_PASSWORD=cli-tools gog --no-input --account jeremy@robbenmedia.com sheets append SPREADSHEET_ID "Sheet1!A:D" '["new1","new2","new3","new4"]'
+```
+
+## Available Commands
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `get <spreadsheetId> <range>` | Read cell values | `--formula` (show formulas) |
+| `update <spreadsheetId> <range> [values...]` | Write values to cells | `--raw` (no parse) |
+| `append <spreadsheetId> <range> [values...]` | Append rows | |
+| `info <spreadsheetId>` | Get spreadsheet metadata | |
+| `create <title>` | Create a new spreadsheet | |
+
+Values are passed as positional JSON arrays, one per row.
+
+## Output Format
+
+With `--json`: raw Google Sheets API JSON. With `--plain`: TSV (great for piping sheet data). Default: human-readable table.
+
+## Configuration
+
+Auth: gogcli file keyring (`GOG_KEYRING_PASSWORD=cli-tools`). Account: `--account jeremy@robbenmedia.com`.
+
+## Study @learnings/LEARNINGS.md
+
+## Keeping this skill current
+
+This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:
+
+```bash
+gog update
+```
+
+That refreshes the binary and any installed pack skills. Locally edited skills are skipped (agent-safe). If a skill is skipped, tell the user the path; only overwrite with `gog skills update --overwrite-local` or `gog update --force-skills` when they ask.

--- a/skills/pack/google-tag-manager/SKILL.md
+++ b/skills/pack/google-tag-manager/SKILL.md
@@ -60,6 +60,11 @@ Auth: `GOG_KEYRING_PASSWORD=cli-tools` with `--account jeremy@robbenmedia.com`
 
 ## Study @learnings/LEARNINGS.md
 
+
+## Command accuracy
+
+Prefer `gog <group> --help` and subcommand `--help` when flags are uncertain; the live binary is the source of truth over any table in this skill.
+
 ## Keeping this skill current
 
 This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:

--- a/skills/pack/google-tag-manager/SKILL.md
+++ b/skills/pack/google-tag-manager/SKILL.md
@@ -1,0 +1,71 @@
+---
+
+name: google-tag-manager
+description: "Google Tag Manager container and tag management CLI"
+allowed-tools: "Bash(gog:*)"
+
+---
+
+# Google Tag Manager
+
+Use `gog tag-manager` (alias: `gog gtm`) for managing GTM containers, tags, triggers, and variables.
+
+## Preflight
+
+Verify the active binary exposes the GTM command surface before using this skill:
+
+```bash
+gog --help | rg 'tag-manager|gtm'
+```
+
+Expected help output includes `tag-manager (gtm) <command> [flags]`.
+
+If `gog tag-manager` or `gog gtm` fails with `unexpected argument`, the binary on `PATH` is stale or was built without GTM commands. Fix the installed binary first; stored OAuth scopes alone are not enough to make the CLI command surface exist.
+
+## Quick Start
+
+```bash
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com tag-manager accounts
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com tag-manager containers --account-id 12345
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com tag-manager tags --account-id 12345 --container-id 67890
+```
+
+## Available Commands
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `accounts` | List GTM accounts | |
+| `containers` | List containers in an account | `--account-id` |
+| `tags` | List tags in a container | `--account-id`, `--container-id`, `--workspace-id` |
+| `tag` | Get a single tag by path | `<tagPath>` (positional) |
+| `triggers` | List triggers in a container | `--account-id`, `--container-id`, `--workspace-id` |
+| `variables` | List variables in a container | `--account-id`, `--container-id`, `--workspace-id` |
+| `versions` | List container versions | `--account-id`, `--container-id` |
+
+## Resource Paths
+
+GTM uses path-based IDs: `accounts/123/containers/456/workspaces/789/tags/101`
+
+## Output Modes
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Raw Google API JSON output |
+| `--plain` | TSV for piping to other tools |
+| (default) | Human-readable table |
+
+## Configuration
+
+Auth: `GOG_KEYRING_PASSWORD=cli-tools` with `--account jeremy@robbenmedia.com`
+
+## Study @learnings/LEARNINGS.md
+
+## Keeping this skill current
+
+This skill is part of the **gog companion skill pack**. When `gog` reports an update is available, run:
+
+```bash
+gog update
+```
+
+That refreshes the binary and any installed pack skills. Locally edited skills are skipped (agent-safe). If a skill is skipped, tell the user the path; only overwrite with `gog skills update --overwrite-local` or `gog update --force-skills` when they ask.


### PR DESCRIPTION
## Summary

- Ships an embedded companion skill pack (10 Google/gog agent skills) and `gog skills status|update|install`.
- Adds `gog update` for GitHub Releases binary self-update + pack skill refresh (skips dirty skills per path; re-execs after binary replace so the new embed is used).
- Throttled stderr update notice for agents/humans (`GOG_SKIP_UPDATE_CHECK=1` to disable).

## Spec / review

- Plan: `docs/plans/gog-skill-pack-update-2026-08-07.html`
- Codex review disposition: `docs/plans/code-review-skill-pack-update.md` (P1/P2 addressed)

## Test plan

- [x] `go test ./internal/skillpack/ ./internal/selfupdate/`
- [x] `gog skills status` discovers installs under `~/.agents` / `~/.claude` / `~/.codex`
- [ ] CI green
- [ ] After merge: cut `v0.10.0`, bootstrap `~/.local/bin/gog`, run `gog skills update --overwrite-local` once on this machine