### PR TITLE
release: v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,21 @@
 
 ## Unreleased
 
+## 0.10.0 - 2026-08-07
+
+### Highlights
+
+- CLI: self-update the binary from GitHub Releases and refresh the embedded companion Google skill pack with `gog update` / `gog skills` (#39).
+
 ### Added
 
-- CLI: `gog update` self-updates the binary from GitHub Releases and refreshes the embedded companion Google skill pack (pack skills only).
-- CLI: `gog skills status|update|install` discovers pack skills under agent skill roots (`.agents`, `.claude`, `.codex`, etc.), skips locally edited skills by default, and never touches non-pack skills or `learnings/`.
-- CLI: throttled stderr notice when a newer release is available (`GOG_SKIP_UPDATE_CHECK=1` to disable).
-- Skills: ship 10 companion skills under `skills/pack/` (Gmail personal/workspace, Analytics, Business Profile, Calendar, Docs, Drive, Search Console, Sheets, Tag Manager).
+- CLI: `gog update` self-updates the binary from GitHub Releases and refreshes the embedded companion Google skill pack (pack skills only). (#39)
+- CLI: `gog skills status|update|install` discovers pack skills under agent skill roots (`.agents`, `.claude`, `.codex`, etc.), skips locally edited skills by default, and never touches non-pack skills or `learnings/`. (#39)
+- CLI: throttled stderr notice when a newer release is available (`GOG_SKIP_UPDATE_CHECK=1` to disable). (#39)
+- Skills: ship 10 companion skills under `skills/pack/` (Gmail personal/workspace, Analytics, Business Profile, Calendar, Docs, Drive, Search Console, Sheets, Tag Manager). (#39)
+- Analytics: add account and property user access management with `gog analytics admin access-bindings`. (#38)
+- Tag Manager: add account user permission management with `gog gtm user-permissions`. (#38)
 - Docs: `gog docs create` now uses Docs API `documents.create`, returns full document metadata (including `revisionId`), and still supports `--parent` via Drive move.
-- Analytics: add account and property user access management with `gog analytics admin access-bindings`.
-- Tag Manager: add account user permission management with `gog gtm user-permissions`.
 - APIs: add Google BigQuery, Analytics (GA4), Search Console, Tag Manager, YouTube Data API v3, and Business Profile command groups.
 - Gmail: add `gog gmail trash` and `gog gmail labels delete`.
 - Sheets: add batch operations (`batch-get`, `batch-update`) and sheet tab management commands.

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	version = "0.9.0"
+	version = "0.10.0"
 	commit  = ""
 	date    = ""
 )


### PR DESCRIPTION
## Summary
- Version **0.10.0** changelog + default version string.
- Ships `gog update` / companion skill pack from #39.

## Test plan
- [x] CHANGELOG has `## 0.10.0 - 2026-08-07`
- [ ] CI green
- [ ] After merge: tag `v0.10.0` and verify GoReleaser assets