### PR TITLE
chore: Robben-only install/release path and OAuth grant fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,23 @@ Fast, script-friendly CLI for Gmail, Calendar, Chat, Classroom, Drive, Docs, Sli
 
 ## Installation
 
-### Homebrew
+Robben Media maintains this fork independently. Build and install it from the Robben Media repository:
 
 ```bash
-brew install steipete/tap/gogcli
-```
-
-### Build from Source
-
-```bash
-git clone https://github.com/steipete/gogcli.git
+git clone https://github.com/Robben-Media/gogcli.git
 cd gogcli
-make
+make build
+install -m 755 bin/gog ~/.local/bin/gog
 ```
 
-Run:
+Verify the installed binary:
 
 ```bash
-./bin/gog --help
+gog --version
+gog --help
 ```
+
+Upstream Homebrew taps and `go install ...@main` are not supported installation methods for this fork. The retained Go module namespace is an implementation compatibility detail, not an install target.
 
 ### Updates (binary + companion skills)
 
@@ -340,6 +338,12 @@ Service scope matrix (auto-generated; run `go run scripts/gen-auth-services-md.g
 | people | yes | People API | `profile` | OIDC profile scope |
 | groups | no | Cloud Identity API | `https://www.googleapis.com/auth/cloud-identity.groups.readonly` | Workspace only |
 | keep | no | Keep API | `https://www.googleapis.com/auth/keep.readonly` | Workspace only; service account (domain-wide delegation) |
+| youtube | yes | YouTube Data API v3 | `https://www.googleapis.com/auth/youtube.readonly` |  |
+| bigquery | yes | BigQuery API | `https://www.googleapis.com/auth/bigquery`<br>`https://www.googleapis.com/auth/bigquery.readonly` |  |
+| analytics | yes | Analytics Data API, Analytics Admin API | `https://www.googleapis.com/auth/analytics.readonly`<br>`https://www.googleapis.com/auth/analytics.edit`<br>`https://www.googleapis.com/auth/analytics.manage.users.readonly`<br>`https://www.googleapis.com/auth/analytics.manage.users` | Includes manage.users for accessBindings / invite users |
+| searchconsole | yes | Search Console API | `https://www.googleapis.com/auth/webmasters.readonly`<br>`https://www.googleapis.com/auth/webmasters` | Full webmasters scope covers site user permission APIs |
+| tagmanager | yes | Tag Manager API v2 | `https://www.googleapis.com/auth/tagmanager.readonly`<br>`https://www.googleapis.com/auth/tagmanager.edit.containers`<br>`https://www.googleapis.com/auth/tagmanager.edit.containerversions`<br>`https://www.googleapis.com/auth/tagmanager.manage.accounts`<br>`https://www.googleapis.com/auth/tagmanager.manage.users`<br>`https://www.googleapis.com/auth/tagmanager.publish` | Includes manage.users + edit/publish (not delete.containers) |
+| businessprofile | yes | Business Information API, Business Account Management API | `https://www.googleapis.com/auth/business.manage` |  |
 <!-- auth-services:end -->
 
 ### Service Accounts (Workspace only)
@@ -1381,7 +1385,7 @@ Optional env:
 - `GOG_LIVE_SKIP=groups,keep`
 - `GOG_LIVE_AUTH=all,groups`
 - `GOG_LIVE_ALLOW_NONTEST=1`
-- `GOG_LIVE_EMAIL_TEST=steipete+gogtest@gmail.com`
+- `GOG_LIVE_EMAIL_TEST=test-account@example.com` (required for tests that send email)
 - `GOG_LIVE_GROUP_EMAIL=group@domain`
 - `GOG_LIVE_CLASSROOM_COURSE=<courseId>`
 - `GOG_LIVE_CLASSROOM_CREATE=1`
@@ -1413,7 +1417,8 @@ MIT
 
 ## Links
 
-- [GitHub Repository](https://github.com/steipete/gogcli)
+- [Robben Media fork](https://github.com/Robben-Media/gogcli)
+- [Original project by Peter Steinberger](https://github.com/steipete/gogcli)
 - [Gmail API Documentation](https://developers.google.com/gmail/api)
 - [Google Calendar API Documentation](https://developers.google.com/calendar)
 - [Google Drive API Documentation](https://developers.google.com/drive)
@@ -1424,7 +1429,9 @@ MIT
 
 ## Credits
 
-This project is inspired by Mario Zechner's original CLIs:
+This Robben Media fork is based on Peter Steinberger's original [`gogcli`](https://github.com/steipete/gogcli). We are grateful for the foundation he created and retain attribution under the MIT license while maintaining this fork independently going forward.
+
+The original project was inspired by Mario Zechner's CLIs:
 
 - [gmcli](https://github.com/badlogic/gmcli)
 - [gccli](https://github.com/badlogic/gccli)

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Service scope matrix (auto-generated; run `go run scripts/gen-auth-services-md.g
 | youtube | yes | YouTube Data API v3 | `https://www.googleapis.com/auth/youtube.readonly` |  |
 | bigquery | yes | BigQuery API | `https://www.googleapis.com/auth/bigquery`<br>`https://www.googleapis.com/auth/bigquery.readonly` |  |
 | analytics | yes | Analytics Data API, Analytics Admin API | `https://www.googleapis.com/auth/analytics.readonly`<br>`https://www.googleapis.com/auth/analytics.edit`<br>`https://www.googleapis.com/auth/analytics.manage.users.readonly`<br>`https://www.googleapis.com/auth/analytics.manage.users` | Includes manage.users for accessBindings / invite users |
-| searchconsole | yes | Search Console API | `https://www.googleapis.com/auth/webmasters.readonly`<br>`https://www.googleapis.com/auth/webmasters` | Full webmasters scope covers site user permission APIs |
+| searchconsole | yes | Search Console API | `https://www.googleapis.com/auth/webmasters.readonly`<br>`https://www.googleapis.com/auth/webmasters` |  |
 | tagmanager | yes | Tag Manager API v2 | `https://www.googleapis.com/auth/tagmanager.readonly`<br>`https://www.googleapis.com/auth/tagmanager.edit.containers`<br>`https://www.googleapis.com/auth/tagmanager.edit.containerversions`<br>`https://www.googleapis.com/auth/tagmanager.manage.accounts`<br>`https://www.googleapis.com/auth/tagmanager.manage.users`<br>`https://www.googleapis.com/auth/tagmanager.publish` | Includes manage.users + edit/publish (not delete.containers) |
 | businessprofile | yes | Business Information API, Business Account Management API | `https://www.googleapis.com/auth/business.manage` |  |
 <!-- auth-services:end -->

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,110 +1,92 @@
 ---
-summary: "Release checklist for gogcli (GitHub release + Homebrew tap)"
+summary: "Release checklist for the Robben Media gogcli fork"
 ---
 
 # Releasing `gogcli`
 
-This playbook mirrors the Homebrew + GitHub flow used in `../camsnap`.
+Robben Media maintains this fork independently from the original project. Releases come only from `Robben-Media/gogcli`; upstream repositories, taps, and install methods are not part of this process.
 
-Always do **all** steps below (CI + changelog + tag + GitHub release artifacts + tap update + Homebrew sanity install). No partial releases.
+Shortcut scripts:
 
-Shortcut scripts (preferred, keep notes non-empty):
 ```sh
 scripts/release.sh X.Y.Z
 scripts/verify-release.sh X.Y.Z
 ```
 
-Assumptions:
-- Repo: `steipete/gogcli`
-- Tap repo: `../homebrew-tap` (tap: `steipete/tap`)
-- Homebrew formula name: `gogcli` (installs the `gog` binary)
+## 0) Prerequisites
 
-## 0) Prereqs
-- Clean working tree on `main`.
-- Go toolchain installed (Go version comes from `go.mod`).
-- `make` works locally.
-- Access to the tap repo (e.g. `steipete/homebrew-tap`).
+- Repo: `Robben-Media/gogcli`
+- Clean working tree on `main`
+- Go toolchain from `go.mod`
+- GitHub CLI authenticated for the Robben Media repository
+- `make ci` succeeds locally
 
-## 1) Verify build is green
+## 1) Verify the build
+
 ```sh
 make ci
+make build
+./bin/gog --version
 ```
 
-Confirm GitHub Actions `ci` is green for the commit you’re tagging:
+Confirm GitHub Actions `ci` is green for the commit being tagged:
+
 ```sh
-gh run list -L 5 --branch main
+gh run list -L 5 --repo Robben-Media/gogcli --branch main
 ```
 
-## 2) Update changelog
-- Update `CHANGELOG.md` for the version you’re releasing.
+## 2) Update the changelog
 
-Example heading:
-- `## 0.1.0 - 2025-12-12`
+Update `CHANGELOG.md` with a dated section for the release.
 
-## 3) Commit, tag & push
+Example:
+
+```text
+## 0.10.0 - 2026-08-04
+```
+
+## 3) Commit, tag, and push
+
 ```sh
-git checkout main
-git pull
+git switch main
+git pull --ff-only origin main
 
-# commit changelog + any release tweaks
 git commit -am "release: vX.Y.Z"
-
 git tag -a vX.Y.Z -m "Release X.Y.Z"
 git push origin main --tags
 ```
 
-## 4) Verify GitHub release artifacts
-The tag push triggers `.github/workflows/release.yml` (GoReleaser). Ensure it completes successfully and the release has assets.
+## 4) Verify the Robben Media GitHub release
+
+The tag triggers `.github/workflows/release.yml`. Confirm the workflow succeeds, release notes are non-empty, and the expected assets and checksums are present:
 
 ```sh
-gh run list -L 5 --workflow release.yml
-gh release view vX.Y.Z
+gh run list -L 5 --repo Robben-Media/gogcli --workflow release.yml
+gh release view vX.Y.Z --repo Robben-Media/gogcli
 ```
 
-Ensure GitHub release notes are not empty (mirror the changelog section).
+If the workflow supports manual reruns:
 
-If the workflow needs a rerun:
 ```sh
-gh workflow run release.yml -f tag=vX.Y.Z
+gh workflow run release.yml --repo Robben-Media/gogcli -f tag=vX.Y.Z
 ```
 
-## 5) Update (or add) the Homebrew formula
-In the tap repo (assumed sibling at `../homebrew-tap`), create/update `Formula/gogcli.rb`.
+## 5) Verify from Robben source
 
-Recommended formula shape (build-from-source, no binary assets needed):
-- `version "X.Y.Z"`
-- `url "https://github.com/steipete/gogcli/archive/refs/tags/vX.Y.Z.tar.gz"`
-- `sha256 "<sha256>"`
-- `depends_on "go" => :build`
-- Build:
-  - `system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/gog"`
+Run the repository verification script:
 
-Compute the SHA256 for the tag tarball:
 ```sh
-curl -L -o /tmp/gogcli.tar.gz https://github.com/steipete/gogcli/archive/refs/tags/vX.Y.Z.tar.gz
-shasum -a 256 /tmp/gogcli.tar.gz
+scripts/verify-release.sh X.Y.Z
 ```
 
-Commit + push in the tap repo:
+The script validates the changelog, CI, GitHub release, local test suite, and a fresh local build from the Robben Media checkout.
+
+For an operator installation, build from the verified Robben checkout and install the resulting binary:
+
 ```sh
-cd ../homebrew-tap
-git add Formula/gogcli.rb
-git commit -m "gogcli vX.Y.Z"
-git push origin main
+make build
+install -m 755 bin/gog ~/.local/bin/gog
+gog --version
 ```
 
-## 6) Sanity-check install from tap
-```sh
-brew update
-brew uninstall gogcli || true
-brew untap steipete/tap || true
-brew tap steipete/tap
-brew install steipete/tap/gogcli
-brew test steipete/tap/gogcli
-
-gog --help
-```
-
-## Notes
-- `gog` currently does not print a version string; use tags + changelog as the source of truth.
-- If you later add `gog version`, update this doc to validate `gog version` post-install.
+Do not use an upstream Homebrew tap or `go install ...@main`. The retained Go module namespace is an internal compatibility detail, not an installation source.

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,7 +48,7 @@
           <a href="#quickstart">Quickstart</a>
           <a href="#features">Features</a>
           <a href="#examples">Examples</a>
-          <a class="nav__cta" href="https://github.com/steipete/gogcli">GitHub</a>
+          <a class="nav__cta" href="https://github.com/Robben-Media/gogcli">GitHub</a>
         </nav>
       </div>
     </header>
@@ -82,7 +82,7 @@
 
             <div class="hero__actions">
               <a class="btn btn--primary" href="#install">Install</a>
-              <a class="btn btn--ghost" href="https://github.com/steipete/gogcli#quick-start">Readme</a>
+              <a class="btn btn--ghost" href="https://github.com/Robben-Media/gogcli#quick-start">Readme</a>
             </div>
 
             <p class="note">
@@ -102,7 +102,9 @@
               </div>
               <div class="term__body">
                 <pre class="term__pre"><code id="demo">
-$ brew install steipete/tap/gogcli
+$ git clone https://github.com/Robben-Media/gogcli.git
+$ cd gogcli && make build
+$ install -m 755 bin/gog ~/.local/bin/gog
 $ gog auth credentials ~/Downloads/client_secret.json
 $ gog auth add you@gmail.com
 
@@ -136,20 +138,22 @@ $ gog drive ls --query "mimeType='application/pdf'" --max 3
         <div class="wrap section__grid">
           <div>
             <h2>Install</h2>
-            <p class="muted">Homebrew tap, or build from source.</p>
+            <p class="muted">Build and install the independently maintained Robben Media fork.</p>
           </div>
 
           <div class="cols">
             <div class="card block">
-              <h3>Homebrew</h3>
-              <pre class="code"><code>brew install steipete/tap/gogcli</code></pre>
+              <h3>From the Robben Media fork</h3>
+              <pre class="code"><code>git clone https://github.com/Robben-Media/gogcli.git
+cd gogcli
+make build
+install -m 755 bin/gog ~/.local/bin/gog</code></pre>
             </div>
             <div class="card block">
-              <h3>From source</h3>
-              <pre class="code"><code>git clone https://github.com/steipete/gogcli.git
-cd gogcli
-make
-./bin/gog --help</code></pre>
+              <h3>Verify</h3>
+              <pre class="code"><code>gog --version
+gog --help</code></pre>
+              <p class="muted">Upstream Homebrew taps and go-install shortcuts are not supported for this fork.</p>
             </div>
           </div>
         </div>
@@ -264,8 +268,8 @@ gog slides export &lt;presentationId&gt; --format pptx --out ./deck.pptx</code><
           </div>
 
           <div class="footerline">
-            <a class="btn btn--primary" href="https://github.com/steipete/gogcli">Go to GitHub</a>
-            <a class="btn btn--ghost" href="https://github.com/steipete/gogcli/blob/main/CHANGELOG.md">Changelog</a>
+            <a class="btn btn--primary" href="https://github.com/Robben-Media/gogcli">Go to GitHub</a>
+            <a class="btn btn--ghost" href="https://github.com/Robben-Media/gogcli/blob/main/CHANGELOG.md">Changelog</a>
           </div>
         </div>
       </section>
@@ -279,15 +283,15 @@ gog slides export &lt;presentationId&gt; --format pptx --out ./deck.pptx</code><
             <span>gog</span>
           </div>
           <div class="sitefoot__small">
-            <span>Built by <a href="https://steipete.me">Peter Steinberger</a>.</span>
+            <span>Originally created by <a href="https://steipete.me">Peter Steinberger</a>; independently maintained by Robben Media.</span>
             <span class="sep" aria-hidden="true">·</span>
-            <a href="https://github.com/steipete/gogcli/blob/main/LICENSE">MIT</a>
+            <a href="https://github.com/Robben-Media/gogcli/blob/main/LICENSE">MIT</a>
           </div>
         </div>
         <div class="sitefoot__right">
-          <a href="https://github.com/steipete/gogcli">Source</a>
-          <a href="https://github.com/steipete/gogcli#installation">Install</a>
-          <a href="https://github.com/steipete/gogcli#commands">Commands</a>
+          <a href="https://github.com/Robben-Media/gogcli">Source</a>
+          <a href="https://github.com/Robben-Media/gogcli#installation">Install</a>
+          <a href="https://github.com/Robben-Media/gogcli#commands">Commands</a>
         </div>
       </div>
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -510,7 +510,11 @@ func (c *AuthAddCmd) Run(ctx context.Context) error {
 	}
 	driveScope := strings.ToLower(strings.TrimSpace(c.DriveScope))
 	gmailScope := strings.ToLower(strings.TrimSpace(c.GmailScope))
-	disableIncludeGrantedScopes := c.Readonly ||
+	// --force-consent means "grant exactly these scopes". Keeping
+	// include_granted_scopes=true merges historical grants (e.g. old YouTube +
+	// drive.file) and Google can 400 with "scopes that cannot be requested together".
+	disableIncludeGrantedScopes := c.ForceConsent ||
+		c.Readonly ||
 		driveScope == "readonly" ||
 		driveScope == strFile ||
 		gmailScope == "readonly"

--- a/internal/googleauth/oauth_flow.go
+++ b/internal/googleauth/oauth_flow.go
@@ -62,7 +62,8 @@ var (
 
 func Authorize(ctx context.Context, opts AuthorizeOptions) (string, error) {
 	if opts.Timeout <= 0 {
-		opts.Timeout = 2 * time.Minute
+		// Browser consent (especially Workspace multi-scope) often exceeds 2m.
+		opts.Timeout = 10 * time.Minute
 	}
 
 	if len(opts.Scopes) == 0 {

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -219,14 +219,12 @@ var serviceInfoByService = map[Service]serviceInfo{
 		note: "Includes manage.users for accessBindings / invite users",
 	},
 	ServiceSearchConsole: {
-		// webmasters (full) already covers Search Console user/permission APIs.
 		scopes: []string{
 			"https://www.googleapis.com/auth/webmasters.readonly",
 			"https://www.googleapis.com/auth/webmasters",
 		},
 		user: true,
 		apis: []string{"Search Console API"},
-		note: "Full webmasters scope covers site user permission APIs",
 	},
 	ServiceTagManager: {
 		// readonly alone cannot manage users. manage.users is required for

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -205,29 +205,43 @@ var serviceInfoByService = map[Service]serviceInfo{
 		apis: []string{"BigQuery API"},
 	},
 	ServiceAnalytics: {
+		// manage.users* is required for accessBindings / adding users with roles.
+		// edit alone is not enough for user permission APIs; LLMs can call Admin API
+		// with the same refresh token when these scopes are on the grant.
 		scopes: []string{
 			"https://www.googleapis.com/auth/analytics.readonly",
 			"https://www.googleapis.com/auth/analytics.edit",
+			"https://www.googleapis.com/auth/analytics.manage.users.readonly",
 			"https://www.googleapis.com/auth/analytics.manage.users",
 		},
 		user: true,
 		apis: []string{"Analytics Data API", "Analytics Admin API"},
+		note: "Includes manage.users for accessBindings / invite users",
 	},
 	ServiceSearchConsole: {
+		// webmasters (full) already covers Search Console user/permission APIs.
 		scopes: []string{
 			"https://www.googleapis.com/auth/webmasters.readonly",
 			"https://www.googleapis.com/auth/webmasters",
 		},
 		user: true,
 		apis: []string{"Search Console API"},
+		note: "Full webmasters scope covers site user permission APIs",
 	},
 	ServiceTagManager: {
+		// readonly alone cannot manage users. manage.users is required for
+		// account/container user permissions; edit/publish for full GTM ops.
 		scopes: []string{
 			"https://www.googleapis.com/auth/tagmanager.readonly",
+			"https://www.googleapis.com/auth/tagmanager.edit.containers",
+			"https://www.googleapis.com/auth/tagmanager.edit.containerversions",
+			"https://www.googleapis.com/auth/tagmanager.manage.accounts",
 			"https://www.googleapis.com/auth/tagmanager.manage.users",
+			"https://www.googleapis.com/auth/tagmanager.publish",
 		},
 		user: true,
 		apis: []string{"Tag Manager API v2"},
+		note: "Includes manage.users + edit/publish (not delete.containers)",
 	},
 	ServiceBusinessProfile: {
 		scopes: []string{"https://www.googleapis.com/auth/business.manage"},

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -154,6 +154,17 @@ func TestServicesInfo_Metadata(t *testing.T) {
 	}
 }
 
+func TestServicesInfo_SearchConsoleDoesNotClaimUserManagement(t *testing.T) {
+	info, found := findServiceInfo(ServicesInfo(), ServiceSearchConsole)
+	if !found {
+		t.Fatal("missing searchconsole info")
+	}
+
+	if info.Note != "" {
+		t.Fatalf("searchconsole note = %q, want no unsupported user-management claim", info.Note)
+	}
+}
+
 func findServiceInfo(infos []ServiceInfo, svc Service) (ServiceInfo, bool) {
 	for _, info := range infos {
 		if info.Service == svc {

--- a/scripts/live-test.sh
+++ b/scripts/live-test.sh
@@ -31,7 +31,7 @@ Skip keys (base):
   tasks, contacts, people, groups, keep, classroom
 
 Env:
-  GOG_LIVE_EMAIL_TEST=steipete+gogtest@gmail.com
+  GOG_LIVE_EMAIL_TEST=test-account@example.com  # required; no default
   GOG_LIVE_GROUP_EMAIL=<group@domain>
   GOG_LIVE_CLASSROOM_COURSE=<courseId>
   GOG_LIVE_CLASSROOM_CREATE=1
@@ -137,7 +137,11 @@ fi
 
 echo "Using account: $ACCOUNT"
 
-EMAIL_TEST="${GOG_LIVE_EMAIL_TEST:-steipete+gogtest@gmail.com}"
+EMAIL_TEST="${GOG_LIVE_EMAIL_TEST:-}"
+if [ -z "$EMAIL_TEST" ]; then
+  echo "GOG_LIVE_EMAIL_TEST is required for live tests; no external test mailbox is used by default." >&2
+  exit 2
+fi
 TS=$(date +%Y%m%d%H%M%S)
 LIVE_TMP=$(mktemp -d "${TMPDIR:-/tmp}/gog-live-$TS-XXXX")
 trap 'rm -rf "$LIVE_TMP"' EXIT

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -12,7 +12,9 @@ cd "$root"
 
 expected_origin="https://github.com/Robben-Media/gogcli"
 origin="$(git remote get-url origin)"
-if [[ "$origin" != "$expected_origin" && "$origin" != "git@github.com:Robben-Media/gogcli.git" ]]; then
+origin="${origin%/}"
+origin="${origin%.git}"
+if [[ "$origin" != "$expected_origin" && "$origin" != "git@github.com:Robben-Media/gogcli" ]]; then
   echo "unexpected origin: $origin" >&2
   echo "expected the Robben Media fork: $expected_origin" >&2
   exit 2

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -10,6 +10,14 @@ fi
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root"
 
+expected_origin="https://github.com/Robben-Media/gogcli"
+origin="$(git remote get-url origin)"
+if [[ "$origin" != "$expected_origin" && "$origin" != "git@github.com:Robben-Media/gogcli.git" ]]; then
+  echo "unexpected origin: $origin" >&2
+  echo "expected the Robben Media fork: $expected_origin" >&2
+  exit 2
+fi
+
 changelog="CHANGELOG.md"
 if ! rg -q "^## ${version} - " "$changelog"; then
   echo "missing changelog section for $version" >&2
@@ -21,6 +29,8 @@ if rg -q "^## ${version} - Unreleased" "$changelog"; then
 fi
 
 notes_file="$(mktemp -t gogcli-release-notes)"
+trap 'rm -f "$notes_file"' EXIT
+
 awk -v ver="$version" '
   $0 ~ "^## "ver" " {print "## "ver; in_section=1; next}
   in_section && /^## / {exit}
@@ -32,94 +42,32 @@ if [[ ! -s "$notes_file" ]]; then
   exit 2
 fi
 
-release_body="$(gh release view "v$version" --json body -q .body)"
+release_body="$(gh release view "v$version" --repo Robben-Media/gogcli --json body -q .body)"
 if [[ -z "$release_body" ]]; then
   echo "GitHub release notes empty for v$version" >&2
   exit 2
 fi
 
-assets_count="$(gh release view "v$version" --json assets -q '.assets | length')"
+assets_count="$(gh release view "v$version" --repo Robben-Media/gogcli --json assets -q '.assets | length')"
 if [[ "$assets_count" -eq 0 ]]; then
   echo "no GitHub release assets for v$version" >&2
   exit 2
 fi
 
-release_run_id="$(gh run list -L 20 --workflow release.yml --json databaseId,conclusion,headBranch -q ".[] | select(.headBranch==\"v$version\") | select(.conclusion==\"success\") | .databaseId" | head -n1)"
+release_run_id="$(gh run list --repo Robben-Media/gogcli -L 20 --workflow release.yml --json databaseId,conclusion,headBranch -q ".[] | select(.headBranch==\"v$version\") | select(.conclusion==\"success\") | .databaseId" | head -n1)"
 if [[ -z "$release_run_id" ]]; then
   echo "release workflow not green for v$version" >&2
   exit 2
 fi
 
-ci_ok="$(gh run list -L 1 --workflow ci --branch main --json conclusion -q '.[0].conclusion')"
+ci_ok="$(gh run list --repo Robben-Media/gogcli -L 1 --workflow ci --branch main --json conclusion -q '.[0].conclusion')"
 if [[ "$ci_ok" != "success" ]]; then
   echo "CI not green for main" >&2
   exit 2
 fi
 
 make ci
+make build
+./bin/gog --version
 
-formula_path="../homebrew-tap/Formula/gogcli.rb"
-if [[ ! -f "$formula_path" ]]; then
-  echo "missing formula at $formula_path" >&2
-  exit 2
-fi
-
-formula_version="$(awk -F '\"' '/^[[:space:]]*version /{print $2; exit}' "$formula_path" | xargs)"
-if [[ "$formula_version" != "$version" ]]; then
-  echo "formula version mismatch: $formula_version" >&2
-  exit 2
-fi
-
-tmp_assets_dir="$(mktemp -d -t gogcli-release-assets)"
-gh release download "v$version" -p checksums.txt -D "$tmp_assets_dir" >/dev/null
-checksums_file="$tmp_assets_dir/checksums.txt"
-
-sha_for_asset() {
-  local name="$1"
-  awk -v n="$name" '$2==n {print $1}' "$checksums_file"
-}
-
-formula_sha_for_url() {
-  local url_substr="$1"
-  awk -v s="$url_substr" '
-    index($0, s) {found=1; next}
-    found && $1=="sha256" {gsub(/"/, "", $2); print $2; exit}
-  ' "$formula_path"
-}
-
-darwin_amd64_expected="$(sha_for_asset "gogcli_${version}_darwin_amd64.tar.gz")"
-darwin_arm64_expected="$(sha_for_asset "gogcli_${version}_darwin_arm64.tar.gz")"
-linux_amd64_expected="$(sha_for_asset "gogcli_${version}_linux_amd64.tar.gz")"
-linux_arm64_expected="$(sha_for_asset "gogcli_${version}_linux_arm64.tar.gz")"
-
-darwin_amd64_formula="$(formula_sha_for_url "gogcli_#{version}_darwin_amd64.tar.gz")"
-darwin_arm64_formula="$(formula_sha_for_url "gogcli_#{version}_darwin_arm64.tar.gz")"
-linux_amd64_formula="$(formula_sha_for_url "gogcli_#{version}_linux_amd64.tar.gz")"
-linux_arm64_formula="$(formula_sha_for_url "gogcli_#{version}_linux_arm64.tar.gz")"
-
-if [[ "$darwin_amd64_formula" != "$darwin_amd64_expected" ]]; then
-  echo "formula sha mismatch (darwin_amd64): $darwin_amd64_formula (expected $darwin_amd64_expected)" >&2
-  exit 2
-fi
-if [[ "$darwin_arm64_formula" != "$darwin_arm64_expected" ]]; then
-  echo "formula sha mismatch (darwin_arm64): $darwin_arm64_formula (expected $darwin_arm64_expected)" >&2
-  exit 2
-fi
-if [[ "$linux_amd64_formula" != "$linux_amd64_expected" ]]; then
-  echo "formula sha mismatch (linux_amd64): $linux_amd64_formula (expected $linux_amd64_expected)" >&2
-  exit 2
-fi
-if [[ "$linux_arm64_formula" != "$linux_arm64_expected" ]]; then
-  echo "formula sha mismatch (linux_arm64): $linux_arm64_formula (expected $linux_arm64_expected)" >&2
-  exit 2
-fi
-
-brew update >/dev/null
-brew upgrade gogcli || brew install steipete/tap/gogcli
-brew test steipete/tap/gogcli
-gog --version
-
-rm -rf "$tmp_assets_dir"
-rm -f "$notes_file"
-
-echo "Release v$version verified (CI, GitHub release notes/assets, Homebrew install/test)."
+echo "Release v$version verified (Robben origin, CI, GitHub release notes/assets, local build)."


### PR DESCRIPTION
## Summary
- Point install docs, site links, live-test defaults, and release verification at **Robben-Media/gogcli** (drop upstream Homebrew/tap assumptions).
- Expand Analytics / Tag Manager OAuth scopes for admin user APIs and practical GTM ops; regenerate the README scope matrix.
- OAuth UX: `--force-consent` requests exact scopes (no `include_granted_scopes` merge), and browser consent timeout is 10 minutes for multi-scope Workspace grants.

## Test plan
- [x] `go test ./internal/googleauth/ ./internal/cmd/` (CGO_ENABLED=0 on Mini)
- [ ] `make ci` / green Actions on this PR
- [ ] Spot-check `gog auth add --force-consent` still opens consent and completes
- [ ] Confirm `scripts/verify-release.sh` docs match operator flow (no Homebrew)