### PR TITLE
fix(update): harden self-update behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 
+- CLI: keep `gog update` output script-safe, throttle failed release checks, and preserve the existing binary when atomic replacement fails.
 - CLI: correct the shared `--out` flag help for download/export commands (sheets, docs, slides, drive, gmail attachments, chat media) to describe the derived default filename instead of an inaccurate "gogcli config dir". (#37)
 - CLI: make `--plain config list` and `--plain policy list` emit stable TSV for scriptable output. (#26)
 - Calendar: fix recurrence rules with BYDAY parameter (e.g., `BYDAY=MO,TU,WE,TH,FR`). (#120)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,6 +63,13 @@ gh release view vX.Y.Z
 
 Ensure GitHub release notes are not empty (mirror the changelog section).
 
+The companion skill pack ships in two forms from the same source under `skills/pack/`:
+
+- the `SKILL.md` files are present in the tagged Git tree;
+- the same files are embedded in the `gog` binary with `go:embed`.
+
+No separate skill-pack release artifact is required.
+
 If the workflow needs a rerun:
 ```sh
 gh workflow run release.yml -f tag=vX.Y.Z

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -148,10 +148,12 @@ func printSkillResults(ctx context.Context, results []skillpack.ApplyResult) err
 	}
 	if len(dirty) > 0 {
 		fmt.Fprintf(os.Stdout, "skipped (local edits): %s\n", strings.Join(unique(dirty), ", "))
-		fmt.Fprintf(os.Stdout, "Tell the user which skills were skipped and their paths; do not force-overwrite unless they ask.\n")
+		fmt.Fprintln(os.Stderr, "Tell the user which skills were skipped and their paths; do not force-overwrite unless they ask.")
 	}
 	if len(missing) > 0 {
-		fmt.Fprintf(os.Stdout, "not installed: %s — run: gog skills install\n", strings.Join(unique(missing), ", "))
+		missingList := strings.Join(unique(missing), ", ")
+		fmt.Fprintf(os.Stdout, "not installed: %s\n", missingList)
+		fmt.Fprintf(os.Stderr, "gog: skills not installed: %s — run: gog skills install\n", missingList)
 	}
 	if len(updated) == 0 && len(installed) == 0 && len(dirty) == 0 && len(missing) == 0 {
 		fmt.Fprintln(os.Stdout, "all installed pack skills are current")

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -26,15 +26,19 @@ type UpdateCmd struct {
 	SkillsAfterBinary bool `name:"skills-after-binary" hidden:"" help:"Internal: run skills refresh after binary update"`
 }
 
+var newSelfUpdateClient = func() *selfupdate.Client {
+	return &selfupdate.Client{
+		Repo:  strings.TrimSpace(os.Getenv("GOG_UPDATE_REPO")),
+		Token: firstNonEmpty(os.Getenv("GITHUB_TOKEN"), os.Getenv("GH_TOKEN")),
+	}
+}
+
 func (c *UpdateCmd) Run(ctx context.Context) error {
 	if c.SkillsOnly && c.BinaryOnly {
 		return fmt.Errorf("use only one of --skills-only or --binary-only")
 	}
 
-	client := &selfupdate.Client{
-		Repo:  strings.TrimSpace(os.Getenv("GOG_UPDATE_REPO")),
-		Token: firstNonEmpty(os.Getenv("GITHUB_TOKEN"), os.Getenv("GH_TOKEN")),
-	}
+	client := newSelfUpdateClient()
 
 	if c.Check {
 		res, err := selfupdate.Check(ctx, client, version)
@@ -44,6 +48,12 @@ func (c *UpdateCmd) Run(ctx context.Context) error {
 
 		if outfmt.IsJSON(ctx) {
 			return outfmt.WriteJSON(os.Stdout, res)
+		}
+		if outfmt.IsPlain(ctx) {
+			fmt.Fprintln(os.Stdout, "CURRENT\tLATEST\tUPDATE\tASSET")
+			fmt.Fprintf(os.Stdout, "%s\t%s\t%t\t%s\n", res.Current, res.Latest, res.Update, res.Asset)
+
+			return nil
 		}
 
 		if res.Update {

--- a/internal/cmd/update_test.go
+++ b/internal/cmd/update_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/selfupdate"
+)
+
+func TestExecute_UpdateCheckPlainTSV(t *testing.T) {
+	originalClient := newSelfUpdateClient
+	originalVersion := version
+	t.Cleanup(func() {
+		newSelfUpdateClient = originalClient
+		version = originalVersion
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(selfupdate.Release{TagName: "v9.9.9"})
+	}))
+	t.Cleanup(server.Close)
+
+	newSelfUpdateClient = func() *selfupdate.Client {
+		return &selfupdate.Client{BaseURL: server.URL, HTTP: server.Client()}
+	}
+	version = "1.2.3"
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "update", "--check"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	want := "CURRENT\tLATEST\tUPDATE\tASSET\n1.2.3\t9.9.9\ttrue\t" + selfupdate.AssetNameFor("v9.9.9") + "\n"
+	if out != want {
+		t.Fatalf("plain update check output = %q, want %q", out, want)
+	}
+}
+
+func TestExecute_SkillsUpdateWritesInstructionsToStderr(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	dirtySkill := filepath.Join(home, ".agents", "skills", "google-calendar")
+	if err := os.MkdirAll(dirtySkill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirtySkill, "SKILL.md"), []byte("local edit\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr string
+	stdout := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			if err := Execute([]string{"skills", "update"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if strings.Contains(stdout, "run:") || strings.Contains(stdout, "Tell the user") {
+		t.Fatalf("stdout contains instructional text: %q", stdout)
+	}
+	if !strings.Contains(stderr, "run: gog skills install") {
+		t.Fatalf("stderr missing install instruction: %q", stderr)
+	}
+	if !strings.Contains(stderr, "Tell the user which skills were skipped") {
+		t.Fatalf("stderr missing dirty-skill instruction: %q", stderr)
+	}
+}

--- a/internal/selfupdate/apply.go
+++ b/internal/selfupdate/apply.go
@@ -22,6 +22,7 @@ var (
 	errAlreadyLatest    = errors.New("already on latest version")
 	errChecksumMismatch = errors.New("checksum mismatch")
 	errArchiveNoBinary  = errors.New("archive missing gog binary")
+	renameFile          = os.Rename
 )
 
 // ApplyOptions controls binary replacement.
@@ -331,13 +332,13 @@ func replaceExecutable(dest string, data []byte) error {
 	backup := dest + ".bak"
 	_ = os.Remove(backup)
 
-	if runtime.GOOS == "windows" {
-		if err := os.Rename(dest, backup); err != nil && !os.IsNotExist(err) {
+	if runtime.GOOS == goosWindows {
+		if err := renameFile(dest, backup); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("backup current binary: %w", err)
 		}
 
-		if err := os.Rename(tmpName, dest); err != nil {
-			_ = os.Rename(backup, dest)
+		if err := renameFile(tmpName, dest); err != nil {
+			_ = renameFile(backup, dest)
 
 			return fmt.Errorf("replace binary: %w", err)
 		}
@@ -347,13 +348,7 @@ func replaceExecutable(dest string, data []byte) error {
 		return nil
 	}
 
-	if err := os.Rename(tmpName, dest); err != nil {
-		if err2 := os.Remove(dest); err2 == nil {
-			if err3 := os.Rename(tmpName, dest); err3 == nil {
-				return nil
-			}
-		}
-
+	if err := renameFile(tmpName, dest); err != nil {
 		return fmt.Errorf("replace binary: %w", err)
 	}
 

--- a/internal/selfupdate/check_cache.go
+++ b/internal/selfupdate/check_cache.go
@@ -12,12 +12,14 @@ import (
 	"github.com/steipete/gogcli/internal/config"
 )
 
-// CheckCache stores last successful remote version check.
+// CheckCache stores the last remote version check attempt and any successful result.
 type CheckCache struct {
 	CheckedAt time.Time `json:"checked_at"`
 	Latest    string    `json:"latest"`
 	Current   string    `json:"current"`
 }
+
+var isTestProcess = testing.Testing
 
 func checkCachePath() (string, error) {
 	dir, err := config.Dir()
@@ -95,7 +97,7 @@ func MaybeNotify(ctx context.Context, client *Client, current string, interval t
 	}
 
 	// Avoid network during `go test` and when callers set GOG_TEST=1.
-	if testing.Testing() || os.Getenv("GOG_TEST") == "1" {
+	if isTestProcess() || os.Getenv("GOG_TEST") == "1" {
 		return ""
 	}
 
@@ -111,13 +113,20 @@ func MaybeNotify(ctx context.Context, client *Client, current string, interval t
 		return ""
 	}
 
+	checkedAt := time.Now().UTC()
+
 	res, err := Check(ctx, client, current)
 	if err != nil {
+		_ = SaveCheckCache(CheckCache{
+			CheckedAt: checkedAt,
+			Current:   current,
+		})
+
 		return ""
 	}
 
 	_ = SaveCheckCache(CheckCache{
-		CheckedAt: time.Now().UTC(),
+		CheckedAt: checkedAt,
 		Latest:    res.Latest,
 		Current:   current,
 	})

--- a/internal/selfupdate/github.go
+++ b/internal/selfupdate/github.go
@@ -12,7 +12,10 @@ import (
 	"time"
 )
 
-const defaultRepo = "Robben-Media/gogcli"
+const (
+	defaultRepo = "Robben-Media/gogcli"
+	goosWindows = "windows"
+)
 
 var (
 	errReleaseMissingTag = errors.New("release missing tag_name")
@@ -121,7 +124,7 @@ func AssetNameFor(version string) string {
 	goarch := runtime.GOARCH
 	ext := "tar.gz"
 
-	if goos == "windows" {
+	if goos == goosWindows {
 		ext = "zip"
 	}
 

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +17,10 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
+
+var errTestRename = errors.New("rename failed")
 
 func TestNormalizeAndAssetName(t *testing.T) {
 	t.Parallel()
@@ -30,7 +34,7 @@ func TestNormalizeAndAssetName(t *testing.T) {
 		t.Fatalf("asset name: %s", name)
 	}
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		if !strings.HasSuffix(name, ".zip") {
 			t.Fatalf("windows asset should be zip: %s", name)
 		}
@@ -151,5 +155,109 @@ func TestChecksumLineMatch(t *testing.T) {
 
 	if checksumLineMatch("abc  other\n", "file.tar.gz", "abc") {
 		t.Fatal("unexpected match")
+	}
+}
+
+func TestMaybeNotifyThrottlesFailedChecks(t *testing.T) {
+	originalTesting := isTestProcess
+	isTestProcess = func() bool { return false }
+
+	t.Cleanup(func() { isTestProcess = originalTesting })
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GOG_TEST", "")
+	t.Setenv("GOG_SKIP_UPDATE_CHECK", "")
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{BaseURL: server.URL, HTTP: server.Client()}
+
+	if notice := MaybeNotify(context.Background(), client, "1.2.3", time.Hour); notice != "" {
+		t.Fatalf("first notice = %q, want silent failure", notice)
+	}
+
+	if notice := MaybeNotify(context.Background(), client, "1.2.3", time.Hour); notice != "" {
+		t.Fatalf("second notice = %q, want cached silent failure", notice)
+	}
+
+	if requests != 1 {
+		t.Fatalf("release checks = %d, want 1 within throttle interval", requests)
+	}
+}
+
+func TestApplyPreservesExecutableWhenAtomicReplaceFails(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("Unix atomic replacement behavior")
+	}
+
+	originalRename := renameFile
+	renameFile = func(_, _ string) error { return errTestRename }
+
+	t.Cleanup(func() { renameFile = originalRename })
+
+	binaryPayload := []byte("#!/bin/sh\necho replacement\n")
+	var archive bytes.Buffer
+	gz := gzip.NewWriter(&archive)
+
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: "gog", Mode: 0o755, Size: int64(len(binaryPayload))}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := tw.Write(binaryPayload); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assetName := AssetNameFor("v9.9.9")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/Robben-Media/gogcli/releases/latest":
+			_ = json.NewEncoder(w).Encode(Release{
+				TagName: "v9.9.9",
+				Assets:  []Asset{{Name: assetName, BrowserDownloadURL: "http://" + r.Host + "/asset"}},
+			})
+		case "/asset":
+			_, _ = w.Write(archive.Bytes())
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	dest := filepath.Join(t.TempDir(), "gog")
+	if err := os.WriteFile(dest, []byte("original"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Apply(context.Background(), ApplyOptions{
+		Client:     &Client{BaseURL: server.URL, HTTP: server.Client()},
+		CurrentVer: "1.2.3",
+		DestPath:   dest,
+	})
+	if err == nil {
+		t.Fatal("Apply succeeded despite rename failure")
+	}
+
+	got, readErr := os.ReadFile(dest)
+	if readErr != nil {
+		t.Fatalf("read original executable: %v", readErr)
+	}
+
+	if string(got) != "original" {
+		t.Fatalf("original executable = %q, want preserved content", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Preserve the installed binary when an atomic Unix replacement fails.
- Throttle failed background release checks for the configured interval instead of retrying on every command.
- Emit stable TSV for `gog --plain update --check` and keep skill-update instructions on stderr.
- Document that companion skills ship in Git and embedded in the binary, with no separate release artifact.

## Root cause

Follow-up to #39: the Unix fallback removed the destination after a failed rename, failed checks were cached only after success, and plain/instructional output did not honor the CLI stdout contract.

## Verification

- `make ci`
- Focused red/green tests for CLI output, outage throttling, and failed executable replacement
- Two-axis code review against `main`: Standards pass, Spec pass