### PR TITLE
fix(auth): preserve scopes during reauthorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Distribution: use `Robben-Media/gogcli` as the sole install and release source; remove upstream Homebrew/tap assumptions.
-- Auth: request the full Analytics and Tag Manager administration scopes, make `--force-consent` request the exact selected scopes, and allow up to 10 minutes for browser consent.
+- Auth: request the full Analytics and Tag Manager administration scopes, preserve existing scopes during service-specific reauthorization, add explicit `--replace-scopes`, and allow up to 10 minutes for browser consent. (#13)
 
 ## 0.10.0 - 2026-08-07
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ To request fewer scopes:
 gog auth add you@gmail.com --services drive,calendar
 ```
 
-To request read-only scopes (write operations will fail with 403 insufficient scopes):
+To request read-only scopes for a new account:
 
 ```bash
 gog auth add you@gmail.com --services drive,calendar --readonly
@@ -308,13 +308,24 @@ Notes:
 
 - `--drive-scope readonly` is enough for listing/downloading/exporting via Drive (write operations will 403).
 - `--drive-scope file` is write-capable (limited to files created/opened by this app) and can’t be combined with `--readonly`.
+- Reauthorization is additive by default. If the account already has write scopes, `--readonly` retains them; add `--replace-scopes` to intentionally downgrade the grant.
 
-If you need to add services later and Google doesn't return a refresh token, re-run with `--force-consent`:
+To add services later, re-run `auth add` with the additional services. Existing stored scopes are retained. If Google doesn't return a refresh token, add `--force-consent`:
+
+```bash
+gog auth add you@gmail.com --services sheets --force-consent
+```
+
+To intentionally replace the existing grant with exactly the selected services, use `--replace-scopes` (which implies `--force-consent`):
+
+```bash
+gog auth add you@gmail.com --services sheets --replace-scopes
+```
+
+To recover after replacing scopes accidentally, reauthorize with every service the account should retain. For the default user-service set:
 
 ```bash
 gog auth add you@gmail.com --services user --force-consent
-# Or add just Sheets
-gog auth add you@gmail.com --services sheets --force-consent
 ```
 
 `--services all` is accepted as an alias for `user` for backwards compatibility.

--- a/docs/index.html
+++ b/docs/index.html
@@ -202,9 +202,17 @@ gog gmail search 'newer_than:7d' --max 10 --json | jq</code></pre>
               <h3>Re-auth a service (e.g. Sheets)</h3>
               <p>
                 If you add scopes later and Google doesn’t return a refresh token, re-run with
-                <code>--force-consent</code>.
+                <code>--force-consent</code>. Existing stored scopes are retained.
               </p>
               <pre class="code"><code>gog auth add you@gmail.com --services sheets --force-consent</code></pre>
+              <p>
+                To intentionally replace the existing grant with exactly the selected services, use
+                <code>--replace-scopes</code>.
+              </p>
+              <p>
+                To recover after an accidental replacement, reauthorize every service the account should retain;
+                for the default set, run <code>gog auth add you@gmail.com --services user --force-consent</code>.
+              </p>
             </div>
           </div>
         </div>

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -103,12 +103,14 @@ Implementation: `internal/secrets/store.go`.
   - requests `access_type=offline`
   - supports `--force-consent` to force the consent prompt when Google doesn't return a refresh token
   - uses `include_granted_scopes=true` to support incremental auth re-runs
+  - preserves scopes recorded for an existing account when adding services
+  - supports `--replace-scopes` for an explicit exact-scope replacement (implies `--force-consent`)
 
 Scope selection note:
 
 - The consent screen shows the scopes the CLI requested.
 - Users cannot selectively un-check individual requested scopes in the consent screen; they either approve all requested scopes or cancel.
-- To request fewer scopes, choose fewer services via `gog auth add --services ...` or use `gog auth add --readonly` where applicable.
+- For a new account, request fewer scopes with `gog auth add --services ...` or `gog auth add --readonly`. Reauthorization is additive; use `--replace-scopes` to intentionally downgrade an existing grant.
 
 ## Config layout
 
@@ -148,7 +150,7 @@ Flag aliases:
 - `gog auth credentials <credentials.json|->`
 - `gog auth credentials list`
 - `gog --client <name> auth credentials <credentials.json|->`
-- `gog auth add <email> [--services user|all|gmail,calendar,classroom,drive,docs,contacts,tasks,sheets,people,groups] [--readonly] [--drive-scope full|readonly|file] [--manual] [--force-consent]`
+- `gog auth add <email> [--services user|all|gmail,calendar,classroom,drive,docs,contacts,tasks,sheets,people,groups] [--readonly] [--drive-scope full|readonly|file] [--manual] [--force-consent] [--replace-scopes]`
 - `gog auth services [--markdown]`
 - `gog auth keep <email> --key <service-account.json>` (Google Keep; Workspace only)
 - `gog auth list`
@@ -344,7 +346,9 @@ We store a single refresh token per Google account email.
 
 - `gog auth add` requests a union of scopes based on `--services`.
 - Each API client refreshes an access token for the subset of scopes needed for that service.
-- If you later want additional services, re-run `gog auth add <email> --services ...` (may require `--force-consent` to mint a new refresh token).
+- If you later want additional services, re-run `gog auth add <email> --services ...`; stored scopes are retained (and Google may require `--force-consent` to mint a new refresh token).
+- Use `--replace-scopes` only to intentionally replace an existing grant with exactly the selected services.
+- To recover after an accidental replacement, re-run `gog auth add <email> --services user --force-consent` (or list every service the account should retain).
 
 - Gmail: `https://mail.google.com/` (or narrower scopes if we decide later)
 - Calendar: `https://www.googleapis.com/auth/calendar`

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/99designs/keyring"
 
 	"github.com/steipete/gogcli/internal/authclient"
 	"github.com/steipete/gogcli/internal/config"
@@ -479,13 +482,14 @@ func (c *AuthTokensImportCmd) Run(ctx context.Context) error {
 }
 
 type AuthAddCmd struct {
-	Email        string `arg:"" name:"email" help:"Email"`
-	Manual       bool   `name:"manual" help:"Browserless auth flow (paste redirect URL)"`
-	ForceConsent bool   `name:"force-consent" help:"Force consent screen to obtain a refresh token"`
-	ServicesCSV  string `name:"services" help:"Services to authorize: user|all or comma-separated ${auth_services} (Keep uses service account: gog auth service-account set)" default:"user"`
-	Readonly     bool   `name:"readonly" help:"Use read-only scopes where available (still includes OIDC identity scopes)"`
-	DriveScope   string `name:"drive-scope" help:"Drive scope mode: full|readonly|file" enum:"full,readonly,file" default:"full"`
-	GmailScope   string `name:"gmail-scope" help:"Gmail scope mode: full|readonly" enum:"full,readonly" default:"full"`
+	Email         string `arg:"" name:"email" help:"Email"`
+	Manual        bool   `name:"manual" help:"Browserless auth flow (paste redirect URL)"`
+	ForceConsent  bool   `name:"force-consent" help:"Force consent screen to obtain a refresh token"`
+	ReplaceScopes bool   `name:"replace-scopes" help:"Replace an existing grant with exactly --services scopes (implies --force-consent)"`
+	ServicesCSV   string `name:"services" help:"Services to authorize: user|all or comma-separated ${auth_services} (Keep uses service account: gog auth service-account set)" default:"user"`
+	Readonly      bool   `name:"readonly" help:"Use read-only scopes where available (still includes OIDC identity scopes)"`
+	DriveScope    string `name:"drive-scope" help:"Drive scope mode: full|readonly|file" enum:"full,readonly,file" default:"full"`
+	GmailScope    string `name:"gmail-scope" help:"Gmail scope mode: full|readonly" enum:"full,readonly" default:"full"`
 }
 
 func (c *AuthAddCmd) Run(ctx context.Context) error {
@@ -510,14 +514,6 @@ func (c *AuthAddCmd) Run(ctx context.Context) error {
 	}
 	driveScope := strings.ToLower(strings.TrimSpace(c.DriveScope))
 	gmailScope := strings.ToLower(strings.TrimSpace(c.GmailScope))
-	// --force-consent means "grant exactly these scopes". Keeping
-	// include_granted_scopes=true merges historical grants (e.g. old YouTube +
-	// drive.file) and Google can 400 with "scopes that cannot be requested together".
-	disableIncludeGrantedScopes := c.ForceConsent ||
-		c.Readonly ||
-		driveScope == "readonly" ||
-		driveScope == strFile ||
-		gmailScope == "readonly"
 	scopes, err := googleauth.ScopesForManageWithOptions(services, googleauth.ScopeOptions{
 		Readonly:   c.Readonly,
 		DriveScope: googleauth.DriveScopeMode(c.DriveScope),
@@ -531,12 +527,41 @@ func (c *AuthAddCmd) Run(ctx context.Context) error {
 	if keychainErr := ensureKeychainAccessIfNeeded(); keychainErr != nil {
 		return fmt.Errorf("keychain access: %w", keychainErr)
 	}
+	store, err := openSecretsStore()
+	if err != nil {
+		return err
+	}
+
+	existing, existingErr := store.GetToken(client, c.Email)
+	hasExisting := existingErr == nil
+	if existingErr != nil && !errors.Is(existingErr, keyring.ErrKeyNotFound) {
+		return fmt.Errorf("read existing token: %w", existingErr)
+	}
+
+	if hasExisting && !c.ReplaceScopes {
+		services, scopes = googleauth.MergeAuthGrant(services, scopes, existing.Services, existing.Scopes)
+	}
+
+	serviceNames := authServiceNames(services)
+	forceConsent := c.ForceConsent || c.ReplaceScopes
+	// Scope variants must be requested exactly because Google can reject a
+	// historical grant containing incompatible variants (for example old
+	// YouTube scopes plus drive.file). Existing scopes are still explicitly
+	// included above unless the user chose --replace-scopes.
+	disableIncludeGrantedScopes := forceConsent ||
+		c.Readonly ||
+		driveScope == "readonly" ||
+		driveScope == strFile ||
+		gmailScope == "readonly"
+	if c.ReplaceScopes {
+		u.Err().Println("Replacing the existing OAuth grant with exactly the selected services and scopes.")
+	}
 
 	refreshToken, err := authorizeGoogle(ctx, googleauth.AuthorizeOptions{
 		Services:                    services,
 		Scopes:                      scopes,
 		Manual:                      c.Manual,
-		ForceConsent:                c.ForceConsent,
+		ForceConsent:                forceConsent,
 		DisableIncludeGrantedScopes: disableIncludeGrantedScopes,
 		Client:                      client,
 	})
@@ -551,16 +576,6 @@ func (c *AuthAddCmd) Run(ctx context.Context) error {
 	if normalizeEmail(authorizedEmail) != normalizeEmail(c.Email) {
 		return fmt.Errorf("authorized as %s, expected %s", authorizedEmail, c.Email)
 	}
-
-	store, err := openSecretsStore()
-	if err != nil {
-		return err
-	}
-	serviceNames := make([]string, 0, len(services))
-	for _, svc := range services {
-		serviceNames = append(serviceNames, string(svc))
-	}
-	sort.Strings(serviceNames)
 
 	if err := store.SetToken(client, authorizedEmail, secrets.Token{
 		Client:       client,
@@ -595,6 +610,15 @@ func (c *AuthAddCmd) Run(ctx context.Context) error {
 	u.Out().Printf("services\t%s", strings.Join(serviceNames, ","))
 	u.Out().Printf("client\t%s", client)
 	return nil
+}
+
+func authServiceNames(services []googleauth.Service) []string {
+	names := make([]string, 0, len(services))
+	for _, service := range services {
+		names = append(names, string(service))
+	}
+	sort.Strings(names)
+	return names
 }
 
 type AuthListCmd struct {

--- a/internal/cmd/auth_add_test.go
+++ b/internal/cmd/auth_add_test.go
@@ -597,9 +597,173 @@ func TestAuthAddCmd_SheetsDriveScopeFile(t *testing.T) {
 	}
 }
 
+func TestAuthAddCmd_PreservesExistingGrant(t *testing.T) {
+	origAuth := authorizeGoogle
+	origOpen := openSecretsStore
+	origKeychain := ensureKeychainAccess
+	origFetch := fetchAuthorizedEmail
+	t.Cleanup(func() {
+		authorizeGoogle = origAuth
+		openSecretsStore = origOpen
+		ensureKeychainAccess = origKeychain
+		fetchAuthorizedEmail = origFetch
+	})
+
+	ensureKeychainAccess = func() error { return nil }
+	store := newMemSecretsStore()
+	existingServices := []googleauth.Service{googleauth.ServiceGmail, googleauth.ServiceDrive}
+	existingScopes, scopeErr := googleauth.ScopesForManage(existingServices)
+	if scopeErr != nil {
+		t.Fatalf("ScopesForManage: %v", scopeErr)
+	}
+	if err := store.SetToken(config.DefaultClientName, "user@example.com", secrets.Token{
+		Email:        "user@example.com",
+		Services:     []string{"gmail", "drive"},
+		Scopes:       existingScopes,
+		RefreshToken: "old-rt",
+	}); err != nil {
+		t.Fatalf("SetToken: %v", err)
+	}
+	openSecretsStore = func() (secrets.Store, error) { return store, nil }
+
+	var gotOpts googleauth.AuthorizeOptions
+	authorizeGoogle = func(_ context.Context, opts googleauth.AuthorizeOptions) (string, error) {
+		gotOpts = opts
+		gotOpts.Services = append([]googleauth.Service(nil), opts.Services...)
+		gotOpts.Scopes = append([]string(nil), opts.Scopes...)
+		return "new-rt", nil
+	}
+	fetchAuthorizedEmail = func(context.Context, string, string, []string, time.Duration) (string, error) {
+		return "user@example.com", nil
+	}
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "auth", "add", "user@example.com",
+				"--services", "sheets", "--force-consent",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	for _, service := range []googleauth.Service{googleauth.ServiceGmail, googleauth.ServiceDrive, googleauth.ServiceSheets} {
+		if !containsServiceInSlice(gotOpts.Services, service) {
+			t.Fatalf("missing %s from authorization services: %v", service, gotOpts.Services)
+		}
+	}
+	if !containsStringInSlice(gotOpts.Scopes, "https://www.googleapis.com/auth/gmail.modify") {
+		t.Fatalf("existing Gmail scope was not retained: %v", gotOpts.Scopes)
+	}
+	if !containsStringInSlice(gotOpts.Scopes, "https://www.googleapis.com/auth/spreadsheets") {
+		t.Fatalf("new Sheets scope was not requested: %v", gotOpts.Scopes)
+	}
+	if !gotOpts.ForceConsent || !gotOpts.DisableIncludeGrantedScopes {
+		t.Fatalf("unexpected force-consent options: %+v", gotOpts)
+	}
+
+	stored, err := store.GetToken(config.DefaultClientName, "user@example.com")
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if strings.Join(stored.Services, ",") != "drive,gmail,sheets" {
+		t.Fatalf("unexpected stored services: %v", stored.Services)
+	}
+	if !containsStringInSlice(stored.Scopes, "https://www.googleapis.com/auth/gmail.modify") ||
+		!containsStringInSlice(stored.Scopes, "https://www.googleapis.com/auth/spreadsheets") {
+		t.Fatalf("unexpected stored scopes: %v", stored.Scopes)
+	}
+}
+
+func TestAuthAddCmd_ReplaceScopesIsExplicit(t *testing.T) {
+	origAuth := authorizeGoogle
+	origOpen := openSecretsStore
+	origKeychain := ensureKeychainAccess
+	origFetch := fetchAuthorizedEmail
+	t.Cleanup(func() {
+		authorizeGoogle = origAuth
+		openSecretsStore = origOpen
+		ensureKeychainAccess = origKeychain
+		fetchAuthorizedEmail = origFetch
+	})
+
+	ensureKeychainAccess = func() error { return nil }
+	store := newMemSecretsStore()
+	existingScopes, scopeErr := googleauth.ScopesForManage([]googleauth.Service{googleauth.ServiceGmail})
+	if scopeErr != nil {
+		t.Fatalf("ScopesForManage: %v", scopeErr)
+	}
+	if err := store.SetToken(config.DefaultClientName, "user@example.com", secrets.Token{
+		Email:        "user@example.com",
+		Services:     []string{"gmail"},
+		Scopes:       existingScopes,
+		RefreshToken: "old-rt",
+	}); err != nil {
+		t.Fatalf("SetToken: %v", err)
+	}
+	openSecretsStore = func() (secrets.Store, error) { return store, nil }
+
+	var gotOpts googleauth.AuthorizeOptions
+	authorizeGoogle = func(_ context.Context, opts googleauth.AuthorizeOptions) (string, error) {
+		gotOpts = opts
+		gotOpts.Services = append([]googleauth.Service(nil), opts.Services...)
+		gotOpts.Scopes = append([]string(nil), opts.Scopes...)
+		return "new-rt", nil
+	}
+	fetchAuthorizedEmail = func(context.Context, string, string, []string, time.Duration) (string, error) {
+		return "user@example.com", nil
+	}
+
+	var stderr string
+	_ = captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "auth", "add", "user@example.com",
+				"--services", "sheets", "--replace-scopes",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if !gotOpts.ForceConsent || !gotOpts.DisableIncludeGrantedScopes {
+		t.Fatalf("--replace-scopes must force an exact consent request: %+v", gotOpts)
+	}
+	if len(gotOpts.Services) != 1 || gotOpts.Services[0] != googleauth.ServiceSheets {
+		t.Fatalf("unexpected replacement services: %v", gotOpts.Services)
+	}
+	if containsStringInSlice(gotOpts.Scopes, "https://www.googleapis.com/auth/gmail.modify") {
+		t.Fatalf("replacement unexpectedly retained Gmail scope: %v", gotOpts.Scopes)
+	}
+	if !strings.Contains(stderr, "Replacing the existing OAuth grant") {
+		t.Fatalf("missing replacement warning: %q", stderr)
+	}
+
+	stored, err := store.GetToken(config.DefaultClientName, "user@example.com")
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if strings.Join(stored.Services, ",") != "sheets" {
+		t.Fatalf("unexpected stored replacement services: %v", stored.Services)
+	}
+	if containsStringInSlice(stored.Scopes, "https://www.googleapis.com/auth/gmail.modify") {
+		t.Fatalf("stored replacement unexpectedly retained Gmail scope: %v", stored.Scopes)
+	}
+}
+
 func containsStringInSlice(items []string, want string) bool {
 	for _, it := range items {
 		if it == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsServiceInSlice(items []googleauth.Service, want googleauth.Service) bool {
+	for _, item := range items {
+		if item == want {
 			return true
 		}
 	}

--- a/internal/cmd/auth_tokens_more_test.go
+++ b/internal/cmd/auth_tokens_more_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/99designs/keyring"
+
 	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/secrets"
@@ -178,7 +180,7 @@ func (m *memStore) GetToken(client string, email string) (secrets.Token, error) 
 	}
 	tok, ok := m.tokens[client+":"+email]
 	if !ok {
-		return secrets.Token{}, errors.New("not found")
+		return secrets.Token{}, keyring.ErrKeyNotFound
 	}
 	return tok, nil
 }

--- a/internal/errfmt/errfmt.go
+++ b/internal/errfmt/errfmt.go
@@ -65,14 +65,26 @@ func Format(err error) string {
 			reason = gerr.Errors[0].Reason
 		}
 
+		message := fmt.Sprintf("Google API error (%d): %s", gerr.Code, gerr.Message)
 		if reason != "" {
-			return fmt.Sprintf("Google API error (%d %s): %s", gerr.Code, reason, gerr.Message)
+			message = fmt.Sprintf("Google API error (%d %s): %s", gerr.Code, reason, gerr.Message)
 		}
 
-		return fmt.Sprintf("Google API error (%d): %s", gerr.Code, gerr.Message)
+		if gerr.Code == 403 && isInsufficientScopeReason(reason, gerr.Message) {
+			message += "\n\nRe-authorize the account with all required services; for example:\n  gog auth add <email> --services user --force-consent"
+		}
+
+		return message
 	}
 
 	return err.Error()
+}
+
+func isInsufficientScopeReason(reason, message string) bool {
+	combined := strings.ToLower(reason + " " + message)
+
+	return strings.Contains(combined, "insufficientpermissions") ||
+		strings.Contains(combined, "insufficient authentication scope")
 }
 
 // UserFacingError forces a specific message, while preserving the underlying cause.

--- a/internal/errfmt/errfmt_test.go
+++ b/internal/errfmt/errfmt_test.go
@@ -69,7 +69,7 @@ func TestFormat_GoogleAPIError(t *testing.T) {
 	}
 	got := Format(err)
 
-	if !containsAll(got, "403", "insufficientPermissions", "nope") {
+	if !containsAll(got, "403", "insufficientPermissions", "nope", "--services user --force-consent") {
 		t.Fatalf("unexpected: %q", got)
 	}
 }

--- a/internal/googleauth/accounts_server.go
+++ b/internal/googleauth/accounts_server.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/99designs/keyring"
 	"golang.org/x/oauth2"
 
 	"github.com/steipete/gogcli/internal/config"
@@ -281,12 +282,9 @@ func (ms *ManageServer) handleAuthUpgrade(w http.ResponseWriter, r *http.Request
 	}
 	ms.oauthState = state
 
-	// Use requested manage services (exclude Keep)
-	services := manageServices(ms.opts.Services)
-
-	scopes, err := ScopesForManage(services)
+	_, scopes, err := ms.authGrant(email)
 	if err != nil {
-		http.Error(w, "Failed to get scopes", http.StatusInternalServerError)
+		http.Error(w, "Failed to read existing authorization", http.StatusInternalServerError)
 		return
 	}
 
@@ -398,6 +396,14 @@ func (ms *ManageServer) handleOAuthCallback(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	services, scopes, err = ms.authGrant(email)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		renderErrorPage(w, "Failed to read existing authorization: "+err.Error())
+
+		return
+	}
+
 	// Pre-flight: ensure keychain is accessible before storing token
 	needKeychain, err := shouldEnsureKeychainAccess()
 	if err != nil {
@@ -437,6 +443,28 @@ func (ms *ManageServer) handleOAuthCallback(w http.ResponseWriter, r *http.Reque
 	// Render success page with the new template
 	w.WriteHeader(http.StatusOK)
 	renderSuccessPageWithDetails(w, email, serviceNames)
+}
+
+func (ms *ManageServer) authGrant(email string) ([]Service, []string, error) {
+	services := manageServices(ms.opts.Services)
+
+	scopes, err := ScopesForManage(services)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	existing, err := ms.store.GetToken(ms.client, email)
+	if errors.Is(err, keyring.ErrKeyNotFound) {
+		return services, scopes, nil
+	}
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("read existing token: %w", err)
+	}
+
+	services, scopes = MergeAuthGrant(services, scopes, existing.Services, existing.Scopes)
+
+	return services, scopes, nil
 }
 
 func (ms *ManageServer) handleSetDefault(w http.ResponseWriter, r *http.Request) {

--- a/internal/googleauth/accounts_server_test.go
+++ b/internal/googleauth/accounts_server_test.go
@@ -12,11 +12,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/99designs/keyring"
 	"golang.org/x/oauth2"
 
 	"github.com/steipete/gogcli/internal/config"
@@ -57,7 +59,17 @@ func (s *fakeStore) SetToken(client string, email string, tok secrets.Token) err
 
 	return nil
 }
-func (s *fakeStore) GetToken(string, string) (secrets.Token, error) { return secrets.Token{}, nil }
+
+func (s *fakeStore) GetToken(client string, email string) (secrets.Token, error) {
+	for _, token := range s.tokens {
+		if token.Client == client && token.Email == email {
+			return token, nil
+		}
+	}
+
+	return secrets.Token{}, keyring.ErrKeyNotFound
+}
+
 func (s *fakeStore) DeleteToken(client string, email string) error {
 	s.deleteClient = client
 	s.deleteCalled = email
@@ -573,7 +585,15 @@ func TestManageServer_HandleOAuthCallback_Success(t *testing.T) {
 
 	t.Cleanup(func() { _ = ln.Close() })
 
-	store := &fakeStore{}
+	existingScopes, err := ScopesForManage([]Service{ServiceDrive})
+	if err != nil {
+		t.Fatalf("ScopesForManage: %v", err)
+	}
+	store := &fakeStore{tokens: []secrets.Token{{
+		Email:    "me@example.com",
+		Services: []string{"drive"},
+		Scopes:   existingScopes,
+	}}}
 	ms := &ManageServer{
 		oauthState: "state1",
 		listener:   ln,
@@ -598,6 +618,16 @@ func TestManageServer_HandleOAuthCallback_Success(t *testing.T) {
 
 	if store.setTokenValue.RefreshToken != "refresh" {
 		t.Fatalf("expected refresh token stored")
+	}
+
+	if !slices.Contains(store.setTokenValue.Services, "drive") ||
+		!slices.Contains(store.setTokenValue.Services, "gmail") {
+		t.Fatalf("expected existing and requested services, got %v", store.setTokenValue.Services)
+	}
+
+	if !slices.Contains(store.setTokenValue.Scopes, "https://www.googleapis.com/auth/drive") ||
+		!slices.Contains(store.setTokenValue.Scopes, "https://www.googleapis.com/auth/gmail.modify") {
+		t.Fatalf("expected existing and requested scopes, got %v", store.setTokenValue.Scopes)
 	}
 
 	if !strings.Contains(rr.Body.String(), "me@example.com") {
@@ -900,9 +930,19 @@ func TestManageServer_HandleAuthUpgrade(t *testing.T) {
 
 	t.Cleanup(func() { _ = ln.Close() })
 
+	existingScopes, err := ScopesForManage([]Service{ServiceDrive})
+	if err != nil {
+		t.Fatalf("ScopesForManage: %v", err)
+	}
+	store := &fakeStore{tokens: []secrets.Token{{
+		Email:    "test@example.com",
+		Services: []string{"drive"},
+		Scopes:   existingScopes,
+	}}}
 	ms := &ManageServer{
 		listener: ln,
 		opts:     ManageServerOptions{Services: []Service{ServiceGmail}},
+		store:    store,
 	}
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/auth/upgrade?email=test@example.com", nil)
@@ -947,6 +987,10 @@ func TestManageServer_HandleAuthUpgrade(t *testing.T) {
 		if !scopeSet[s] {
 			t.Fatalf("expected scope %q in %q", s, scope)
 		}
+	}
+
+	if !scopeSet["https://www.googleapis.com/auth/drive"] {
+		t.Fatalf("expected existing Drive scope in %q", scope)
 	}
 
 	if scopeSet["https://www.googleapis.com/auth/keep.readonly"] {

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -282,6 +282,63 @@ func manageServices(services []Service) []Service {
 	return filtered
 }
 
+// MergeAuthGrant preserves an existing OAuth grant while adding requested
+// services and scopes. Unknown historical service names are ignored.
+func MergeAuthGrant(
+	requestedServices []Service,
+	requestedScopes []string,
+	existingServices []string,
+	existingScopes []string,
+) ([]Service, []string) {
+	seenServices := make(map[Service]struct{}, len(requestedServices)+len(existingServices))
+
+	services := make([]Service, 0, len(requestedServices)+len(existingServices))
+	for _, service := range requestedServices {
+		if _, ok := seenServices[service]; ok {
+			continue
+		}
+		seenServices[service] = struct{}{}
+		services = append(services, service)
+	}
+
+	for _, name := range existingServices {
+		service, err := ParseService(name)
+		if err != nil || service == ServiceKeep {
+			continue
+		}
+
+		if _, ok := seenServices[service]; ok {
+			continue
+		}
+		seenServices[service] = struct{}{}
+		services = append(services, service)
+	}
+
+	sort.Slice(services, func(i, j int) bool { return services[i] < services[j] })
+
+	seenScopes := make(map[string]struct{}, len(requestedScopes)+len(existingScopes))
+
+	scopes := make([]string, 0, len(requestedScopes)+len(existingScopes))
+	for _, values := range [][]string{requestedScopes, existingScopes} {
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+
+			if _, ok := seenScopes[value]; ok {
+				continue
+			}
+			seenScopes[value] = struct{}{}
+			scopes = append(scopes, value)
+		}
+	}
+
+	sort.Strings(scopes)
+
+	return services, scopes
+}
+
 func AllServices() []Service {
 	out := make([]Service, len(serviceOrder))
 	copy(out, serviceOrder)


### PR DESCRIPTION
## Summary

- preserve existing OAuth services and scopes when reauthorizing through both `gog auth add` and the browser account manager
- add explicit `--replace-scopes` behavior with a warning before OAuth
- keep stored service/scope metadata aligned with the requested grant
- add actionable recovery guidance for insufficient-scope errors and update the auth documentation

## Why

Service-specific reauthorization previously requested and stored only the newly selected service scopes. That could silently discard a multi-service account's existing access. Reauthorization is now additive by default; exact replacement requires an explicit flag.

## Impact

Existing accounts can add or reauthorize a service without unexpectedly breaking other Google service integrations. Users who intentionally want a narrower grant can use `--replace-scopes`, and the documentation explains downgrade and recovery behavior.

## Validation

- `make ci`
- focused auth command tests
- focused OAuth URL and callback storage tests

Closes #13