### PR TITLE
feat(gtm): add version publishing workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Tag Manager: add composable workspace version creation and container-version publishing commands. (#11)
+
 ### Changed
 
 - Distribution: use `Robben-Media/gogcli` as the sole install and release source; remove upstream Homebrew/tap assumptions.

--- a/internal/cmd/tagmanager.go
+++ b/internal/cmd/tagmanager.go
@@ -23,6 +23,7 @@ type TagManagerCmd struct {
 	Triggers        TagManagerTriggersCmd        `cmd:"" name:"triggers" group:"Read" help:"List triggers in a workspace"`
 	Variables       TagManagerVariablesCmd       `cmd:"" name:"variables" group:"Read" help:"List variables in a workspace"`
 	Versions        TagManagerVersionsCmd        `cmd:"" name:"versions" group:"Read" help:"List container version headers"`
+	Workspaces      TagManagerWorkspacesCmd      `cmd:"" name:"workspaces" group:"Write" help:"Manage GTM workspaces"`
 	UserPermissions TagManagerUserPermissionsCmd `cmd:"" name:"user-permissions" group:"Admin" help:"Manage GTM user permissions"`
 }
 
@@ -326,11 +327,16 @@ func (c *TagManagerVariablesCmd) Run(ctx context.Context, flags *RootFlags) erro
 // --- versions ---
 
 type TagManagerVersionsCmd struct {
+	List    TagManagerVersionsListCmd    `cmd:"" default:"withargs" help:"List container version headers"`
+	Publish TagManagerVersionsPublishCmd `cmd:"" name:"publish" help:"Publish a container version"`
+}
+
+type TagManagerVersionsListCmd struct {
 	AccountID   string `name:"account-id" required:"" help:"GTM account ID"`
 	ContainerID string `name:"container-id" required:"" help:"GTM container ID"`
 }
 
-func (c *TagManagerVersionsCmd) Run(ctx context.Context, flags *RootFlags) error {
+func (c *TagManagerVersionsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 	account, err := requireAccount(flags)
 	if err != nil {

--- a/internal/cmd/tagmanager_publishing.go
+++ b/internal/cmd/tagmanager_publishing.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/api/tagmanager/v2"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type TagManagerWorkspacesCmd struct {
+	CreateVersion TagManagerWorkspacesCreateVersionCmd `cmd:"" name:"create-version" help:"Create a container version from a workspace"`
+}
+
+type TagManagerWorkspacesCreateVersionCmd struct {
+	Path  string `arg:"" optional:"" name:"path" help:"Full GTM workspace path"`
+	Name  string `name:"name" help:"Container version name"`
+	Notes string `name:"notes" help:"Container version notes"`
+}
+
+type TagManagerVersionsPublishCmd struct {
+	Path        string `arg:"" optional:"" name:"path" help:"Full GTM container version path"`
+	Fingerprint string `name:"fingerprint" help:"Expected container version fingerprint"`
+}
+
+const tagManagerAccountsPathSegment = "accounts"
+
+func tagManagerWorkspaceResourcePath(value string) (string, error) {
+	path := strings.TrimSpace(value)
+	parts := strings.Split(path, "/")
+	if len(parts) != 6 || parts[0] != tagManagerAccountsPathSegment || strings.TrimSpace(parts[1]) == "" ||
+		parts[2] != "containers" || strings.TrimSpace(parts[3]) == "" ||
+		parts[4] != "workspaces" || strings.TrimSpace(parts[5]) == "" {
+		return "", usage("path must be accounts/ACCOUNT_ID/containers/CONTAINER_ID/workspaces/WORKSPACE_ID")
+	}
+
+	return path, nil
+}
+
+func tagManagerContainerVersionResourcePath(value string) (string, error) {
+	path := strings.TrimSpace(value)
+	parts := strings.Split(path, "/")
+	if len(parts) != 6 || parts[0] != tagManagerAccountsPathSegment || strings.TrimSpace(parts[1]) == "" ||
+		parts[2] != "containers" || strings.TrimSpace(parts[3]) == "" ||
+		parts[4] != "versions" || strings.TrimSpace(parts[5]) == "" {
+		return "", usage("path must be accounts/ACCOUNT_ID/containers/CONTAINER_ID/versions/VERSION_ID")
+	}
+
+	return path, nil
+}
+
+func (c *TagManagerWorkspacesCreateVersionCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	path, err := tagManagerWorkspaceResourcePath(c.Path)
+	if err != nil {
+		return err
+	}
+
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	resp, err := svc.Accounts.Containers.Workspaces.CreateVersion(path, &tagmanager.CreateContainerVersionRequestVersionOptions{
+		Name:  strings.TrimSpace(c.Name),
+		Notes: strings.TrimSpace(c.Notes),
+	}).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	versionPath := ""
+	versionID := ""
+	versionName := ""
+	fingerprint := ""
+	if resp.ContainerVersion != nil {
+		versionPath = resp.ContainerVersion.Path
+		versionID = resp.ContainerVersion.ContainerVersionId
+		versionName = resp.ContainerVersion.Name
+		fingerprint = resp.ContainerVersion.Fingerprint
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"compilerError":    resp.CompilerError,
+			"containerVersion": resp.ContainerVersion,
+			"newWorkspacePath": resp.NewWorkspacePath,
+			"path":             versionPath,
+		})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "PATH\tVERSION_ID\tNAME\tFINGERPRINT\tNEW_WORKSPACE_PATH\tCOMPILER_ERROR")
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%t\n",
+			sanitizeTab(versionPath), sanitizeTab(versionID), sanitizeTab(versionName), sanitizeTab(fingerprint),
+			sanitizeTab(resp.NewWorkspacePath), resp.CompilerError)
+
+		return nil
+	}
+
+	ui.FromContext(ctx).Out().Printf("Created container version: %s", versionPath)
+
+	return nil
+}
+
+func (c *TagManagerVersionsPublishCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	path, err := tagManagerContainerVersionResourcePath(c.Path)
+	if err != nil {
+		return err
+	}
+
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	call := svc.Accounts.Containers.Versions.Publish(path).Context(ctx)
+	if fingerprint := strings.TrimSpace(c.Fingerprint); fingerprint != "" {
+		call = call.Fingerprint(fingerprint)
+	}
+
+	resp, err := call.Do()
+	if err != nil {
+		return err
+	}
+
+	versionPath := ""
+	versionID := ""
+	versionName := ""
+	fingerprint := ""
+	if resp.ContainerVersion != nil {
+		versionPath = resp.ContainerVersion.Path
+		versionID = resp.ContainerVersion.ContainerVersionId
+		versionName = resp.ContainerVersion.Name
+		fingerprint = resp.ContainerVersion.Fingerprint
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"compilerError":    resp.CompilerError,
+			"containerVersion": resp.ContainerVersion,
+			"path":             versionPath,
+		})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "PATH\tVERSION_ID\tNAME\tFINGERPRINT\tCOMPILER_ERROR")
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%t\n",
+			sanitizeTab(versionPath), sanitizeTab(versionID), sanitizeTab(versionName), sanitizeTab(fingerprint), resp.CompilerError)
+
+		return nil
+	}
+
+	ui.FromContext(ctx).Out().Printf("Published container version: %s", versionPath)
+
+	return nil
+}

--- a/internal/cmd/tagmanager_publishing_test.go
+++ b/internal/cmd/tagmanager_publishing_test.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/tagmanager/v2"
+)
+
+func setupTagManagerPublishingTest(t *testing.T, handler http.Handler) {
+	t.Helper()
+
+	original := newTagManagerService
+	t.Cleanup(func() { newTagManagerService = original })
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := tagmanager.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(server.Client()),
+		option.WithEndpoint(server.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	newTagManagerService = func(context.Context, string) (*tagmanager.Service, error) { return service, nil }
+}
+
+func TestExecute_TagManagerWorkspacesCreateVersion(t *testing.T) {
+	setupTagManagerPublishingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/111/containers/c1/workspaces/7:create_version" {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		var body tagmanager.CreateContainerVersionRequestVersionOptions
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Name != "Release 42" || body.Notes != "Publish checkout tracking" {
+			t.Fatalf("unexpected request body: %#v", body)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"containerVersion": {
+				"accountId": "111",
+				"containerId": "c1",
+				"containerVersionId": "42",
+				"name": "Release 42",
+				"path": "accounts/111/containers/c1/versions/42",
+				"fingerprint": "fp-42"
+			},
+			"newWorkspacePath": "accounts/111/containers/c1/workspaces/8"
+		}`))
+	}))
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com", "gtm", "workspaces", "create-version",
+				"accounts/111/containers/c1/workspaces/7",
+				"--name", "Release 42", "--notes", "Publish checkout tracking",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var result struct {
+		Path             string                       `json:"path"`
+		ContainerVersion *tagmanager.ContainerVersion `json:"containerVersion"`
+		NewWorkspacePath string                       `json:"newWorkspacePath"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode output: %v\nout=%q", err, out)
+	}
+	if result.Path != "accounts/111/containers/c1/versions/42" {
+		t.Fatalf("path = %q", result.Path)
+	}
+	if result.ContainerVersion == nil || result.ContainerVersion.ContainerVersionId != "42" {
+		t.Fatalf("unexpected container version: %#v", result.ContainerVersion)
+	}
+	if result.NewWorkspacePath != "accounts/111/containers/c1/workspaces/8" {
+		t.Fatalf("newWorkspacePath = %q", result.NewWorkspacePath)
+	}
+}
+
+func TestExecute_TagManagerVersionsPublish(t *testing.T) {
+	setupTagManagerPublishingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/111/containers/c1/versions/42:publish" {
+			http.NotFound(w, r)
+
+			return
+		}
+		if got := r.URL.Query().Get("fingerprint"); got != "fp-42" {
+			t.Fatalf("fingerprint = %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"containerVersion": {
+				"accountId": "111",
+				"containerId": "c1",
+				"containerVersionId": "42",
+				"name": "Release 42",
+				"path": "accounts/111/containers/c1/versions/42",
+				"fingerprint": "fp-published"
+			}
+		}`))
+	}))
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com", "gtm", "versions", "publish",
+				"accounts/111/containers/c1/versions/42", "--fingerprint", "fp-42",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var result struct {
+		Path             string                       `json:"path"`
+		ContainerVersion *tagmanager.ContainerVersion `json:"containerVersion"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode output: %v\nout=%q", err, out)
+	}
+	if result.Path != "accounts/111/containers/c1/versions/42" {
+		t.Fatalf("path = %q", result.Path)
+	}
+	if result.ContainerVersion == nil || result.ContainerVersion.Fingerprint != "fp-published" {
+		t.Fatalf("unexpected container version: %#v", result.ContainerVersion)
+	}
+}
+
+func TestExecute_TagManagerVersionsPublishPlain(t *testing.T) {
+	setupTagManagerPublishingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/111/containers/c1/versions/42:publish" {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"containerVersion": {
+				"containerVersionId": "42",
+				"name": "Release 42",
+				"path": "accounts/111/containers/c1/versions/42",
+				"fingerprint": "fp-published"
+			}
+		}`))
+	}))
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "admin@example.com", "gtm", "versions", "publish",
+				"accounts/111/containers/c1/versions/42",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	want := "PATH\tVERSION_ID\tNAME\tFINGERPRINT\tCOMPILER_ERROR\n" +
+		"accounts/111/containers/c1/versions/42\t42\tRelease 42\tfp-published\tfalse\n"
+	if out != want {
+		t.Fatalf("plain output:\n%s\nwant:\n%s", out, want)
+	}
+}
+
+func TestExecute_TagManagerWorkspacesCreateVersionPlain(t *testing.T) {
+	setupTagManagerPublishingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/111/containers/c1/workspaces/7:create_version" {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"containerVersion": {
+				"containerVersionId": "42",
+				"name": "Release 42",
+				"path": "accounts/111/containers/c1/versions/42",
+				"fingerprint": "fp-42"
+			},
+			"newWorkspacePath": "accounts/111/containers/c1/workspaces/8"
+		}`))
+	}))
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "admin@example.com", "gtm", "workspaces", "create-version",
+				"accounts/111/containers/c1/workspaces/7",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	want := "PATH\tVERSION_ID\tNAME\tFINGERPRINT\tNEW_WORKSPACE_PATH\tCOMPILER_ERROR\n" +
+		"accounts/111/containers/c1/versions/42\t42\tRelease 42\tfp-42\taccounts/111/containers/c1/workspaces/8\tfalse\n"
+	if out != want {
+		t.Fatalf("plain output:\n%s\nwant:\n%s", out, want)
+	}
+}
+
+func TestExecute_TagManagerPublishingValidatesPathsBeforeAPIRequest(t *testing.T) {
+	original := newTagManagerService
+	t.Cleanup(func() { newTagManagerService = original })
+
+	apiCalled := false
+	unexpectedCallErr := errors.New("unexpected API service creation")
+	newTagManagerService = func(context.Context, string) (*tagmanager.Service, error) {
+		apiCalled = true
+
+		return nil, unexpectedCallErr
+	}
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "workspace path uses workspace resource",
+			args: []string{
+				"--account", "admin@example.com", "gtm", "workspaces", "create-version",
+				"accounts/111/containers/c1/versions/42",
+			},
+			wantErr: "path must be accounts/ACCOUNT_ID/containers/CONTAINER_ID/workspaces/WORKSPACE_ID",
+		},
+		{
+			name: "version path uses version resource",
+			args: []string{
+				"--account", "admin@example.com", "gtm", "versions", "publish",
+				"accounts/111/containers/c1/workspaces/7",
+			},
+			wantErr: "path must be accounts/ACCOUNT_ID/containers/CONTAINER_ID/versions/VERSION_ID",
+		},
+		{
+			name:    "missing version path",
+			args:    []string{"--account", "admin@example.com", "gtm", "versions", "publish"},
+			wantErr: "path must be accounts/ACCOUNT_ID/containers/CONTAINER_ID/versions/VERSION_ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Execute(tt.args)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+
+	if apiCalled {
+		t.Fatal("API service was created for an invalid path")
+	}
+}

--- a/skills/pack/google-tag-manager/SKILL.md
+++ b/skills/pack/google-tag-manager/SKILL.md
@@ -28,6 +28,8 @@ If `gog tag-manager` or `gog gtm` fails with `unexpected argument`, the binary o
 GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com tag-manager accounts
 GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com tag-manager containers --account-id 12345
 GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com tag-manager tags --account-id 12345 --container-id 67890
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com gtm workspaces create-version accounts/12345/containers/67890/workspaces/7 --name "Release"
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com gtm versions publish accounts/12345/containers/67890/versions/42
 ```
 
 ## Available Commands
@@ -41,6 +43,8 @@ GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedi
 | `triggers` | List triggers in a container | `--account-id`, `--container-id`, `--workspace-id` |
 | `variables` | List variables in a container | `--account-id`, `--container-id`, `--workspace-id` |
 | `versions` | List container versions | `--account-id`, `--container-id` |
+| `versions publish` | Publish a container version | `<path>`, `--fingerprint` |
+| `workspaces create-version` | Create a container version from a workspace | `<path>`, `--name`, `--notes` |
 
 ## Resource Paths
 

--- a/specs/features/tagmanager-gaps.md
+++ b/specs/features/tagmanager-gaps.md
@@ -108,7 +108,7 @@ Many resources also accept a full `path` positional arg (e.g. `accounts/123/cont
 - `delete`: confirm destructive, mock DELETE
 - `get`: mock full version payload with nested tags/triggers/variables
 - `live`: mock GET on `live` endpoint
-- `publish`: mock POST, verify fingerprint header if provided
+- `publish`: mock POST, verify fingerprint query parameter if provided
 - `set_latest`/`undelete`: mock POST for each
 - `update`: verify partial update with flagProvided
 


### PR DESCRIPTION
## Summary

- add `gog gtm workspaces create-version <path>` with optional version name and notes
- add `gog gtm versions publish <path>` with optional fingerprint protection
- validate full GTM workspace and container-version resource paths before creating the API service
- provide machine-readable JSON and stable TSV output
- update the changelog, canonical GTM spec, and companion GTM skill

## Why

The CLI exposed GTM reads but lacked the separate create-version and publish operations needed to complete a resource-oriented publishing workflow. Earlier combined-command behavior was not present on `main`; these commands use the exact GTM v2 resource paths instead of guessing a workspace or reconstructing version paths.

## Impact

Users can turn an explicit workspace into a container version and publish that exact version as two composable, scriptable operations.

## Validation

- `make ci`
- focused `httptest` coverage for exact POST paths, request body, fingerprint query parameter, response output, and pre-request path validation
- command help verification for both new commands
- two-axis code review: Standards found no hard violations; Spec passed with no findings

Closes #11