### PR TITLE
feat(gtm): add workspace mutation commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Tag Manager: add workspace trigger and variable create/delete/get/revert/update commands plus built-in-variable management. (#12, #45, #46, #47)
 - Tag Manager: add composable workspace version creation and container-version publishing commands. (#11)
 
 ### Changed

--- a/internal/cmd/tagmanager.go
+++ b/internal/cmd/tagmanager.go
@@ -16,15 +16,16 @@ import (
 var newTagManagerService = googleapi.NewTagManager
 
 type TagManagerCmd struct {
-	Accounts        TagManagerAccountsCmd        `cmd:"" name:"accounts" group:"Read" help:"List GTM accounts"`
-	Containers      TagManagerContainersCmd      `cmd:"" name:"containers" group:"Read" help:"List containers in an account"`
-	Tags            TagManagerTagsCmd            `cmd:"" name:"tags" group:"Read" help:"List tags in a workspace"`
-	Tag             TagManagerTagCmd             `cmd:"" name:"tag" group:"Read" help:"Get a single tag by path"`
-	Triggers        TagManagerTriggersCmd        `cmd:"" name:"triggers" group:"Read" help:"List triggers in a workspace"`
-	Variables       TagManagerVariablesCmd       `cmd:"" name:"variables" group:"Read" help:"List variables in a workspace"`
-	Versions        TagManagerVersionsCmd        `cmd:"" name:"versions" group:"Read" help:"List container version headers"`
-	Workspaces      TagManagerWorkspacesCmd      `cmd:"" name:"workspaces" group:"Write" help:"Manage GTM workspaces"`
-	UserPermissions TagManagerUserPermissionsCmd `cmd:"" name:"user-permissions" group:"Admin" help:"Manage GTM user permissions"`
+	Accounts         TagManagerAccountsCmd         `cmd:"" name:"accounts" group:"Read" help:"List GTM accounts"`
+	BuiltInVariables TagManagerBuiltInVariablesCmd `cmd:"" name:"built-in-variables" group:"Write" help:"Manage built-in variables in a workspace"`
+	Containers       TagManagerContainersCmd       `cmd:"" name:"containers" group:"Read" help:"List containers in an account"`
+	Tags             TagManagerTagsCmd             `cmd:"" name:"tags" group:"Read" help:"List tags in a workspace"`
+	Tag              TagManagerTagCmd              `cmd:"" name:"tag" group:"Read" help:"Get a single tag by path"`
+	Triggers         TagManagerTriggersCmd         `cmd:"" name:"triggers" group:"Write" help:"Manage triggers in a workspace"`
+	Variables        TagManagerVariablesCmd        `cmd:"" name:"variables" group:"Write" help:"Manage variables in a workspace"`
+	Versions         TagManagerVersionsCmd         `cmd:"" name:"versions" group:"Read" help:"List container version headers"`
+	Workspaces       TagManagerWorkspacesCmd       `cmd:"" name:"workspaces" group:"Write" help:"Manage GTM workspaces"`
+	UserPermissions  TagManagerUserPermissionsCmd  `cmd:"" name:"user-permissions" group:"Admin" help:"Manage GTM user permissions"`
 }
 
 func gtmWorkspacePath(accountID, containerID, workspaceID string) string {
@@ -223,12 +224,21 @@ func (c *TagManagerTagCmd) Run(ctx context.Context, flags *RootFlags) error {
 // --- triggers ---
 
 type TagManagerTriggersCmd struct {
+	List   TagManagerTriggersListCmd   `cmd:"" default:"withargs" help:"List triggers in a workspace"`
+	Create TagManagerTriggersCreateCmd `cmd:"" name:"create" help:"Create a trigger"`
+	Delete TagManagerTriggersDeleteCmd `cmd:"" name:"delete" help:"Delete a trigger"`
+	Get    TagManagerTriggersGetCmd    `cmd:"" name:"get" help:"Get a trigger"`
+	Revert TagManagerTriggersRevertCmd `cmd:"" name:"revert" help:"Revert a trigger"`
+	Update TagManagerTriggersUpdateCmd `cmd:"" name:"update" help:"Update a trigger"`
+}
+
+type TagManagerTriggersListCmd struct {
 	AccountID   string `name:"account-id" required:"" help:"GTM account ID"`
 	ContainerID string `name:"container-id" required:"" help:"GTM container ID"`
 	WorkspaceID string `name:"workspace-id" help:"GTM workspace ID (default: 0)" default:"0"`
 }
 
-func (c *TagManagerTriggersCmd) Run(ctx context.Context, flags *RootFlags) error {
+func (c *TagManagerTriggersListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 	account, err := requireAccount(flags)
 	if err != nil {
@@ -275,12 +285,21 @@ func (c *TagManagerTriggersCmd) Run(ctx context.Context, flags *RootFlags) error
 // --- variables ---
 
 type TagManagerVariablesCmd struct {
+	List   TagManagerVariablesListCmd   `cmd:"" default:"withargs" help:"List variables in a workspace"`
+	Create TagManagerVariablesCreateCmd `cmd:"" name:"create" help:"Create a variable"`
+	Delete TagManagerVariablesDeleteCmd `cmd:"" name:"delete" help:"Delete a variable"`
+	Get    TagManagerVariablesGetCmd    `cmd:"" name:"get" help:"Get a variable"`
+	Revert TagManagerVariablesRevertCmd `cmd:"" name:"revert" help:"Revert a variable"`
+	Update TagManagerVariablesUpdateCmd `cmd:"" name:"update" help:"Update a variable"`
+}
+
+type TagManagerVariablesListCmd struct {
 	AccountID   string `name:"account-id" required:"" help:"GTM account ID"`
 	ContainerID string `name:"container-id" required:"" help:"GTM container ID"`
 	WorkspaceID string `name:"workspace-id" help:"GTM workspace ID (default: 0)" default:"0"`
 }
 
-func (c *TagManagerVariablesCmd) Run(ctx context.Context, flags *RootFlags) error {
+func (c *TagManagerVariablesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 	account, err := requireAccount(flags)
 	if err != nil {

--- a/internal/cmd/tagmanager_built_in_variables.go
+++ b/internal/cmd/tagmanager_built_in_variables.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/api/tagmanager/v2"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type TagManagerBuiltInVariablesCmd struct {
+	Create TagManagerBuiltInVariablesCreateCmd `cmd:"" name:"create" help:"Enable built-in variables"`
+	Delete TagManagerBuiltInVariablesDeleteCmd `cmd:"" name:"delete" help:"Disable built-in variables"`
+	List   TagManagerBuiltInVariablesListCmd   `cmd:"" name:"list" help:"List enabled built-in variables"`
+	Revert TagManagerBuiltInVariablesRevertCmd `cmd:"" name:"revert" help:"Revert a built-in variable"`
+}
+
+type TagManagerBuiltInVariablesCreateCmd struct {
+	tagManagerWorkspaceFlags
+	Types []string `name:"type" required:"" sep:"none" help:"Built-in variable type (repeatable)"`
+}
+
+func (c *TagManagerBuiltInVariablesCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, parent, types, err := tagManagerBuiltInRequest(flags, c.tagManagerWorkspaceFlags, c.Types)
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	resp, err := svc.Accounts.Containers.Workspaces.BuiltInVariables.Create(parent).Type(types...).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerBuiltInVariables(ctx, resp.BuiltInVariable, "")
+}
+
+type TagManagerBuiltInVariablesDeleteCmd struct {
+	tagManagerWorkspaceFlags
+	Types []string `name:"type" required:"" sep:"none" help:"Built-in variable type (repeatable)"`
+}
+
+func (c *TagManagerBuiltInVariablesDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, parent, types, err := tagManagerBuiltInRequest(flags, c.tagManagerWorkspaceFlags, c.Types)
+	if err != nil {
+		return err
+	}
+	path := parent + "/built_in_variables"
+	if err = confirmDestructive(ctx, flags, "disable GTM built-in variables "+strings.Join(types, ", ")); err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	if err = svc.Accounts.Containers.Workspaces.BuiltInVariables.Delete(path).Type(types...).Context(ctx).Do(); err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "path": path, "types": types})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "DELETED\tPATH\tTYPES")
+		fmt.Fprintf(w, "true\t%s\t%s\n", path, strings.Join(types, ","))
+		return nil
+	}
+	ui.FromContext(ctx).Out().Printf("Disabled built-in variables: %s", strings.Join(types, ", "))
+	return nil
+}
+
+type TagManagerBuiltInVariablesListCmd struct {
+	tagManagerWorkspaceFlags
+	Page string `name:"page" help:"Page token"`
+}
+
+func (c *TagManagerBuiltInVariablesListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	parent, err := c.parent()
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	call := svc.Accounts.Containers.Workspaces.BuiltInVariables.List(parent).Context(ctx)
+	if page := strings.TrimSpace(c.Page); page != "" {
+		call = call.PageToken(page)
+	}
+	resp, err := call.Do()
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, resp.BuiltInVariable)
+	}
+	return writeTagManagerBuiltInVariables(ctx, resp.BuiltInVariable, resp.NextPageToken)
+}
+
+type TagManagerBuiltInVariablesRevertCmd struct {
+	tagManagerWorkspaceFlags
+	Types []string `name:"type" required:"" sep:"none" help:"Built-in variable type (exactly one)"`
+}
+
+func (c *TagManagerBuiltInVariablesRevertCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if len(c.Types) != 1 {
+		return usage("revert requires exactly one --type")
+	}
+	account, parent, types, err := tagManagerBuiltInRequest(flags, c.tagManagerWorkspaceFlags, c.Types)
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	resp, err := svc.Accounts.Containers.Workspaces.BuiltInVariables.Revert(parent).Type(types[0]).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"type": types[0], "enabled": resp.Enabled})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "TYPE\tENABLED")
+		fmt.Fprintf(w, "%s\t%t\n", types[0], resp.Enabled)
+		return nil
+	}
+	ui.FromContext(ctx).Out().Printf("Reverted built-in variable %s (enabled: %t)", types[0], resp.Enabled)
+	return nil
+}
+
+func tagManagerBuiltInRequest(flags *RootFlags, workspace tagManagerWorkspaceFlags, values []string) (string, string, []string, error) {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return "", "", nil, err
+	}
+	parent, err := workspace.parent()
+	if err != nil {
+		return "", "", nil, err
+	}
+	types := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return "", "", nil, usage("--type must not be blank")
+		}
+		types = append(types, value)
+	}
+	if len(types) == 0 {
+		return "", "", nil, usage("at least one --type is required")
+	}
+	return account, parent, types, nil
+}
+
+func writeTagManagerBuiltInVariables(ctx context.Context, variables []*tagmanager.BuiltInVariable, nextPageToken string) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"builtInVariables": variables, "nextPageToken": nextPageToken})
+	}
+	if len(variables) == 0 {
+		ui.FromContext(ctx).Err().Println("No built-in variables")
+		return nil
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "TYPE\tNAME")
+		for _, variable := range variables {
+			fmt.Fprintf(w, "%s\t%s\n", sanitizeTab(variable.Type), sanitizeTab(variable.Name))
+		}
+		return nil
+	}
+	w, flush := tableWriter(ctx)
+	defer flush()
+	fmt.Fprintln(w, "TYPE\tNAME")
+	for _, variable := range variables {
+		fmt.Fprintf(w, "%s\t%s\n", sanitizeTab(variable.Type), sanitizeTab(variable.Name))
+	}
+	printNextPageHint(ui.FromContext(ctx), nextPageToken)
+	return nil
+}

--- a/internal/cmd/tagmanager_built_in_variables_test.go
+++ b/internal/cmd/tagmanager_built_in_variables_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"google.golang.org/api/tagmanager/v2"
+)
+
+func TestExecute_TagManagerBuiltInVariablesLifecycle(t *testing.T) {
+	collection := "/tagmanager/v2/accounts/111/containers/c1/workspaces/7/built_in_variables"
+	requests := 0
+	setupTagManagerResourceTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == collection:
+			if got := r.URL.Query()["type"]; len(got) != 2 || got[0] != "pageUrl" || got[1] != "clickId" {
+				t.Fatalf("create type query = %#v", got)
+			}
+			_, _ = w.Write([]byte(`{"builtInVariable":[{"path":"accounts/111/containers/c1/workspaces/7/built_in_variables","name":"Page URL","type":"pageUrl"},{"path":"accounts/111/containers/c1/workspaces/7/built_in_variables","name":"Click ID","type":"clickId"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == collection:
+			_, _ = w.Write([]byte(`{"builtInVariable":[{"path":"accounts/111/containers/c1/workspaces/7/built_in_variables","name":"Page URL","type":"pageUrl"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == collection+":revert":
+			if got := r.URL.Query().Get("type"); got != "pageUrl" {
+				t.Fatalf("revert type = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"enabled":true}`))
+		case r.Method == http.MethodDelete && r.URL.Path == collection:
+			if got := r.URL.Query()["type"]; len(got) != 2 || got[0] != "pageUrl" || got[1] != "clickId" {
+				t.Fatalf("delete type query = %#v", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	common := []string{"--account-id", "111", "--container-id", "c1", "--workspace-id", "7"}
+	commands := [][]string{
+		append(append([]string{"--json", "--account", "admin@example.com", "gtm", "built-in-variables", "create"}, common...), "--type", "pageUrl", "--type", "clickId"),
+		append([]string{"--json", "--account", "admin@example.com", "gtm", "built-in-variables", "list"}, common...),
+		append(append([]string{"--json", "--account", "admin@example.com", "gtm", "built-in-variables", "revert"}, common...), "--type", "pageUrl"),
+		append(append([]string{"--json", "--force", "--account", "admin@example.com", "gtm", "built-in-variables", "delete"}, common...), "--type", "pageUrl", "--type", "clickId"),
+	}
+	for index, args := range commands {
+		out := captureStdout(t, func() {
+			_ = captureStderr(t, func() {
+				if err := Execute(args); err != nil {
+					t.Fatalf("Execute(%v): %v", args, err)
+				}
+			})
+		})
+		switch index {
+		case 0:
+			var result struct {
+				BuiltInVariables []map[string]any `json:"builtInVariables"`
+			}
+			if err := json.Unmarshal([]byte(out), &result); err != nil || len(result.BuiltInVariables) != 2 {
+				t.Fatalf("unexpected create output %q: %v", out, err)
+			}
+		case 1:
+			var result []map[string]any
+			if err := json.Unmarshal([]byte(out), &result); err != nil || len(result) != 1 || result[0]["type"] != "pageUrl" {
+				t.Fatalf("unexpected list output %q: %v", out, err)
+			}
+		case 2:
+			var result struct {
+				Type    string `json:"type"`
+				Enabled bool   `json:"enabled"`
+			}
+			if err := json.Unmarshal([]byte(out), &result); err != nil || result.Type != "pageUrl" || !result.Enabled {
+				t.Fatalf("unexpected revert output %q: %v", out, err)
+			}
+		case 3:
+			var result struct {
+				Deleted bool     `json:"deleted"`
+				Types   []string `json:"types"`
+			}
+			if err := json.Unmarshal([]byte(out), &result); err != nil || !result.Deleted || len(result.Types) != 2 {
+				t.Fatalf("unexpected delete output %q: %v", out, err)
+			}
+		}
+	}
+	if requests != 4 {
+		t.Fatalf("requests = %d, want 4", requests)
+	}
+}
+
+func TestExecute_TagManagerBuiltInVariablesRejectsBlankTypeBeforeService(t *testing.T) {
+	original := newTagManagerService
+	t.Cleanup(func() { newTagManagerService = original })
+	called := false
+	newTagManagerService = func(context.Context, string) (*tagmanager.Service, error) {
+		called = true
+		return nil, errors.New("unexpected service construction")
+	}
+	err := Execute([]string{
+		"--account", "admin@example.com", "gtm", "built-in-variables", "create",
+		"--account-id", "111", "--container-id", "c1", "--workspace-id", "7", "--type", " ",
+	})
+	if err == nil {
+		t.Fatal("expected blank type error")
+	}
+	if called {
+		t.Fatal("service constructed for blank type")
+	}
+	called = false
+	err = Execute([]string{
+		"--account", "admin@example.com", "gtm", "built-in-variables", "revert",
+		"--account-id", "111", "--container-id", "c1", "--workspace-id", "7",
+		"--type", "pageUrl", "--type", "clickId",
+	})
+	if err == nil {
+		t.Fatal("expected exactly-one-type error")
+	}
+	if called {
+		t.Fatal("service constructed for multiple revert types")
+	}
+}
+
+func TestExecute_TagManagerBuiltInVariablesDeleteRequiresConfirmation(t *testing.T) {
+	original := newTagManagerService
+	t.Cleanup(func() { newTagManagerService = original })
+	called := false
+	newTagManagerService = func(context.Context, string) (*tagmanager.Service, error) {
+		called = true
+		return nil, errors.New("unexpected service construction")
+	}
+	err := Execute([]string{
+		"--no-input", "--account", "admin@example.com", "gtm", "built-in-variables", "delete",
+		"--account-id", "111", "--container-id", "c1", "--workspace-id", "7", "--type", "pageUrl",
+	})
+	if err == nil {
+		t.Fatal("expected confirmation error")
+	}
+	if called {
+		t.Fatal("service constructed before confirmation")
+	}
+}

--- a/internal/cmd/tagmanager_resources.go
+++ b/internal/cmd/tagmanager_resources.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type tagManagerWorkspaceFlags struct {
+	AccountID   string `name:"account-id" required:"" help:"GTM account ID"`
+	ContainerID string `name:"container-id" required:"" help:"GTM container ID"`
+	WorkspaceID string `name:"workspace-id" help:"GTM workspace ID" default:"0"`
+}
+
+func tagManagerResourceRequest(flags *RootFlags, value, resource, placeholder string) (string, string, error) {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return "", "", err
+	}
+	path, err := tagManagerWorkspaceEntityPath(value, resource, placeholder)
+	if err != nil {
+		return "", "", err
+	}
+	return account, path, nil
+}
+
+func (f tagManagerWorkspaceFlags) parent() (string, error) {
+	accountID := strings.TrimSpace(f.AccountID)
+	containerID := strings.TrimSpace(f.ContainerID)
+	workspaceID := strings.TrimSpace(f.WorkspaceID)
+	if accountID == "" || strings.Contains(accountID, "/") {
+		return "", usage("--account-id must be a GTM account ID")
+	}
+	if containerID == "" || strings.Contains(containerID, "/") {
+		return "", usage("--container-id must be a GTM container ID")
+	}
+	if workspaceID == "" || strings.Contains(workspaceID, "/") {
+		return "", usage("--workspace-id must be a GTM workspace ID")
+	}
+
+	return gtmWorkspacePath(accountID, containerID, workspaceID), nil
+}
+
+func tagManagerWorkspaceEntityPath(value, resource, placeholder string) (string, error) {
+	path := strings.TrimSpace(value)
+	parts := strings.Split(path, "/")
+	if len(parts) != 8 || parts[0] != tagManagerAccountsPathSegment || strings.TrimSpace(parts[1]) == "" ||
+		parts[2] != "containers" || strings.TrimSpace(parts[3]) == "" ||
+		parts[4] != "workspaces" || strings.TrimSpace(parts[5]) == "" ||
+		parts[6] != resource || strings.TrimSpace(parts[7]) == "" {
+		return "", usagef("path must be accounts/ACCOUNT_ID/containers/CONTAINER_ID/workspaces/WORKSPACE_ID/%s/%s", resource, placeholder)
+	}
+
+	return path, nil
+}
+
+func parseTagManagerJSONObjects[T any](flagName string, values []string) ([]*T, error) {
+	items := make([]*T, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if !strings.HasPrefix(value, "{") {
+			return nil, usagef("--%s must be a JSON object", flagName)
+		}
+		var item T
+		if err := json.Unmarshal([]byte(value), &item); err != nil {
+			return nil, usagef("invalid --%s JSON: %v", flagName, err)
+		}
+		items = append(items, &item)
+	}
+
+	return items, nil
+}
+
+func parseTagManagerJSONObject[T any](flagName, value string) (*T, error) {
+	items, err := parseTagManagerJSONObjects[T](flagName, []string{value})
+	if err != nil {
+		return nil, err
+	}
+	return items[0], nil
+}
+
+func writeTagManagerDelete(ctx context.Context, resource, path string) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "path": path})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "DELETED\tPATH")
+		fmt.Fprintf(w, "true\t%s\n", path)
+		return nil
+	}
+	ui.FromContext(ctx).Out().Printf("Deleted %s: %s", resource, path)
+	return nil
+}

--- a/internal/cmd/tagmanager_resources_test.go
+++ b/internal/cmd/tagmanager_resources_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/tagmanager/v2"
+)
+
+func TestExecute_TagManagerMutationsValidateBeforeService(t *testing.T) {
+	original := newTagManagerService
+	t.Cleanup(func() { newTagManagerService = original })
+	called := false
+	newTagManagerService = func(context.Context, string) (*tagmanager.Service, error) {
+		called = true
+		return nil, errors.New("unexpected service construction")
+	}
+
+	tests := [][]string{
+		{"--account", "admin@example.com", "gtm", "triggers", "get", "accounts/111/containers/c1/workspaces/7/variables/3"},
+		{"--account", "admin@example.com", "gtm", "triggers", "update", "accounts/111/containers/c1/workspaces/7/triggers/9"},
+		{"--account", "admin@example.com", "gtm", "variables", "update", "accounts/111/containers/c1/workspaces/7/variables/3"},
+		{"--account", "admin@example.com", "gtm", "triggers", "create", "--account-id", "111", "--container-id", "c1", "--name", "Bad", "--type", "pageview", "--filter", "null"},
+		{"--account", "admin@example.com", "gtm", "variables", "create", "--account-id", "111", "--container-id", "c1", "--name", "Bad", "--type", "c", "--parameter", "null"},
+	}
+	for _, args := range tests {
+		if err := Execute(args); err == nil {
+			t.Fatalf("Execute(%v) unexpectedly succeeded", args)
+		}
+	}
+	if called {
+		t.Fatal("service constructed before mutation input validation")
+	}
+}
+
+func TestExecute_TagManagerMutationPlainOutput(t *testing.T) {
+	setupTagManagerResourceTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/triggers/9"):
+			_, _ = w.Write([]byte(`{"triggerId":"9","name":"Page","type":"pageview"}`))
+		case strings.HasSuffix(r.URL.Path, "/variables/3"):
+			_, _ = w.Write([]byte(`{"variableId":"3","name":"Constant","type":"c"}`))
+		case strings.HasSuffix(r.URL.Path, "/built_in_variables"):
+			_, _ = w.Write([]byte(`{"builtInVariable":[{"name":"Page URL","type":"pageUrl"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{[]string{"--plain", "--account", "admin@example.com", "gtm", "triggers", "get", "accounts/111/containers/c1/workspaces/7/triggers/9"}, "TRIGGER_ID\tNAME\tTYPE\n9\tPage\tpageview\n"},
+		{[]string{"--plain", "--account", "admin@example.com", "gtm", "variables", "get", "accounts/111/containers/c1/workspaces/7/variables/3"}, "VARIABLE_ID\tNAME\tTYPE\n3\tConstant\tc\n"},
+		{[]string{"--plain", "--account", "admin@example.com", "gtm", "built-in-variables", "list", "--account-id", "111", "--container-id", "c1", "--workspace-id", "7"}, "TYPE\tNAME\npageUrl\tPage URL\n"},
+	}
+	for _, tt := range tests {
+		got := captureStdout(t, func() {
+			_ = captureStderr(t, func() {
+				if err := Execute(tt.args); err != nil {
+					t.Fatalf("Execute(%v): %v", tt.args, err)
+				}
+			})
+		})
+		if got != tt.want {
+			t.Fatalf("Execute(%v) output = %q, want %q", tt.args, got, tt.want)
+		}
+	}
+}

--- a/internal/cmd/tagmanager_triggers_edit.go
+++ b/internal/cmd/tagmanager_triggers_edit.go
@@ -1,0 +1,272 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"google.golang.org/api/tagmanager/v2"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type TagManagerTriggersCreateCmd struct {
+	tagManagerWorkspaceFlags
+	Name              string   `name:"name" required:"" help:"Trigger name"`
+	Type              string   `name:"type" required:"" help:"GTM trigger type"`
+	Filter            []string `name:"filter" sep:"none" help:"GTM Condition JSON object (repeatable)"`
+	AutoEventFilter   []string `name:"auto-event-filter" sep:"none" help:"GTM auto-event Condition JSON object (repeatable)"`
+	CustomEventFilter []string `name:"custom-event-filter" sep:"none" help:"GTM custom-event Condition JSON object (repeatable)"`
+	EventName         string   `name:"event-name" help:"GTM timer event-name Parameter JSON object"`
+	Interval          string   `name:"interval" help:"GTM timer interval Parameter JSON object"`
+	Limit             string   `name:"limit" help:"GTM timer limit Parameter JSON object"`
+}
+
+func (c *TagManagerTriggersCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	parent, err := c.parent()
+	if err != nil {
+		return err
+	}
+	trigger, err := c.input()
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	created, err := svc.Accounts.Containers.Workspaces.Triggers.Create(parent, trigger).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerTrigger(ctx, "Created", created)
+}
+
+func (c *TagManagerTriggersCreateCmd) input() (*tagmanager.Trigger, error) {
+	name, triggerType := strings.TrimSpace(c.Name), strings.TrimSpace(c.Type)
+	if name == "" || triggerType == "" {
+		return nil, usage("--name and --type must not be empty")
+	}
+	filters, err := parseTagManagerJSONObjects[tagmanager.Condition]("filter", c.Filter)
+	if err != nil {
+		return nil, err
+	}
+	autoEventFilters, err := parseTagManagerJSONObjects[tagmanager.Condition]("auto-event-filter", c.AutoEventFilter)
+	if err != nil {
+		return nil, err
+	}
+	customEventFilters, err := parseTagManagerJSONObjects[tagmanager.Condition]("custom-event-filter", c.CustomEventFilter)
+	if err != nil {
+		return nil, err
+	}
+	var eventName, interval, limit *tagmanager.Parameter
+	if strings.TrimSpace(c.EventName) != "" {
+		eventName, err = parseTagManagerJSONObject[tagmanager.Parameter]("event-name", c.EventName)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if strings.TrimSpace(c.Interval) != "" {
+		interval, err = parseTagManagerJSONObject[tagmanager.Parameter]("interval", c.Interval)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if strings.TrimSpace(c.Limit) != "" {
+		limit, err = parseTagManagerJSONObject[tagmanager.Parameter]("limit", c.Limit)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &tagmanager.Trigger{
+		Name: name, Type: triggerType, Filter: filters, AutoEventFilter: autoEventFilters,
+		CustomEventFilter: customEventFilters, EventName: eventName, Interval: interval, Limit: limit,
+	}, nil
+}
+
+type TagManagerTriggersGetCmd struct {
+	Path string `arg:"" name:"path" help:"Full GTM trigger path"`
+}
+
+func (c *TagManagerTriggersGetCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, path, err := tagManagerResourceRequest(flags, c.Path, "triggers", "TRIGGER_ID")
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	trigger, err := svc.Accounts.Containers.Workspaces.Triggers.Get(path).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerTrigger(ctx, "Trigger", trigger)
+}
+
+type TagManagerTriggersDeleteCmd struct {
+	Path string `arg:"" name:"path" help:"Full GTM trigger path"`
+}
+
+func (c *TagManagerTriggersDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, path, err := tagManagerResourceRequest(flags, c.Path, "triggers", "TRIGGER_ID")
+	if err != nil {
+		return err
+	}
+	if err = confirmDestructive(ctx, flags, "delete GTM trigger "+path); err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	if err = svc.Accounts.Containers.Workspaces.Triggers.Delete(path).Context(ctx).Do(); err != nil {
+		return err
+	}
+	return writeTagManagerDelete(ctx, "trigger", path)
+}
+
+type TagManagerTriggersRevertCmd struct {
+	Path string `arg:"" name:"path" help:"Full GTM trigger path"`
+}
+
+func (c *TagManagerTriggersRevertCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, path, err := tagManagerResourceRequest(flags, c.Path, "triggers", "TRIGGER_ID")
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	resp, err := svc.Accounts.Containers.Workspaces.Triggers.Revert(path).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerTrigger(ctx, "Reverted", resp.Trigger)
+}
+
+type TagManagerTriggersUpdateCmd struct {
+	Path              string   `arg:"" name:"path" help:"Full GTM trigger path"`
+	Name              string   `name:"name" help:"Trigger name"`
+	Type              string   `name:"type" help:"GTM trigger type"`
+	Filter            []string `name:"filter" sep:"none" help:"GTM Condition JSON object (repeatable)"`
+	AutoEventFilter   []string `name:"auto-event-filter" sep:"none" help:"GTM auto-event Condition JSON object (repeatable)"`
+	CustomEventFilter []string `name:"custom-event-filter" sep:"none" help:"GTM custom-event Condition JSON object (repeatable)"`
+	EventName         string   `name:"event-name" help:"GTM timer event-name Parameter JSON object"`
+	Interval          string   `name:"interval" help:"GTM timer interval Parameter JSON object"`
+	Limit             string   `name:"limit" help:"GTM timer limit Parameter JSON object"`
+}
+
+func (c *TagManagerTriggersUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	account, path, err := tagManagerResourceRequest(flags, c.Path, "triggers", "TRIGGER_ID")
+	if err != nil {
+		return err
+	}
+	if !flagProvidedAny(kctx, "name", "type", "filter", "auto-event-filter", "custom-event-filter", "event-name", "interval", "limit") {
+		return usage("at least one trigger field flag is required")
+	}
+	apply, err := c.buildPatch(kctx)
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	trigger, err := svc.Accounts.Containers.Workspaces.Triggers.Get(path).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	apply(trigger)
+	updated, err := svc.Accounts.Containers.Workspaces.Triggers.Update(path, trigger).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerTrigger(ctx, "Updated", updated)
+}
+
+func (c *TagManagerTriggersUpdateCmd) buildPatch(kctx *kong.Context) (func(*tagmanager.Trigger), error) {
+	if flagProvided(kctx, "name") && strings.TrimSpace(c.Name) == "" {
+		return nil, usage("--name must not be blank")
+	}
+	if flagProvided(kctx, "type") && strings.TrimSpace(c.Type) == "" {
+		return nil, usage("--type must not be blank")
+	}
+	conditions := make(map[string][]*tagmanager.Condition)
+	for name, values := range map[string][]string{
+		"filter": c.Filter, "auto-event-filter": c.AutoEventFilter, "custom-event-filter": c.CustomEventFilter,
+	} {
+		if flagProvided(kctx, name) {
+			parsed, err := parseTagManagerJSONObjects[tagmanager.Condition](name, values)
+			if err != nil {
+				return nil, err
+			}
+			conditions[name] = parsed
+		}
+	}
+	parameters := make(map[string]*tagmanager.Parameter)
+	for name, value := range map[string]string{"event-name": c.EventName, "interval": c.Interval, "limit": c.Limit} {
+		if flagProvided(kctx, name) {
+			parsed, err := parseTagManagerJSONObject[tagmanager.Parameter](name, value)
+			if err != nil {
+				return nil, err
+			}
+			parameters[name] = parsed
+		}
+	}
+	return func(trigger *tagmanager.Trigger) {
+		if flagProvided(kctx, "name") {
+			trigger.Name = strings.TrimSpace(c.Name)
+		}
+		if flagProvided(kctx, "type") {
+			trigger.Type = strings.TrimSpace(c.Type)
+		}
+		if value, ok := conditions["filter"]; ok {
+			trigger.Filter = value
+		}
+		if value, ok := conditions["auto-event-filter"]; ok {
+			trigger.AutoEventFilter = value
+		}
+		if value, ok := conditions["custom-event-filter"]; ok {
+			trigger.CustomEventFilter = value
+		}
+		if value, ok := parameters["event-name"]; ok {
+			trigger.EventName = value
+		}
+		if value, ok := parameters["interval"]; ok {
+			trigger.Interval = value
+		}
+		if value, ok := parameters["limit"]; ok {
+			trigger.Limit = value
+		}
+	}, nil
+}
+
+func writeTagManagerTrigger(ctx context.Context, action string, trigger *tagmanager.Trigger) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"trigger": trigger})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "TRIGGER_ID\tNAME\tTYPE")
+		if trigger != nil {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", sanitizeTab(trigger.TriggerId), sanitizeTab(trigger.Name), sanitizeTab(trigger.Type))
+		}
+		return nil
+	}
+	if trigger == nil {
+		ui.FromContext(ctx).Out().Printf("%s trigger: no published version", action)
+		return nil
+	}
+	ui.FromContext(ctx).Out().Printf("%s trigger: %s", action, trigger.Path)
+	return nil
+}

--- a/internal/cmd/tagmanager_triggers_edit_test.go
+++ b/internal/cmd/tagmanager_triggers_edit_test.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/tagmanager/v2"
+)
+
+func setupTagManagerResourceTest(t *testing.T, handler http.Handler) {
+	t.Helper()
+
+	original := newTagManagerService
+	t.Cleanup(func() { newTagManagerService = original })
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := tagmanager.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(server.Client()),
+		option.WithEndpoint(server.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	newTagManagerService = func(context.Context, string) (*tagmanager.Service, error) { return service, nil }
+}
+
+func TestExecute_TagManagerTriggersCreate(t *testing.T) {
+	setupTagManagerResourceTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/111/containers/c1/workspaces/7/triggers" {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		var body tagmanager.Trigger
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Name != "Checkout" || body.Type != "customEvent" || len(body.Filter) != 1 || len(body.CustomEventFilter) != 1 {
+			t.Fatalf("unexpected trigger: %#v", body)
+		}
+		if body.Filter[0].Type != "equals" || body.Filter[0].Parameter[0].Key != "arg0" || body.Filter[0].Parameter[0].Type != "template" {
+			t.Fatalf("unexpected filter: %#v", body.Filter[0])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"path":"accounts/111/containers/c1/workspaces/7/triggers/9","triggerId":"9","name":"Checkout","type":"customEvent"}`))
+	}))
+
+	filter := `{"type":"equals","parameter":[{"type":"template","key":"arg0","value":"{{Page URL}}"},{"type":"template","key":"arg1","value":"https://example.com"}]}`
+	customEventFilter := `{"type":"matchRegex","parameter":[{"type":"template","key":"arg0","value":"{{Event}}"},{"type":"template","key":"arg1","value":"^checkout$"}]}`
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com", "gtm", "triggers", "create",
+				"--account-id", "111", "--container-id", "c1", "--workspace-id", "7",
+				"--name", "Checkout", "--type", "customEvent",
+				"--filter", filter, "--custom-event-filter", customEventFilter,
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var result struct {
+		Trigger *tagmanager.Trigger `json:"trigger"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if result.Trigger == nil || result.Trigger.TriggerId != "9" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestExecute_TagManagerTriggerConfigurations(t *testing.T) {
+	setupTagManagerResourceTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body tagmanager.Trigger
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		switch body.Type {
+		case "click":
+			if len(body.AutoEventFilter) != 1 || body.AutoEventFilter[0].Parameter[0].Type != "template" {
+				t.Fatalf("click filter not preserved: %#v", body)
+			}
+		case "timer":
+			if body.EventName == nil || body.Interval == nil || body.Limit == nil || body.Interval.Type != "template" {
+				t.Fatalf("timer parameters not preserved: %#v", body)
+			}
+		default:
+			t.Fatalf("unexpected trigger type: %q", body.Type)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+
+	autoEventFilter := `{"type":"equals","parameter":[{"type":"template","key":"arg0","value":"{{Click ID}}"},{"type":"template","key":"arg1","value":"buy"}]}`
+	parameter := `{"type":"template","value":"value"}`
+	for _, args := range [][]string{
+		{"--json", "--account", "admin@example.com", "gtm", "triggers", "create", "--account-id", "111", "--container-id", "c1", "--name", "Click", "--type", "click", "--auto-event-filter", autoEventFilter},
+		{"--json", "--account", "admin@example.com", "gtm", "triggers", "create", "--account-id", "111", "--container-id", "c1", "--name", "Timer", "--type", "timer", "--event-name", parameter, "--interval", parameter, "--limit", parameter},
+	} {
+		captureStdout(t, func() {
+			_ = captureStderr(t, func() {
+				if err := Execute(args); err != nil {
+					t.Fatalf("Execute(%v): %v", args, err)
+				}
+			})
+		})
+	}
+}
+
+func TestExecute_TagManagerTriggersLifecycle(t *testing.T) {
+	path := "/tagmanager/v2/accounts/111/containers/c1/workspaces/7/triggers/9"
+	requests := 0
+	setupTagManagerResourceTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == path:
+			_, _ = w.Write([]byte(`{"path":"accounts/111/containers/c1/workspaces/7/triggers/9","triggerId":"9","name":"Old","type":"pageview"}`))
+		case r.Method == http.MethodPut && r.URL.Path == path:
+			var body tagmanager.Trigger
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode update: %v", err)
+			}
+			if body.Name != "New" || body.Type != "pageview" {
+				t.Fatalf("partial update lost fields: %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"path":"accounts/111/containers/c1/workspaces/7/triggers/9","triggerId":"9","name":"New","type":"pageview"}`))
+		case r.Method == http.MethodPost && r.URL.Path == path+":revert":
+			_, _ = w.Write([]byte(`{"trigger":{"path":"accounts/111/containers/c1/workspaces/7/triggers/9","triggerId":"9","name":"Published","type":"pageview"}}`))
+		case r.Method == http.MethodDelete && r.URL.Path == path:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	resource := "accounts/111/containers/c1/workspaces/7/triggers/9"
+	for _, args := range [][]string{
+		{"--json", "--account", "admin@example.com", "gtm", "triggers", "get", resource},
+		{"--json", "--account", "admin@example.com", "gtm", "triggers", "update", resource, "--name", "New"},
+		{"--json", "--account", "admin@example.com", "gtm", "triggers", "revert", resource},
+		{"--json", "--force", "--account", "admin@example.com", "gtm", "triggers", "delete", resource},
+	} {
+		captureStdout(t, func() {
+			_ = captureStderr(t, func() {
+				if err := Execute(args); err != nil {
+					t.Fatalf("Execute(%v): %v", args, err)
+				}
+			})
+		})
+	}
+	if requests != 5 { // update reads the current trigger before replacing it.
+		t.Fatalf("requests = %d, want 5", requests)
+	}
+}
+
+func TestExecute_TagManagerTriggersDeleteRequiresConfirmation(t *testing.T) {
+	called := false
+	setupTagManagerResourceTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+	err := Execute([]string{
+		"--json", "--no-input", "--account", "admin@example.com", "gtm", "triggers", "delete",
+		"accounts/111/containers/c1/workspaces/7/triggers/9",
+	})
+	if err == nil {
+		t.Fatal("expected confirmation error")
+	}
+	if called {
+		t.Fatal("API called before confirmation")
+	}
+}

--- a/internal/cmd/tagmanager_variables_edit.go
+++ b/internal/cmd/tagmanager_variables_edit.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"google.golang.org/api/tagmanager/v2"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type TagManagerVariablesCreateCmd struct {
+	tagManagerWorkspaceFlags
+	Name       string   `name:"name" required:"" help:"Variable name"`
+	Type       string   `name:"type" required:"" help:"GTM variable type"`
+	Parameters []string `name:"parameter" sep:"none" help:"GTM Parameter JSON object (repeatable)"`
+}
+
+func (c *TagManagerVariablesCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	parent, err := c.parent()
+	if err != nil {
+		return err
+	}
+	name, variableType := strings.TrimSpace(c.Name), strings.TrimSpace(c.Type)
+	if name == "" || variableType == "" {
+		return usage("--name and --type must not be empty")
+	}
+	parameters, err := parseTagManagerJSONObjects[tagmanager.Parameter]("parameter", c.Parameters)
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	variable, err := svc.Accounts.Containers.Workspaces.Variables.Create(parent, &tagmanager.Variable{
+		Name: name, Type: variableType, Parameter: parameters,
+	}).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerVariable(ctx, "Created", variable)
+}
+
+type TagManagerVariablesGetCmd struct {
+	Path string `arg:"" name:"path" help:"Full GTM variable path"`
+}
+
+func (c *TagManagerVariablesGetCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, path, err := tagManagerResourceRequest(flags, c.Path, "variables", "VARIABLE_ID")
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	variable, err := svc.Accounts.Containers.Workspaces.Variables.Get(path).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerVariable(ctx, "Variable", variable)
+}
+
+type TagManagerVariablesDeleteCmd struct {
+	Path string `arg:"" name:"path" help:"Full GTM variable path"`
+}
+
+func (c *TagManagerVariablesDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, path, err := tagManagerResourceRequest(flags, c.Path, "variables", "VARIABLE_ID")
+	if err != nil {
+		return err
+	}
+	if err = confirmDestructive(ctx, flags, "delete GTM variable "+path); err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	if err = svc.Accounts.Containers.Workspaces.Variables.Delete(path).Context(ctx).Do(); err != nil {
+		return err
+	}
+	return writeTagManagerDelete(ctx, "variable", path)
+}
+
+type TagManagerVariablesRevertCmd struct {
+	Path string `arg:"" name:"path" help:"Full GTM variable path"`
+}
+
+func (c *TagManagerVariablesRevertCmd) Run(ctx context.Context, flags *RootFlags) error {
+	account, path, err := tagManagerResourceRequest(flags, c.Path, "variables", "VARIABLE_ID")
+	if err != nil {
+		return err
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	resp, err := svc.Accounts.Containers.Workspaces.Variables.Revert(path).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerVariable(ctx, "Reverted", resp.Variable)
+}
+
+type TagManagerVariablesUpdateCmd struct {
+	Path       string   `arg:"" name:"path" help:"Full GTM variable path"`
+	Name       string   `name:"name" help:"Variable name"`
+	Type       string   `name:"type" help:"GTM variable type"`
+	Parameters []string `name:"parameter" sep:"none" help:"GTM Parameter JSON object (repeatable)"`
+}
+
+func (c *TagManagerVariablesUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	account, path, err := tagManagerResourceRequest(flags, c.Path, "variables", "VARIABLE_ID")
+	if err != nil {
+		return err
+	}
+	if !flagProvidedAny(kctx, "name", "type", "parameter") {
+		return usage("at least one of --name, --type, or --parameter is required")
+	}
+	if flagProvided(kctx, "name") && strings.TrimSpace(c.Name) == "" {
+		return usage("--name must not be blank")
+	}
+	if flagProvided(kctx, "type") && strings.TrimSpace(c.Type) == "" {
+		return usage("--type must not be blank")
+	}
+	var parameters []*tagmanager.Parameter
+	if flagProvided(kctx, "parameter") {
+		parameters, err = parseTagManagerJSONObjects[tagmanager.Parameter]("parameter", c.Parameters)
+		if err != nil {
+			return err
+		}
+	}
+	svc, err := newTagManagerService(ctx, account)
+	if err != nil {
+		return err
+	}
+	variable, err := svc.Accounts.Containers.Workspaces.Variables.Get(path).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	if flagProvided(kctx, "name") {
+		variable.Name = strings.TrimSpace(c.Name)
+	}
+	if flagProvided(kctx, "type") {
+		variable.Type = strings.TrimSpace(c.Type)
+	}
+	if flagProvided(kctx, "parameter") {
+		variable.Parameter = parameters
+	}
+	updated, err := svc.Accounts.Containers.Workspaces.Variables.Update(path, variable).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeTagManagerVariable(ctx, "Updated", updated)
+}
+
+func writeTagManagerVariable(ctx context.Context, action string, variable *tagmanager.Variable) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"variable": variable})
+	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		fmt.Fprintln(w, "VARIABLE_ID\tNAME\tTYPE")
+		if variable != nil {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", sanitizeTab(variable.VariableId), sanitizeTab(variable.Name), sanitizeTab(variable.Type))
+		}
+		return nil
+	}
+	if variable == nil {
+		ui.FromContext(ctx).Out().Printf("%s variable: no published version", action)
+		return nil
+	}
+	ui.FromContext(ctx).Out().Printf("%s variable: %s", action, variable.Path)
+	return nil
+}

--- a/internal/cmd/tagmanager_variables_edit_test.go
+++ b/internal/cmd/tagmanager_variables_edit_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"google.golang.org/api/tagmanager/v2"
+)
+
+func TestExecute_TagManagerVariablesCreate(t *testing.T) {
+	setupTagManagerResourceTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/111/containers/c1/workspaces/7/variables" {
+			http.NotFound(w, r)
+			return
+		}
+		var body tagmanager.Variable
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Name != "Lookup" || body.Type != "smm" || len(body.Parameter) != 2 {
+			t.Fatalf("unexpected variable: %#v", body)
+		}
+		parameter := body.Parameter[0]
+		if parameter.Type != "list" || len(parameter.List) != 1 || parameter.List[0].Map[0].Key != "key" {
+			t.Fatalf("nested parameter not preserved: %#v", parameter)
+		}
+		if body.Parameter[1].Type != "boolean" || body.Parameter[1].Value != "true" {
+			t.Fatalf("boolean parameter not preserved: %#v", body.Parameter[1])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"path":"accounts/111/containers/c1/workspaces/7/variables/3","variableId":"3","name":"Lookup","type":"smm"}`))
+	}))
+
+	parameter := `{"type":"list","key":"map","list":[{"type":"map","map":[{"type":"template","key":"key","value":"a"},{"type":"template","key":"value","value":"b"}]}]}`
+	booleanParameter := `{"type":"boolean","key":"setDefaultValue","value":"true"}`
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "admin@example.com", "gtm", "variables", "create",
+				"--account-id", "111", "--container-id", "c1", "--workspace-id", "7",
+				"--name", "Lookup", "--type", "smm", "--parameter", parameter, "--parameter", booleanParameter,
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	var result struct {
+		Variable *tagmanager.Variable `json:"variable"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil || result.Variable == nil || result.Variable.VariableId != "3" {
+		t.Fatalf("unexpected output %q: %v", out, err)
+	}
+}
+
+func TestExecute_TagManagerVariablesLifecycle(t *testing.T) {
+	path := "/tagmanager/v2/accounts/111/containers/c1/workspaces/7/variables/3"
+	requests := 0
+	setupTagManagerResourceTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == path:
+			_, _ = w.Write([]byte(`{"path":"accounts/111/containers/c1/workspaces/7/variables/3","variableId":"3","name":"Old","type":"c"}`))
+		case r.Method == http.MethodPut && r.URL.Path == path:
+			var body tagmanager.Variable
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.Name != "New" || body.Type != "c" {
+				t.Fatalf("partial update lost fields: %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"path":"accounts/111/containers/c1/workspaces/7/variables/3","variableId":"3","name":"New","type":"c"}`))
+		case r.Method == http.MethodPost && r.URL.Path == path+":revert":
+			_, _ = w.Write([]byte(`{"variable":{"path":"accounts/111/containers/c1/workspaces/7/variables/3","variableId":"3","name":"Published","type":"c"}}`))
+		case r.Method == http.MethodDelete && r.URL.Path == path:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	resource := "accounts/111/containers/c1/workspaces/7/variables/3"
+	for _, args := range [][]string{
+		{"--json", "--account", "admin@example.com", "gtm", "variables", "get", resource},
+		{"--json", "--account", "admin@example.com", "gtm", "variables", "update", resource, "--name", "New"},
+		{"--json", "--account", "admin@example.com", "gtm", "variables", "revert", resource},
+		{"--json", "--force", "--account", "admin@example.com", "gtm", "variables", "delete", resource},
+	} {
+		captureStdout(t, func() {
+			_ = captureStderr(t, func() {
+				if err := Execute(args); err != nil {
+					t.Fatalf("Execute(%v): %v", args, err)
+				}
+			})
+		})
+	}
+	if requests != 5 {
+		t.Fatalf("requests = %d, want 5", requests)
+	}
+}

--- a/skills/pack/google-tag-manager/SKILL.md
+++ b/skills/pack/google-tag-manager/SKILL.md
@@ -30,6 +30,8 @@ GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedi
 GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com tag-manager tags --account-id 12345 --container-id 67890
 GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com gtm workspaces create-version accounts/12345/containers/67890/workspaces/7 --name "Release"
 GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com gtm versions publish accounts/12345/containers/67890/versions/42
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com gtm triggers create --account-id 12345 --container-id 67890 --workspace-id 7 --name "Checkout" --type customEvent --custom-event-filter '{"type":"equals","parameter":[{"type":"template","key":"arg0","value":"{{Event}}"},{"type":"template","key":"arg1","value":"checkout"}]}'
+GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedia.com gtm built-in-variables create --account-id 12345 --container-id 67890 --workspace-id 7 --type pageUrl --type clickId
 ```
 
 ## Available Commands
@@ -40,8 +42,13 @@ GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedi
 | `containers` | List containers in an account | `--account-id` |
 | `tags` | List tags in a container | `--account-id`, `--container-id`, `--workspace-id` |
 | `tag` | Get a single tag by path | `<tagPath>` (positional) |
-| `triggers` | List triggers in a container | `--account-id`, `--container-id`, `--workspace-id` |
-| `variables` | List variables in a container | `--account-id`, `--container-id`, `--workspace-id` |
+| `triggers` | List triggers in a workspace | `--account-id`, `--container-id`, `--workspace-id` |
+| `triggers create` | Create a trigger | workspace flags, `--name`, `--type`; repeatable Condition JSON flags |
+| `triggers delete/get/revert/update` | Mutate a trigger by full path | `<path>`; update field flags; delete uses `--force` |
+| `variables` | List variables in a workspace | `--account-id`, `--container-id`, `--workspace-id` |
+| `variables create` | Create a custom variable | workspace flags, `--name`, `--type`, repeatable `--parameter` JSON |
+| `variables delete/get/revert/update` | Mutate a custom variable by full path | `<path>`; update field flags; delete uses `--force` |
+| `built-in-variables create/delete/list/revert` | Manage workspace built-in variables | workspace flags, repeatable `--type`; delete uses `--force` |
 | `versions` | List container versions | `--account-id`, `--container-id` |
 | `versions publish` | Publish a container version | `<path>`, `--fingerprint` |
 | `workspaces create-version` | Create a container version from a workspace | `<path>`, `--name`, `--notes` |

--- a/specs/features/tagmanager-gaps.md
+++ b/specs/features/tagmanager-gaps.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Tag Manager v2 API has 99 missing methods. Currently implemented: `accounts.list`, `containers.list`, `versionHeaders.list`, `workspaces.tags.get`, `workspaces.tags.list`, `workspaces.triggers.list`, `workspaces.variables.list`.
+This document tracks the remaining Tag Manager v2 surface and the CLI conventions used as methods are added. Implemented workspace surfaces include trigger and custom-variable list/create/delete/get/revert/update, built-in-variable create/delete/list/revert, version creation/publishing, and account user-permission management.
 
 All Tag Manager resources use a deeply nested path-based hierarchy:
 ```
@@ -203,11 +203,11 @@ Many resources also accept a full `path` positional arg (e.g. `accounts/123/cont
 
 | Method | CLI Command | Args/Flags | Output |
 |--------|-------------|------------|--------|
-| **create** | `gog gtm triggers create` | workspace flags; `--name` (required); `--type` (required, e.g. pageview, click, formSubmit, customEvent, etc.); `--filter` (repeatable); `--custom-event-filter` (repeatable) | JSON object |
+| **create** | `gog gtm triggers create` | workspace flags; `--name` and `--type` (required); repeatable Condition JSON via `--filter`, `--auto-event-filter`, and `--custom-event-filter`; timer Parameter JSON via `--event-name`, `--interval`, and `--limit` | JSON object |
 | **delete** | `gog gtm triggers delete <path>` | `path` (positional). `--force`. `confirmDestructive()`. | JSON `{"deleted": true}` |
 | **get** | `gog gtm triggers get <path>` | `path` (positional) | JSON object, TSV: TRIGGER_ID, NAME, TYPE |
 | **revert** | `gog gtm triggers revert <path>` | `path` (positional) | JSON object |
-| **update** | `gog gtm triggers update <path>` | `path` (positional); `--name`, `--type`, `--filter` (optional). Uses `flagProvided()`. | JSON object |
+| **update** | `gog gtm triggers update <path>` | `path` (positional); any create field flag. Uses `flagProvided()` and rejects empty updates. | JSON object |
 
 **Test requirements:**
 - Full CRUD + revert cycle; verify trigger type enum values
@@ -218,11 +218,11 @@ Many resources also accept a full `path` positional arg (e.g. `accounts/123/cont
 
 | Method | CLI Command | Args/Flags | Output |
 |--------|-------------|------------|--------|
-| **create** | `gog gtm variables create` | workspace flags; `--name` (required); `--type` (required); `--parameter` (repeatable key=value) | JSON object |
+| **create** | `gog gtm variables create` | workspace flags; `--name` and `--type` (required); `--parameter` accepts repeatable GTM Parameter JSON objects, including nested map/list values | JSON object |
 | **delete** | `gog gtm variables delete <path>` | `path` (positional). `--force`. `confirmDestructive()`. | JSON `{"deleted": true}` |
 | **get** | `gog gtm variables get <path>` | `path` (positional) | JSON object, TSV: VARIABLE_ID, NAME, TYPE |
 | **revert** | `gog gtm variables revert <path>` | `path` (positional) | JSON object |
-| **update** | `gog gtm variables update <path>` | `path` (positional); `--name`, `--type`, `--parameter` (optional). Uses `flagProvided()`. | JSON object |
+| **update** | `gog gtm variables update <path>` | `path` (positional); `--name`, `--type`, `--parameter` (optional). Uses `flagProvided()` and rejects empty updates. | JSON object |
 
 **Test requirements:**
 - Full CRUD + revert cycle; verify parameter key=value parsing
@@ -236,7 +236,7 @@ Many resources also accept a full `path` positional arg (e.g. `accounts/123/cont
 | **create** | `gog gtm built-in-variables create` | workspace flags; `--type` (required, repeatable: e.g. pageUrl, pageHostname, pagePath, referrer, event, etc.) | JSON object with list of created built-in variables |
 | **delete** | `gog gtm built-in-variables delete` | workspace flags; `--type` (required, repeatable). `--force`. `confirmDestructive()`. | JSON `{"deleted": true}` |
 | **list** | `gog gtm built-in-variables list` | workspace flags | JSON array, TSV: TYPE, NAME |
-| **revert** | `gog gtm built-in-variables revert` | workspace flags; `--type` (required) | JSON object |
+| **revert** | `gog gtm built-in-variables revert` | workspace flags; exactly one `--type` (required) | JSON object with type and resulting enabled state |
 
 **Notes:** Built-in variables use `type` enum instead of individual IDs. Create/delete take arrays of types.
 


### PR DESCRIPTION
## Summary

- add trigger create, delete, get, revert, and partial-update commands while preserving existing list syntax
- add custom-variable mutations with typed and nested GTM parameter JSON
- add built-in-variable create, delete, list, and revert commands
- document the complete GTM workspace mutation surface

## Impact

GTM workspaces can now be configured through the CLI without flattening typed Google Tag Manager conditions or parameters. Destructive operations use the shared confirmation and `--force` behavior, with machine-readable JSON and stable TSV output.

## Validation

- two-axis standards and issue/spec review
- focused `httptest` API-boundary coverage
- `make ci`

Closes #12
Closes #45
Closes #46
Closes #47