### PR TITLE
chore(scripts): enforce strict shell mode

### DIFF
--- a/loop.sh
+++ b/loop.sh
@@ -6,7 +6,7 @@
 #   ./loop.sh 20        # Build mode, max 20 iterations
 #   ./loop.sh plan 5    # Plan mode, max 5 iterations
 
-set -e
+set -euo pipefail
 
 MODE="${1:-build}"
 MAX_ITERATIONS="${2:-999999}"

--- a/specs/lint-specs.sh
+++ b/specs/lint-specs.sh
@@ -11,7 +11,7 @@
 #   6. Delete commands mention confirmDestructive
 #   7. Test requirements section exists
 
-set -uo pipefail
+set -euo pipefail
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -24,12 +24,12 @@ FILES_CHECKED=0
 
 warn() {
   echo -e "${YELLOW}  WARN${NC} [$1]: $2"
-  ((WARNINGS++))
+  ((WARNINGS += 1))
 }
 
 fail() {
   echo -e "${RED}  FAIL${NC} [$1]: $2"
-  ((ERRORS++))
+  ((ERRORS += 1))
 }
 
 pass() {
@@ -43,7 +43,7 @@ lint_spec() {
   echo ""
   echo "Linting: $basename"
   echo "─────────────────────────────────────"
-  ((FILES_CHECKED++))
+  ((FILES_CHECKED += 1))
 
   local content
   content=$(cat "$file")
@@ -144,7 +144,7 @@ if [ $# -gt 0 ]; then
       lint_spec "$f"
     else
       echo "File not found: $f"
-      ((ERRORS++))
+      ((ERRORS += 1))
     fi
   done
 else


### PR DESCRIPTION
## Summary

- enable `set -euo pipefail` in `loop.sh` and `specs/lint-specs.sh`
- make spec-linter counters safe under Bash `errexit`
- preserve explicit guards around expected nonzero operations

## Why

The scripts used inconsistent strict-mode settings. In the spec linter, post-increment arithmetic returns a failing shell status when incrementing from zero, which caused premature exits once `errexit` was enabled.

## Impact

Both scripts now have intentional, consistent error handling. The spec linter still accumulates warnings and errors and exits according to its final error count. `loop.sh` was not executed during verification because it invokes an agent loop and pushes changes.

## Validation

- `bash -n loop.sh specs/lint-specs.sh`
- `./specs/lint-specs.sh` — 19 files, 0 errors, 2 existing warnings
- missing-file error path exits 1 after reporting the final count
- two-axis code review — zero findings
- `make ci`

Closes #27