### PR TITLE
fix(policy): normalize hyphenated service commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Distribution: use `Robben-Media/gogcli` as the sole install and release source; remove upstream Homebrew/tap assumptions.
 - Auth: request the full Analytics and Tag Manager administration scopes, preserve existing scopes during service-specific reauthorization, add explicit `--replace-scopes`, and allow up to 10 minutes for browser consent. (#13)
 
+### Fixed
+
+- Policy: enforce normalized service policies for canonical hyphenated Business Profile, Search Console, and Tag Manager commands. (#50, #100)
+
 ## 0.10.0 - 2026-08-07
 
 ### Highlights

--- a/internal/cmd/policy_enforcement.go
+++ b/internal/cmd/policy_enforcement.go
@@ -10,17 +10,20 @@ import (
 )
 
 var commandServiceAliases = map[string]string{
-	"bq":       "bigquery",
-	"business": "businessprofile",
-	"email":    serviceGmail,
-	"ga":       "analytics",
-	"ga4":      "analytics",
-	"gbp":      "businessprofile",
-	"gsc":      "searchconsole",
-	"gtm":      "tagmanager",
-	"mail":     serviceGmail,
-	"sc":       "searchconsole",
-	"yt":       "youtube",
+	"bq":               "bigquery",
+	"business":         "businessprofile",
+	"business-profile": "businessprofile",
+	"email":            serviceGmail,
+	"ga":               "analytics",
+	"ga4":              "analytics",
+	"gbp":              "businessprofile",
+	"gsc":              "searchconsole",
+	"gtm":              "tagmanager",
+	"mail":             serviceGmail,
+	"sc":               "searchconsole",
+	"search-console":   "searchconsole",
+	"tag-manager":      "tagmanager",
+	"yt":               "youtube",
 }
 
 type policyDecision struct {

--- a/internal/cmd/policy_enforcement_test.go
+++ b/internal/cmd/policy_enforcement_test.go
@@ -172,6 +172,82 @@ func TestCommandActionID_FlattensGmailSettingsAndAliases(t *testing.T) {
 	}
 }
 
+func TestPolicyEnforcement_NormalizesHyphenatedServicesAndAliases(t *testing.T) {
+	tests := []struct {
+		name      string
+		commands  [][]string
+		action    string
+		otherRule string
+	}{
+		{
+			name: "business profile",
+			commands: [][]string{
+				{"business-profile", "accounts", "list"},
+				{"gbp", "accounts", "list"},
+				{"business", "accounts", "list"},
+			},
+			action:    "businessprofile:accounts.list",
+			otherRule: "businessprofile:locations.list",
+		},
+		{
+			name: "search console",
+			commands: [][]string{
+				{"search-console", "sites", "list"},
+				{"gsc", "sites", "list"},
+				{"sc", "sites", "list"},
+			},
+			action:    "searchconsole:sites.list",
+			otherRule: "searchconsole:sitemaps.list",
+		},
+		{
+			name: "tag manager",
+			commands: [][]string{
+				{"tag-manager", "accounts"},
+				{"gtm", "accounts"},
+			},
+			action:    "tagmanager:accounts",
+			otherRule: "tagmanager:containers",
+		},
+	}
+
+	parser, _, err := newParser("test")
+	if err != nil {
+		t.Fatalf("newParser: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, command := range tt.commands {
+				kctx, err := parser.Parse(command)
+				if err != nil {
+					t.Fatalf("Parse(%q): %v", command, err)
+				}
+				action := commandActionID(kctx)
+				if action != tt.action {
+					t.Fatalf("commandActionID(%q) = %q, want %q", command, action, tt.action)
+				}
+
+				service, _, _ := strings.Cut(action, ":")
+				explicitDeny := []config.Policy{{Name: "deny", Deny: []string{tt.action}}}
+				if !hasPolicyForService(explicitDeny, service) {
+					t.Fatalf("explicit deny policy not discovered for %q", command)
+				}
+				if decision := evaluatePolicies(explicitDeny, action, "", ""); !decision.Denied || decision.ImplicitAllowlist {
+					t.Fatalf("explicit deny decision for %q = %#v", command, decision)
+				}
+
+				allowlist := []config.Policy{{Name: "allow-other", Allow: []string{tt.otherRule}}}
+				if !hasPolicyForService(allowlist, service) {
+					t.Fatalf("allowlist policy not discovered for %q", command)
+				}
+				if decision := evaluatePolicies(allowlist, action, "", ""); !decision.Denied || !decision.ImplicitAllowlist {
+					t.Fatalf("implicit allowlist decision for %q = %#v", command, decision)
+				}
+			}
+		})
+	}
+}
+
 func TestPolicyCommandsBypassPolicyEnforcement(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())


### PR DESCRIPTION
## Summary

- normalize canonical `business-profile`, `search-console`, and `tag-manager` service names to their policy IDs
- verify every registered alias produces the same action ID
- cover policy discovery, explicit deny, and implicit allowlist behavior

Closes #50

## Testing

- `go test ./internal/cmd -run 'Test(CommandActionID_FlattensGmailSettingsAndAliases|PolicyEnforcement_NormalizesHyphenatedServicesAndAliases)$' -count=1`\n- `go test ./internal/cmd -count=1`\n- `git diff --check`\n\n## Review\n\n- Standards axis: no findings\n- Spec axis: no findings