### PR TITLE
fix(analytics): preserve plain TSV row boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Policy: enforce normalized service policies for canonical hyphenated Business Profile, Search Console, and Tag Manager commands. (#50, #100)
+- Analytics: preserve physical TSV row and column boundaries for report and audience values in `--plain` output. (#51, #101)
 
 ## 0.10.0 - 2026-08-07
 

--- a/internal/cmd/analytics.go
+++ b/internal/cmd/analytics.go
@@ -139,7 +139,7 @@ func (c *AnalyticsReportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	for _, mh := range resp.MetricHeaders {
 		headers = append(headers, mh.Name)
 	}
-	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	writeTableRow(ctx, w, headers)
 
 	// Build data rows
 	for _, row := range resp.Rows {
@@ -150,7 +150,7 @@ func (c *AnalyticsReportCmd) Run(ctx context.Context, flags *RootFlags) error {
 		for _, mv := range row.MetricValues {
 			vals = append(vals, mv.Value)
 		}
-		fmt.Fprintln(w, strings.Join(vals, "\t"))
+		writeTableRow(ctx, w, vals)
 	}
 
 	return nil
@@ -235,7 +235,7 @@ func (c *AnalyticsRealtimeCmd) Run(ctx context.Context, flags *RootFlags) error 
 	for _, mh := range resp.MetricHeaders {
 		headers = append(headers, mh.Name)
 	}
-	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	writeTableRow(ctx, w, headers)
 
 	for _, row := range resp.Rows {
 		var vals []string
@@ -245,7 +245,7 @@ func (c *AnalyticsRealtimeCmd) Run(ctx context.Context, flags *RootFlags) error 
 		for _, mv := range row.MetricValues {
 			vals = append(vals, mv.Value)
 		}
-		fmt.Fprintln(w, strings.Join(vals, "\t"))
+		writeTableRow(ctx, w, vals)
 	}
 
 	return nil

--- a/internal/cmd/analytics_audience.go
+++ b/internal/cmd/analytics_audience.go
@@ -277,7 +277,7 @@ func (c *AnalyticsAudienceExportsQueryCmd) Run(ctx context.Context, flags *RootF
 
 	// Print header row
 	if len(dimensionNames) > 0 {
-		fmt.Fprintln(w, strings.Join(dimensionNames, "\t"))
+		writeTableRow(ctx, w, dimensionNames)
 	} else {
 		fmt.Fprintln(w, "DIMENSION_VALUES")
 	}
@@ -289,7 +289,7 @@ func (c *AnalyticsAudienceExportsQueryCmd) Run(ctx context.Context, flags *RootF
 			vals = append(vals, dv.Value)
 		}
 		if len(vals) > 0 {
-			fmt.Fprintln(w, strings.Join(vals, "\t"))
+			writeTableRow(ctx, w, vals)
 		}
 	}
 

--- a/internal/cmd/analytics_reports.go
+++ b/internal/cmd/analytics_reports.go
@@ -135,7 +135,7 @@ func (c *AnalyticsPivotReportCmd) Run(ctx context.Context, flags *RootFlags) err
 			}
 		}
 	}
-	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	writeTableRow(ctx, w, headers)
 
 	// Build data rows
 	for _, row := range resp.Rows {
@@ -146,7 +146,7 @@ func (c *AnalyticsPivotReportCmd) Run(ctx context.Context, flags *RootFlags) err
 		for _, mv := range row.MetricValues {
 			vals = append(vals, mv.Value)
 		}
-		fmt.Fprintln(w, strings.Join(vals, "\t"))
+		writeTableRow(ctx, w, vals)
 	}
 
 	return nil
@@ -228,7 +228,7 @@ func (c *AnalyticsBatchReportsCmd) Run(ctx context.Context, flags *RootFlags) er
 			for _, mh := range report.MetricHeaders {
 				headers = append(headers, mh.Name)
 			}
-			fmt.Fprintln(w, strings.Join(headers, "\t"))
+			writeTableRow(ctx, w, headers)
 			for _, row := range report.Rows {
 				var vals []string
 				for _, dv := range row.DimensionValues {
@@ -237,7 +237,7 @@ func (c *AnalyticsBatchReportsCmd) Run(ctx context.Context, flags *RootFlags) er
 				for _, mv := range row.MetricValues {
 					vals = append(vals, mv.Value)
 				}
-				fmt.Fprintln(w, strings.Join(vals, "\t"))
+				writeTableRow(ctx, w, vals)
 			}
 		}
 	}
@@ -318,7 +318,7 @@ func (c *AnalyticsBatchPivotReportsCmd) Run(ctx context.Context, flags *RootFlag
 			for _, dh := range report.DimensionHeaders {
 				headers = append(headers, dh.Name)
 			}
-			fmt.Fprintln(w, strings.Join(headers, "\t"))
+			writeTableRow(ctx, w, headers)
 			for _, row := range report.Rows {
 				var vals []string
 				for _, dv := range row.DimensionValues {
@@ -327,7 +327,7 @@ func (c *AnalyticsBatchPivotReportsCmd) Run(ctx context.Context, flags *RootFlag
 				for _, mv := range row.MetricValues {
 					vals = append(vals, mv.Value)
 				}
-				fmt.Fprintln(w, strings.Join(vals, "\t"))
+				writeTableRow(ctx, w, vals)
 			}
 		}
 	}

--- a/internal/cmd/analytics_tsv_test.go
+++ b/internal/cmd/analytics_tsv_test.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+
+	analyticsdata "google.golang.org/api/analyticsdata/v1beta"
+)
+
+const (
+	unsafeAnalyticsDimensionHeader = "dimension\tname"
+	unsafeAnalyticsMetricHeader    = "metric\nname"
+	unsafeAnalyticsDimensionValue  = "dimension\rvalue"
+	unsafeAnalyticsMetricValue     = "metric\r\nvalue"
+	analyticsSafeTSV               = "dimension name\tmetric name\ndimension value\tmetric value\n"
+)
+
+func analyticsUnsafeReport() map[string]any {
+	return map[string]any{
+		"dimensionHeaders": []map[string]any{{"name": unsafeAnalyticsDimensionHeader}},
+		"metricHeaders":    []map[string]any{{"name": unsafeAnalyticsMetricHeader, "type": "TYPE_INTEGER"}},
+		"rows": []map[string]any{{
+			"dimensionValues": []map[string]any{{"value": unsafeAnalyticsDimensionValue}},
+			"metricValues":    []map[string]any{{"value": unsafeAnalyticsMetricValue}},
+		}},
+		"rowCount": 1,
+	}
+}
+
+func analyticsTSVTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var response map[string]any
+		switch {
+		case r.Method == http.MethodPost &&
+			(strings.HasSuffix(r.URL.Path, ":runReport") || strings.HasSuffix(r.URL.Path, ":runRealtimeReport")):
+			response = analyticsUnsafeReport()
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":runPivotReport"):
+			response = analyticsUnsafeReport()
+			response["pivotHeaders"] = []map[string]any{{
+				"pivotDimensionHeaders": []map[string]any{{
+					"dimensionValues": []map[string]any{{"value": unsafeAnalyticsMetricHeader}},
+				}},
+			}}
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchRunReports"):
+			response = map[string]any{"reports": []map[string]any{analyticsUnsafeReport()}}
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchRunPivotReports"):
+			report := analyticsUnsafeReport()
+			report["dimensionHeaders"] = []map[string]any{
+				{"name": unsafeAnalyticsDimensionHeader},
+				{"name": unsafeAnalyticsMetricHeader},
+			}
+			response = map[string]any{"pivotReports": []map[string]any{report}}
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":query"):
+			response = map[string]any{
+				"audienceExport": map[string]any{
+					"dimensions": []map[string]any{
+						{"dimensionName": unsafeAnalyticsDimensionHeader},
+						{"dimensionName": unsafeAnalyticsMetricHeader},
+					},
+				},
+				"audienceRows": []map[string]any{{
+					"dimensionValues": []map[string]any{
+						{"value": unsafeAnalyticsDimensionValue},
+						{"value": unsafeAnalyticsMetricValue},
+					},
+				}},
+			}
+		default:
+			http.NotFound(w, r)
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+}
+
+func setupAnalyticsTSVService(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	original := newAnalyticsDataService
+	t.Cleanup(func() { newAnalyticsDataService = original })
+
+	service, err := analyticsdata.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newAnalyticsDataService = func(context.Context, string) (*analyticsdata.Service, error) {
+		return service, nil
+	}
+}
+
+func TestAnalyticsReports_PlainTSVPreservesRows(t *testing.T) {
+	srv := analyticsTSVTestServer(t)
+	defer srv.Close()
+	setupAnalyticsTSVService(t, srv)
+
+	tests := []struct {
+		name    string
+		command []string
+		want    string
+	}{
+		{
+			name:    "standard",
+			command: []string{"analytics", "report", "--property", "456", "--metrics", "sessions", "--dimensions", "country"},
+			want:    analyticsSafeTSV,
+		},
+		{
+			name:    "realtime",
+			command: []string{"analytics", "realtime", "--property", "456", "--metrics", "activeUsers", "--dimensions", "country"},
+			want:    analyticsSafeTSV,
+		},
+		{
+			name:    "pivot",
+			command: []string{"analytics", "pivot-report", "--property", "456", "--dimensions", "country", "--metrics", "sessions", "--pivots-json", `[{"fieldNames":["browser"]}]`},
+			want:    analyticsSafeTSV,
+		},
+		{
+			name:    "batch",
+			command: []string{"analytics", "batch-reports", "--property", "456", "--requests-json", `[{}]`},
+			want:    "Report 1: 1 rows\n" + analyticsSafeTSV,
+		},
+		{
+			name:    "batch pivot",
+			command: []string{"analytics", "batch-pivot-reports", "--property", "456", "--requests-json", `[{"pivots":[{"fieldNames":["browser"]}]}]`},
+			want:    "Pivot Report 1\n" + analyticsSafeTSV,
+		},
+		{
+			name:    "audience",
+			command: []string{"analytics", "audience-exports", "query", "--name", "properties/456/audienceExports/1"},
+			want:    analyticsSafeTSV,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"--plain", "--account", "a@b.com"}, tt.command...)
+			out := captureStdout(t, func() {
+				_ = captureStderr(t, func() {
+					if err := Execute(args); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+			if out != tt.want {
+				t.Fatalf("plain output = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestAnalyticsReport_JSONPreservesUnsafeStrings(t *testing.T) {
+	srv := analyticsTSVTestServer(t)
+	defer srv.Close()
+	setupAnalyticsTSVService(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "a@b.com", "analytics", "report",
+				"--property", "456", "--metrics", "sessions", "--dimensions", "country",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var response struct {
+		DimensionHeaders []struct {
+			Name string `json:"name"`
+		} `json:"dimensionHeaders"`
+		MetricHeaders []struct {
+			Name string `json:"name"`
+		} `json:"metricHeaders"`
+		Rows []struct {
+			DimensionValues []struct {
+				Value string `json:"value"`
+			} `json:"dimensionValues"`
+			MetricValues []struct {
+				Value string `json:"value"`
+			} `json:"metricValues"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(out), &response); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if got := response.DimensionHeaders[0].Name; got != unsafeAnalyticsDimensionHeader {
+		t.Fatalf("dimension header = %q", got)
+	}
+	if got := response.MetricHeaders[0].Name; got != unsafeAnalyticsMetricHeader {
+		t.Fatalf("metric header = %q", got)
+	}
+	if got := response.Rows[0].DimensionValues[0].Value; got != unsafeAnalyticsDimensionValue {
+		t.Fatalf("dimension value = %q", got)
+	}
+	if got := response.Rows[0].MetricValues[0].Value; got != unsafeAnalyticsMetricValue {
+		t.Fatalf("metric value = %q", got)
+	}
+}

--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -2,12 +2,21 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
+)
+
+var plainFieldReplacer = strings.NewReplacer(
+	"\t", " ",
+	"\r\n", " ",
+	"\r", " ",
+	"\n", " ",
 )
 
 func tableWriter(ctx context.Context) (io.Writer, func()) {
@@ -16,6 +25,20 @@ func tableWriter(ctx context.Context) (io.Writer, func()) {
 	}
 	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	return tw, func() { _ = tw.Flush() }
+}
+
+func writeTableRow(ctx context.Context, w io.Writer, fields []string) {
+	if outfmt.IsPlain(ctx) {
+		fields = append([]string(nil), fields...)
+		for i := range fields {
+			fields[i] = sanitizePlainField(fields[i])
+		}
+	}
+	fmt.Fprintln(w, strings.Join(fields, "\t"))
+}
+
+func sanitizePlainField(s string) string {
+	return plainFieldReplacer.Replace(s)
 }
 
 func printNextPageHint(u *ui.UI, nextPageToken string) {

--- a/internal/cmd/output_helpers_test.go
+++ b/internal/cmd/output_helpers_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+func TestWriteTableRowSanitizesPlainFieldsOnly(t *testing.T) {
+	fields := []string{"plain\tfield", "line\nfeed", "carriage\rreturn", "windows\r\nline"}
+
+	var plain bytes.Buffer
+	plainCtx := outfmt.WithMode(context.Background(), outfmt.Mode{Plain: true})
+	writeTableRow(plainCtx, &plain, fields)
+	if got, want := plain.String(), "plain field\tline feed\tcarriage return\twindows line\n"; got != want {
+		t.Fatalf("plain row = %q, want %q", got, want)
+	}
+
+	var human bytes.Buffer
+	writeTableRow(context.Background(), &human, fields)
+	if got, want := human.String(), "plain\tfield\tline\nfeed\tcarriage\rreturn\twindows\r\nline\n"; got != want {
+		t.Fatalf("human row = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- add a mode-aware table-row writer that sanitizes plain TSV fields
- route standard, realtime, pivot, batch, batch-pivot, and audience report rows through the shared writer
- preserve JSON strings and default human rendering

Closes #51

## Testing

- `go test ./internal/cmd -run 'Test(WriteTableRowSanitizesPlainFieldsOnly|AnalyticsReports_PlainTSVPreservesRows|AnalyticsReport_JSONPreservesUnsafeStrings)$' -count=1`\n- `go test ./internal/cmd -count=1`\n- pinned `goimports` and `gofumpt`\n- `git diff --check`\n\n## Review\n\n- Standards axis: no findings\n- Spec axis: no findings