### PR TITLE
fix(sheets): preserve plain TSV row boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Policy: enforce normalized service policies for canonical hyphenated Business Profile, Search Console, and Tag Manager commands. (#50, #100)
 - Analytics: preserve physical TSV row and column boundaries for report and audience values in `--plain` output. (#51, #101)
 - BigQuery: preserve physical TSV row and column boundaries for query results in `--plain` output. (#52, #102)
+- Sheets: preserve physical TSV row and column boundaries for single-range, batch-range, and filter-range values in `--plain` output. (#53)
 
 ## 0.10.0 - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Policy: enforce normalized service policies for canonical hyphenated Business Profile, Search Console, and Tag Manager commands. (#50, #100)
 - Analytics: preserve physical TSV row and column boundaries for report and audience values in `--plain` output. (#51, #101)
 - BigQuery: preserve physical TSV row and column boundaries for query results in `--plain` output. (#52, #102)
-- Sheets: preserve physical TSV row and column boundaries for single-range, batch-range, and filter-range values in `--plain` output. (#53)
+- Sheets: preserve physical TSV row and column boundaries for single-range, batch-range, and filter-range values in `--plain` output. (#53, #103)
 
 ## 0.10.0 - 2026-08-07
 

--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -28,13 +28,18 @@ func tableWriter(ctx context.Context) (io.Writer, func()) {
 }
 
 func writeTableRow(ctx context.Context, w io.Writer, fields []string) {
-	if outfmt.IsPlain(ctx) {
-		fields = append([]string(nil), fields...)
-		for i := range fields {
-			fields[i] = sanitizePlainField(fields[i])
-		}
+	fmt.Fprintln(w, strings.Join(plainTableFields(ctx, fields), "\t"))
+}
+
+func plainTableFields(ctx context.Context, fields []string) []string {
+	if !outfmt.IsPlain(ctx) {
+		return fields
 	}
-	fmt.Fprintln(w, strings.Join(fields, "\t"))
+	fields = append([]string(nil), fields...)
+	for i := range fields {
+		fields[i] = sanitizePlainField(fields[i])
+	}
+	return fields
 }
 
 func sanitizePlainField(s string) string {

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -130,15 +130,15 @@ func (c *SheetsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return nil
 	}
 
-	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	w, flush := tableWriter(ctx)
+	defer flush()
 	for _, row := range resp.Values {
 		cells := make([]string, len(row))
 		for i, cell := range row {
 			cells[i] = fmt.Sprintf("%v", cell)
 		}
-		fmt.Fprintln(tw, strings.Join(cells, "\t"))
+		writeTableRow(ctx, w, cells)
 	}
-	_ = tw.Flush()
 	return nil
 }
 

--- a/internal/cmd/sheets_batch.go
+++ b/internal/cmd/sheets_batch.go
@@ -61,7 +61,7 @@ func (c *SheetsBatchGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 			for i, cell := range row {
 				cells[i] = fmt.Sprintf("%v", cell)
 			}
-			u.Out().Println(strings.Join(cells, "\t"))
+			u.Out().Println(strings.Join(plainTableFields(ctx, cells), "\t"))
 		}
 	}
 	return nil

--- a/internal/cmd/sheets_gaps.go
+++ b/internal/cmd/sheets_gaps.go
@@ -469,7 +469,7 @@ func (c *SheetsValuesBatchGetByFilterCmd) Run(ctx context.Context, flags *RootFl
 				for j, cell := range row {
 					cells[j] = fmt.Sprintf("%v", cell)
 				}
-				u.Out().Println(strings.Join(cells, "\t"))
+				u.Out().Println(strings.Join(plainTableFields(ctx, cells), "\t"))
 			}
 		}
 	}

--- a/internal/cmd/sheets_tsv_test.go
+++ b/internal/cmd/sheets_tsv_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+)
+
+const sheetsSafeTSV = "tab value\tline feed\tcarriage return\tcrlf value\n"
+
+func TestSheetsValueReads_PlainTSVPreservesRows(t *testing.T) {
+	values := [][]any{{"tab\tvalue", "line\nfeed", "carriage\rreturn", "crlf\r\nvalue"}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var response map[string]any
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/values:batchGet"):
+			response = map[string]any{
+				"spreadsheetId": "s1",
+				"valueRanges": []map[string]any{{
+					"range":  "Sheet1!A1:D1",
+					"values": values,
+				}},
+			}
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/values:batchGetByDataFilter"):
+			response = map[string]any{
+				"valueRanges": []map[string]any{{
+					"valueRange": map[string]any{
+						"range":  "Sheet1!A1:D1",
+						"values": values,
+					},
+				}},
+			}
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/values/"):
+			response = map[string]any{
+				"range":  "Sheet1!A1:D1",
+				"values": values,
+			}
+		default:
+			http.NotFound(w, r)
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	original := newSheetsService
+	t.Cleanup(func() { newSheetsService = original })
+	service, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) {
+		return service, nil
+	}
+
+	tests := []struct {
+		name    string
+		command []string
+	}{
+		{
+			name:    "single range",
+			command: []string{"sheets", "get", "s1", "Sheet1!A1:D1"},
+		},
+		{
+			name:    "batch ranges",
+			command: []string{"sheets", "batch-get", "s1", "Sheet1!A1:D1"},
+		},
+		{
+			name:    "filter ranges",
+			command: []string{"sheets", "batch-get-by-filter", "s1", "--filters-json", `[{"a1Range":"Sheet1!A1:D1"}]`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				_ = captureStderr(t, func() {
+					args := append([]string{"--plain", "--account", "a@b.com"}, tt.command...)
+					if err := Execute(args); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+			if !strings.HasSuffix(out, sheetsSafeTSV) {
+				t.Fatalf("plain output = %q, want sanitized row suffix %q", out, sheetsSafeTSV)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- extract mode-aware `plainTableFields` so plain TSV sanitization is reusable without forcing tabwriter paths
- route single-range, batch-range, and filter-range Sheets value reads through the shared plain-field contract
- preserve JSON cell values and default human rendering

Closes #53

## Testing

- `go test ./internal/cmd -run 'TestSheetsValueReads_PlainTSVPreservesRows|TestWriteTableRow' -count=1`
- `make ci TOOLS_DIR=/tmp/gogcli-go-tools`
- pinned `goimports` and `gofumpt`
- `git diff --check`

## Review

- Standards axis: no findings (optional residual dual print paths are YAGNI-acceptable)
- Spec axis: core delimiter contract met for get/batch-get/batch-get-by-filter; optional follow-up coverage for sparse cells and JSON unsanitized values