### PR TITLE
fix(docs): confirm range deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Analytics: preserve physical TSV row and column boundaries for report and audience values in `--plain` output. (#51, #101)
 - BigQuery: preserve physical TSV row and column boundaries for query results in `--plain` output. (#52, #102)
 - Sheets: preserve physical TSV row and column boundaries for single-range, batch-range, and filter-range values in `--plain` output. (#53, #103)
+- Docs: require shared destructive confirmation before `docs delete-range` submits a content deletion. (#54)
 
 ## 0.10.0 - 2026-08-07
 

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -34,6 +34,10 @@ func (c *DocsDeleteRangeCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("start must be less than end")
 	}
 
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("delete range %d-%d from doc %s", c.Start, c.End, id)); confirmErr != nil {
+		return confirmErr
+	}
+
 	svc, err := newDocsService(ctx, account)
 	if err != nil {
 		return err

--- a/internal/cmd/docs_edit_test.go
+++ b/internal/cmd/docs_edit_test.go
@@ -77,6 +77,7 @@ func setupDocsEditTest(t *testing.T, batchRequests *[][]*docs.Request) (context.
 func TestExecute_DocsDeleteRange_JSON(t *testing.T) {
 	var batchRequests [][]*docs.Request
 	ctx, flags := setupDocsEditTest(t, &batchRequests)
+	flags.Force = true
 
 	out := captureStdout(t, func() {
 		err := runKong(t, &DocsDeleteRangeCmd{}, []string{"doc1", "--start", "5", "--end", "10"}, ctx, flags)
@@ -105,9 +106,43 @@ func TestExecute_DocsDeleteRange_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_DocsDeleteRange_RefusesWithoutForceBeforeServiceCreation(t *testing.T) {
+	var batchRequests [][]*docs.Request
+	ctx, flags := setupDocsEditTest(t, &batchRequests)
+	flags.NoInput = true
+
+	serviceCalls := 0
+	stubDocsService := newDocsService
+	newDocsService = func(ctx context.Context, account string) (*docs.Service, error) {
+		serviceCalls++
+		return stubDocsService(ctx, account)
+	}
+
+	err := runKong(t, &DocsDeleteRangeCmd{}, []string{"doc1", "--start", "5", "--end", "10"}, ctx, flags)
+	if err == nil {
+		t.Fatal("expected confirmation refusal")
+	}
+	if !strings.Contains(err.Error(), "delete range 5-10 from doc doc1") {
+		t.Fatalf("expected confirmation to identify range and document, got: %v", err)
+	}
+	if serviceCalls != 0 {
+		t.Fatalf("expected service not to be created, got %d creation(s)", serviceCalls)
+	}
+	if len(batchRequests) != 0 {
+		t.Fatalf("expected 0 batch requests, got %d", len(batchRequests))
+	}
+}
+
 func TestExecute_DocsDeleteRange_InvalidRange(t *testing.T) {
 	var batchRequests [][]*docs.Request
 	ctx, flags := setupDocsEditTest(t, &batchRequests)
+
+	serviceCalls := 0
+	stubDocsService := newDocsService
+	newDocsService = func(ctx context.Context, account string) (*docs.Service, error) {
+		serviceCalls++
+		return stubDocsService(ctx, account)
+	}
 
 	// start == end
 	err := runKong(t, &DocsDeleteRangeCmd{}, []string{"doc1", "--start", "5", "--end", "5"}, ctx, flags)
@@ -127,6 +162,9 @@ func TestExecute_DocsDeleteRange_InvalidRange(t *testing.T) {
 		t.Fatalf("expected 'start must be less than end' error, got: %v", err)
 	}
 
+	if serviceCalls != 0 {
+		t.Fatalf("expected validation before service creation, got %d creation(s)", serviceCalls)
+	}
 	// No batch requests should have been made
 	if len(batchRequests) != 0 {
 		t.Fatalf("expected 0 batch requests, got %d", len(batchRequests))


### PR DESCRIPTION
## Summary

- gate `docs delete-range` through shared `confirmDestructive` after validation and before Docs service construction
- prompt identifies the document and exact start/end indices; `--force` keeps non-interactive automation
- unit coverage for force success, non-interactive refusal before service creation, and invalid ranges before mutation

Closes #54

## Testing

- `go test ./internal/cmd -run 'TestExecute_DocsDeleteRange' -count=1`
- `make ci TOOLS_DIR=/tmp/gogcli-go-tools-issue-54`
- pinned `goimports` and `gofumpt`
- `git diff --check`

## Review

- Standards axis: no hard findings (mild optional test stub duplication only)
- Spec axis: acceptance criteria met; interactive decline relies on shared `confirmDestructive` coverage