### PR TITLE
fix(gmail): guard permanent batch deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - BigQuery: preserve physical TSV row and column boundaries for query results in `--plain` output. (#52, #102)
 - Sheets: preserve physical TSV row and column boundaries for single-range, batch-range, and filter-range values in `--plain` output. (#53, #103)
 - Docs: require shared destructive confirmation before `docs delete-range` submits a content deletion. (#54)
+- Gmail: require message IDs and shared destructive confirmation before permanent batch deletion. (#55)
 
 ## 0.10.0 - 2026-08-07
 

--- a/internal/cmd/gmail_batch.go
+++ b/internal/cmd/gmail_batch.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"google.golang.org/api/gmail/v1"
@@ -22,9 +23,17 @@ type GmailBatchDeleteCmd struct {
 
 func (c *GmailBatchDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
+	if len(c.MessageIDs) == 0 {
+		return usage("at least one message ID is required")
+	}
+
 	account, err := requireAccount(flags)
 	if err != nil {
 		return err
+	}
+
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("permanently delete %d gmail message(s)", len(c.MessageIDs))); confirmErr != nil {
+		return confirmErr
 	}
 
 	svc, err := newGmailService(ctx, account)

--- a/internal/cmd/gmail_sendas_test.go
+++ b/internal/cmd/gmail_sendas_test.go
@@ -163,6 +163,56 @@ func TestGmailSendAsGetCmd_JSON(t *testing.T) {
 	}
 }
 
+func TestGmailBatchDeleteCmd_RequiresMessageIDsBeforeServiceCreation(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	serviceCreated := false
+	newGmailService = func(context.Context, string) (*gmail.Service, error) {
+		serviceCreated = true
+		return nil, context.Canceled
+	}
+
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	err := (&GmailBatchDeleteCmd{}).Run(ctx, &RootFlags{Account: "a@b.com", Force: true})
+	if err == nil || !strings.Contains(err.Error(), "at least one message ID is required") {
+		t.Fatalf("expected missing message ID error, got %v", err)
+	}
+	if serviceCreated {
+		t.Fatal("service created for empty message IDs")
+	}
+}
+
+func TestGmailBatchDeleteCmd_RequiresConfirmationBeforeServiceCreation(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	serviceCreated := false
+	newGmailService = func(context.Context, string) (*gmail.Service, error) {
+		serviceCreated = true
+		return nil, context.Canceled
+	}
+
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	err := runKong(t, &GmailBatchDeleteCmd{}, []string{"msg1"}, ctx, &RootFlags{Account: "a@b.com", NoInput: true})
+	if err == nil || !strings.Contains(err.Error(), "without --force") {
+		t.Fatalf("expected destructive confirmation error, got %v", err)
+	}
+	if serviceCreated {
+		t.Fatal("service created after destructive deletion was refused")
+	}
+}
+
 func TestGmailBatchDeleteCmd_JSON(t *testing.T) {
 	origNew := newGmailService
 	t.Cleanup(func() { newGmailService = origNew })
@@ -193,7 +243,7 @@ func TestGmailBatchDeleteCmd_JSON(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 
 	out := captureStdout(t, func() {
 		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})


### PR DESCRIPTION
## Summary
- Require at least one message ID and shared destructive confirmation before Gmail permanent `batch delete`
- Empty IDs fail locally before service construction; `--force` remains the automation bypass
- Changelog note for #55

Closes #55

## Test plan
- [x] Focused: `go test ./internal/cmd/ -run 'TestGmailBatchDelete' -count=1`
- [x] Full: `make ci` (fmt-check, lint, test) with Go/tools outside the repo
- [ ] GitHub Actions CI green