### PR TITLE
fix(gmail): guard settings deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Docs: require shared destructive confirmation before `docs delete-range` submits a content deletion. (#54)
 - Gmail: require message IDs and shared destructive confirmation before permanent batch deletion. (#55)
 - Gmail: require shared destructive confirmation before deleting a resolved label. (#56)
+- Gmail: require shared destructive confirmation before removing a delegate, send-as alias, filter, or forwarding address. (#57)
 
 ## 0.10.0 - 2026-08-07
 

--- a/internal/cmd/execute_gmail_settings_more_commands_test.go
+++ b/internal/cmd/execute_gmail_settings_more_commands_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,43 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 )
+
+func TestExecute_GmailSettingsDestructiveCommandsRequireForce(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	serviceCreations := 0
+	newGmailService = func(context.Context, string) (*gmail.Service, error) {
+		serviceCreations++
+		return nil, errors.New("gmail service should not be created")
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "delegate removal", args: []string{"gmail", "settings", "delegates", "remove", "delegate@example.com"}},
+		{name: "send-as deletion", args: []string{"gmail", "settings", "sendas", "delete", "alias@example.com"}},
+		{name: "filter deletion", args: []string{"gmail", "settings", "filters", "delete", "filter-1"}},
+		{name: "forwarding address deletion", args: []string{"gmail", "settings", "forwarding", "delete", "forward@example.com"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"--account", "a@b.com", "--no-input"}, tt.args...)
+			err := Execute(args)
+			if err == nil {
+				t.Fatal("expected destructive command to require --force")
+			}
+			if !strings.Contains(err.Error(), "without --force") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if serviceCreations != 0 {
+				t.Fatalf("gmail service created %d times before refusal", serviceCreations)
+			}
+		})
+	}
+}
 
 func TestExecute_GmailSettingsMoreCommands_JSON(t *testing.T) {
 	origNew := newGmailService
@@ -222,7 +260,7 @@ func TestExecute_GmailSettingsMoreCommands_JSON(t *testing.T) {
 			}
 		})
 		_ = captureStdout(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "gmail", "delegates", "remove", "d@b.com"}); err != nil {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "--force", "gmail", "delegates", "remove", "d@b.com"}); err != nil {
 				t.Fatalf("delegates remove: %v", err)
 			}
 		})
@@ -243,7 +281,7 @@ func TestExecute_GmailSettingsMoreCommands_JSON(t *testing.T) {
 			}
 		})
 		_ = captureStdout(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "gmail", "forwarding", "delete", "f@b.com"}); err != nil {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "--force", "gmail", "forwarding", "delete", "f@b.com"}); err != nil {
 				t.Fatalf("forwarding delete: %v", err)
 			}
 		})
@@ -286,7 +324,7 @@ func TestExecute_GmailSettingsMoreCommands_JSON(t *testing.T) {
 			}
 		})
 		_ = captureStdout(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "gmail", "filters", "delete", "f1"}); err != nil {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "--force", "gmail", "filters", "delete", "f1"}); err != nil {
 				t.Fatalf("filters delete: %v", err)
 			}
 		})
@@ -317,7 +355,7 @@ func TestExecute_GmailSettingsMoreCommands_JSON(t *testing.T) {
 			}
 		})
 		_ = captureStdout(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "gmail", "sendas", "delete", "alias@b.com"}); err != nil {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "--force", "gmail", "sendas", "delete", "alias@b.com"}); err != nil {
 				t.Fatalf("sendas delete: %v", err)
 			}
 		})

--- a/internal/cmd/gmail_delegates.go
+++ b/internal/cmd/gmail_delegates.go
@@ -144,15 +144,19 @@ func (c *GmailDelegatesRemoveCmd) Run(ctx context.Context, flags *RootFlags) err
 		return err
 	}
 
+	delegateEmail := strings.TrimSpace(c.DelegateEmail)
+	if delegateEmail == "" {
+		return usage("empty delegateEmail")
+	}
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("remove gmail delegate %s", delegateEmail)); confirmErr != nil {
+		return confirmErr
+	}
+
 	svc, err := newGmailService(ctx, account)
 	if err != nil {
 		return err
 	}
 
-	delegateEmail := strings.TrimSpace(c.DelegateEmail)
-	if delegateEmail == "" {
-		return usage("empty delegateEmail")
-	}
 	err = svc.Users.Settings.Delegates.Delete("me", delegateEmail).Do()
 	if err != nil {
 		return err

--- a/internal/cmd/gmail_filters.go
+++ b/internal/cmd/gmail_filters.go
@@ -327,15 +327,19 @@ func (c *GmailFiltersDeleteCmd) Run(ctx context.Context, flags *RootFlags) error
 		return err
 	}
 
+	filterID := strings.TrimSpace(c.FilterID)
+	if filterID == "" {
+		return usage("empty filterId")
+	}
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("delete gmail filter %s", filterID)); confirmErr != nil {
+		return confirmErr
+	}
+
 	svc, err := newGmailService(ctx, account)
 	if err != nil {
 		return err
 	}
 
-	filterID := strings.TrimSpace(c.FilterID)
-	if filterID == "" {
-		return usage("empty filterId")
-	}
 	err = svc.Users.Settings.Filters.Delete("me", filterID).Do()
 	if err != nil {
 		return err

--- a/internal/cmd/gmail_filters_cmd_test.go
+++ b/internal/cmd/gmail_filters_cmd_test.go
@@ -111,7 +111,7 @@ func TestGmailFilters_TextPaths(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 
 	_ = captureStdout(t, func() {
 		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})

--- a/internal/cmd/gmail_forwarding.go
+++ b/internal/cmd/gmail_forwarding.go
@@ -145,15 +145,19 @@ func (c *GmailForwardingDeleteCmd) Run(ctx context.Context, flags *RootFlags) er
 		return err
 	}
 
+	forwardingEmail := strings.TrimSpace(c.ForwardingEmail)
+	if forwardingEmail == "" {
+		return usage("empty forwardingEmail")
+	}
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("delete gmail forwarding address %s", forwardingEmail)); confirmErr != nil {
+		return confirmErr
+	}
+
 	svc, err := newGmailService(ctx, account)
 	if err != nil {
 		return err
 	}
 
-	forwardingEmail := strings.TrimSpace(c.ForwardingEmail)
-	if forwardingEmail == "" {
-		return usage("empty forwardingEmail")
-	}
 	err = svc.Users.Settings.ForwardingAddresses.Delete("me", forwardingEmail).Do()
 	if err != nil {
 		return err

--- a/internal/cmd/gmail_sendas.go
+++ b/internal/cmd/gmail_sendas.go
@@ -213,6 +213,9 @@ func (c *GmailSendAsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if sendAsEmail == "" {
 		return errors.New("email is required")
 	}
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("delete gmail send-as alias %s", sendAsEmail)); confirmErr != nil {
+		return confirmErr
+	}
 
 	svc, err := newGmailService(ctx, account)
 	if err != nil {

--- a/internal/cmd/gmail_sendas_more_test.go
+++ b/internal/cmd/gmail_sendas_more_test.go
@@ -55,7 +55,7 @@ func TestGmailSendAs_VerifyDeleteUpdate_JSON(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
 	if uiErr != nil {
 		t.Fatalf("ui.New: %v", uiErr)

--- a/internal/cmd/gmail_sendas_test.go
+++ b/internal/cmd/gmail_sendas_test.go
@@ -447,7 +447,7 @@ func TestGmailSendAsDeleteCmd_JSON(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 
 	out := captureStdout(t, func() {
 		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})

--- a/internal/cmd/gmail_sendas_text_more_test.go
+++ b/internal/cmd/gmail_sendas_text_more_test.go
@@ -64,7 +64,7 @@ func TestGmailSendAsCreateVerifyDeleteUpdate_Text(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 
 	createOut := captureStdout(t, func() {
 		errOut := captureStderr(t, func() {

--- a/internal/cmd/gmail_settings_text_test.go
+++ b/internal/cmd/gmail_settings_text_test.go
@@ -107,7 +107,7 @@ func TestGmailSettings_TextPaths(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 
 	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
 	if uiErr != nil {


### PR DESCRIPTION
## Summary
- Route Gmail delegate remove, send-as delete, filter delete, and forwarding-address delete through shared `confirmDestructive` after target validation and before the delete mutation
- Prompt identifies resource type and target; empty targets fail before prompt; declining and `--no-input` send no delete; `--force` remains the automation bypass
- Changelog note for #57

Closes #57

## Source mapping
- Reviewed local intent: `f5002f6` (`fix(gmail): guard settings deletions`)
- Cherry-picked onto current `origin/main` (post #106 / `a95fc4a`) as `0d636da`
- Changelog: `5ccfe42`
- Later local TSV/routing receipt work on main (`7f17956`, `b096d87`) is out of scope for this issue and not included

## Test plan
- [x] Focused: `go test ./internal/cmd/ -run 'TestExecute_GmailSettingsDestructiveCommandsRequireForce|TestExecute_GmailSettingsMoreCommands_JSON|TestGmailFilters_TextPaths|TestGmailSendAs_VerifyDeleteUpdate_JSON|TestGmailSendAsDeleteCmd_JSON|TestGmailSendAsCreateVerifyDeleteUpdate_Text|TestGmailSettings_TextPaths' -count=1`
- [x] Full: `make ci` (fmt-check, lint, test) with Go/tools outside the repo (`/home/jeremy-johnson/.local/go-sdk/go`, GOPATH `/home/jeremy-johnson/go`)
- [x] Two-axis review since `origin/main` (Standards + Spec): pending agent results / no expected blockers
- [ ] GitHub Actions CI green