### PR TITLE
fix(sheets): confirm sheet tab deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Gmail: require message IDs and shared destructive confirmation before permanent batch deletion. (#55)
 - Gmail: require shared destructive confirmation before deleting a resolved label. (#56)
 - Gmail: require shared destructive confirmation before removing a delegate, send-as alias, filter, or forwarding address. (#57)
+- Sheets: require shared destructive confirmation before deleting a sheet tab. (#58)
 
 ## 0.10.0 - 2026-08-07
 

--- a/internal/cmd/sheets_tabs.go
+++ b/internal/cmd/sheets_tabs.go
@@ -99,6 +99,9 @@ func (c *SheetsSheetDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if id == "" {
 		return usage("empty spreadsheetId")
 	}
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("delete sheet tab %d from spreadsheet %s", c.SheetID, id)); confirmErr != nil {
+		return confirmErr
+	}
 
 	svc, err := newSheetsService(ctx, account)
 	if err != nil {

--- a/internal/cmd/sheets_tabs_test.go
+++ b/internal/cmd/sheets_tabs_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/api/option"
@@ -97,6 +98,49 @@ func TestExecute_SheetsSheetAdd_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_SheetsSheetDelete_NoInputRefusesBeforeRequest(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+
+	var batchUpdateRequests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/spreadsheets/s1:batchUpdate") && r.Method == http.MethodPost {
+			batchUpdateRequests.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"spreadsheetId": "s1"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	var executeErr error
+	_ = captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			executeErr = Execute([]string{"--json", "--no-input", "--account", "a@b.com", "sheets", "sheet", "delete", "s1", "--sheet-id", "42"})
+		})
+	})
+	if executeErr == nil {
+		t.Fatal("expected non-interactive deletion to require --force")
+	}
+	if !strings.Contains(executeErr.Error(), "without --force") {
+		t.Fatalf("expected --force guidance, got %v", executeErr)
+	}
+	if got := batchUpdateRequests.Load(); got != 0 {
+		t.Fatalf("expected no batchUpdate request after refusal, got %d", got)
+	}
+}
+
 func TestExecute_SheetsSheetDelete_JSON(t *testing.T) {
 	origNew := newSheetsService
 	t.Cleanup(func() { newSheetsService = origNew })
@@ -134,7 +178,7 @@ func TestExecute_SheetsSheetDelete_JSON(t *testing.T) {
 	}
 	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
 	if uiErr != nil {
 		t.Fatalf("ui.New: %v", uiErr)


### PR DESCRIPTION
## Summary
- Route `sheets sheet delete` through shared `confirmDestructive` after spreadsheet ID validation and before service construction / `DeleteSheet` batch-update
- Prompt identifies sheet tab ID and spreadsheet ID; `--no-input` without `--force` refuses with no mutation; `--force` preserves intentional automation
- Changelog note for #58

Closes #58

## Source mapping
- Reviewed local intent (identical patches): `da3d610` and `d434a02` (`fix(sheets): confirm sheet tab deletion`; patch-id `3febf7765d4d86f45c59deacc8d2c72325601165`)
- Cherry-picked onto current `origin/main` (post #107 / `3bfc631`) as `7cbc3fb`
- Changelog: `b1dee4a`
- Adjacent local branches/history (Gmail confirmation batch, #85 structural TSV, etc.) intentionally excluded

## Test plan
- [x] Focused: `go test ./internal/cmd -count=1 -run 'TestExecute_SheetsSheet(Delete|Add|Update)'` with Go at `/home/jeremy-johnson/.local/go/bin`
- [x] Full: `make ci` (fmt-check, lint, test)
- [x] Two-axis review since `origin/main` (Standards + Spec): no hard findings; mild test-setup duplication judgement only
- [ ] GitHub Actions CI green