### PR TITLE
fix(sheets): confirm before clearing single-range values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Gmail: require shared destructive confirmation before deleting a resolved label. (#56)
 - Gmail: require shared destructive confirmation before removing a delegate, send-as alias, filter, or forwarding address. (#57)
 - Sheets: require shared destructive confirmation before deleting a sheet tab. (#58)
+- Sheets: require shared destructive confirmation before `sheets clear` removes values from a range. (#59)
 
 ## 0.10.0 - 2026-08-07
 

--- a/internal/cmd/execute_sheets_more_commands_test.go
+++ b/internal/cmd/execute_sheets_more_commands_test.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"google.golang.org/api/option"
@@ -17,10 +17,10 @@ func TestExecute_SheetsClear_NoInputRefusesBeforeServiceConstruction(t *testing.
 	origNew := newSheetsService
 	t.Cleanup(func() { newSheetsService = origNew })
 
-	var serviceCalls atomic.Int32
+	serviceCalls := 0
 	newSheetsService = func(context.Context, string) (*sheets.Service, error) {
-		serviceCalls.Add(1)
-		return nil, nil
+		serviceCalls++
+		return nil, errors.New("sheets service should not be created")
 	}
 
 	err := Execute([]string{"--no-input", "--account", "a@b.com", "sheets", "clear", "id1", "Sheet1!A1:B1"})
@@ -30,8 +30,11 @@ func TestExecute_SheetsClear_NoInputRefusesBeforeServiceConstruction(t *testing.
 	if !strings.Contains(err.Error(), "without --force") {
 		t.Fatalf("expected --force guidance, got %v", err)
 	}
-	if got := serviceCalls.Load(); got != 0 {
-		t.Fatalf("expected refusal before Sheets service construction, got %d call(s)", got)
+	if !strings.Contains(err.Error(), "clear range Sheet1!A1:B1 from spreadsheet id1") {
+		t.Fatalf("expected confirmation to identify spreadsheet and range, got %v", err)
+	}
+	if serviceCalls != 0 {
+		t.Fatalf("expected refusal before Sheets service construction, got %d call(s)", serviceCalls)
 	}
 }
 

--- a/internal/cmd/execute_sheets_more_commands_test.go
+++ b/internal/cmd/execute_sheets_more_commands_test.go
@@ -6,11 +6,34 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 )
+
+func TestExecute_SheetsClear_NoInputRefusesBeforeServiceConstruction(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+
+	var serviceCalls atomic.Int32
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) {
+		serviceCalls.Add(1)
+		return nil, nil
+	}
+
+	err := Execute([]string{"--no-input", "--account", "a@b.com", "sheets", "clear", "id1", "Sheet1!A1:B1"})
+	if err == nil {
+		t.Fatal("expected non-interactive clear to require --force")
+	}
+	if !strings.Contains(err.Error(), "without --force") {
+		t.Fatalf("expected --force guidance, got %v", err)
+	}
+	if got := serviceCalls.Load(); got != 0 {
+		t.Fatalf("expected refusal before Sheets service construction, got %d call(s)", got)
+	}
+}
 
 func TestExecute_SheetsMoreCommands(t *testing.T) {
 	origNew := newSheetsService
@@ -120,7 +143,7 @@ func TestExecute_SheetsMoreCommands(t *testing.T) {
 			}
 		})
 		_ = captureStdout(t, func() {
-			if err := Execute([]string{"--json", "sheets", "clear", "id1", "Sheet1!A1:B1"}); err != nil {
+			if err := Execute([]string{"--json", "--force", "sheets", "clear", "id1", "Sheet1!A1:B1"}); err != nil {
 				t.Fatalf("clear: %v", err)
 			}
 		})

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -348,6 +348,10 @@ func (c *SheetsClearCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("empty range")
 	}
 
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("clear range %s from spreadsheet %s", rangeSpec, spreadsheetID)); confirmErr != nil {
+		return confirmErr
+	}
+
 	svc, err := newSheetsService(ctx, account)
 	if err != nil {
 		return err

--- a/internal/cmd/sheets_commands_test.go
+++ b/internal/cmd/sheets_commands_test.go
@@ -92,7 +92,7 @@ func TestSheetsCommands_JSON(t *testing.T) {
 	}
 	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
 	if uiErr != nil {
 		t.Fatalf("ui.New: %v", uiErr)
@@ -218,7 +218,7 @@ func TestSheetsCommands_Text(t *testing.T) {
 	}
 	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 
 	out := captureStdout(t, func() {
 		u, uiErr := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})


### PR DESCRIPTION
## Summary
- Require shared `confirmDestructive` before `sheets clear` constructs the Sheets service or clears a range.
- Fail non-interactive runs without `--force`, identify spreadsheet + normalized range in the confirmation action, and keep existing validation ordering.
- Add focused refusal coverage, update force-required clear tests, and note the fix in Unreleased CHANGELOG.

Closes #59

## Test plan
- [x] `go test ./internal/cmd/ -count=1 -run 'SheetsClear|SheetsCommands|SheetsMore'`
- [x] `make ci` (Go toolchain outside repo)
- [x] Independent standards + exact-spec review (no confirmed findings)