### PR TITLE
fix(gmail): honor tracking setup/status output modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Gmail: require shared destructive confirmation before removing a delegate, send-as alias, filter, or forwarding address. (#57)
 - Sheets: require shared destructive confirmation before deleting a sheet tab. (#58)
 - Sheets: require shared destructive confirmation before `sheets clear` removes values from a range. (#59)
+- Gmail: honor `--json` and `--plain` for tracking setup and status. (#60)
 
 ## 0.10.0 - 2026-08-07
 

--- a/internal/cmd/gmail_track_cmd_test.go
+++ b/internal/cmd/gmail_track_cmd_test.go
@@ -5,11 +5,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/steipete/gogcli/internal/tracking"
 )
+
+const testTrackingWorkerName = "gog-email-tracker-a-b-com"
 
 func setupTrackingEnv(t *testing.T) {
 	t.Helper()
@@ -18,6 +21,17 @@ func setupTrackingEnv(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
 	t.Setenv("GOG_KEYRING_BACKEND", "file")
 	t.Setenv("GOG_KEYRING_PASSWORD", "testpass")
+}
+
+func configureTracking(t *testing.T) {
+	t.Helper()
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--account", "a@b.com", "--no-input", "gmail", "track", "setup", "--worker-url", "https://example.com"}); err != nil {
+				t.Fatalf("setup Execute: %v", err)
+			}
+		})
+	})
 }
 
 func TestGmailTrackSetupAndStatus(t *testing.T) {
@@ -46,6 +60,192 @@ func TestGmailTrackSetupAndStatus(t *testing.T) {
 	})
 	if !strings.Contains(statusOut, "configured\ttrue") {
 		t.Fatalf("unexpected status output: %q", statusOut)
+	}
+}
+
+func TestGmailTrackSetup_JSON(t *testing.T) {
+	setupTrackingEnv(t)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "--no-input", "gmail", "track", "setup", "--worker-url", "https://example.com"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("setup output is not valid JSON: %v\n%s", err, out)
+	}
+	configPath, err := tracking.ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	want := map[string]any{
+		"configured":      true,
+		"account":         "a@b.com",
+		"configPath":      configPath,
+		"workerURL":       "https://example.com",
+		"workerName":      testTrackingWorkerName,
+		"databaseName":    testTrackingWorkerName,
+		"databaseID":      "",
+		"adminConfigured": true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("setup JSON = %#v, want %#v", got, want)
+	}
+}
+
+func TestGmailTrackSetup_Plain(t *testing.T) {
+	setupTrackingEnv(t)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "--no-input", "gmail", "track", "setup", "--worker-url", "https://example.com"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	configPath, err := tracking.ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	want := "KEY\tVALUE\n" +
+		"configured\ttrue\n" +
+		"account\ta@b.com\n" +
+		"configPath\t" + configPath + "\n" +
+		"workerURL\thttps://example.com\n" +
+		"workerName\t" + testTrackingWorkerName + "\n" +
+		"databaseName\t" + testTrackingWorkerName + "\n" +
+		"databaseID\t\n" +
+		"adminConfigured\ttrue\n"
+	if out != want {
+		t.Fatalf("setup plain output = %q, want %q", out, want)
+	}
+}
+
+func TestGmailTrackStatus_JSON(t *testing.T) {
+	setupTrackingEnv(t)
+	configureTracking(t)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "gmail", "track", "status"}); err != nil {
+				t.Fatalf("status Execute: %v", err)
+			}
+		})
+	})
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("status output is not valid JSON: %v\n%s", err, out)
+	}
+	configPath, err := tracking.ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	want := map[string]any{
+		"configured":      true,
+		"account":         "a@b.com",
+		"configPath":      configPath,
+		"workerURL":       "https://example.com",
+		"workerName":      testTrackingWorkerName,
+		"databaseName":    testTrackingWorkerName,
+		"databaseID":      "",
+		"adminConfigured": true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("status JSON = %#v, want %#v", got, want)
+	}
+}
+
+func TestGmailTrackStatus_Plain(t *testing.T) {
+	setupTrackingEnv(t)
+	configureTracking(t)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "gmail", "track", "status"}); err != nil {
+				t.Fatalf("status Execute: %v", err)
+			}
+		})
+	})
+	configPath, err := tracking.ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	want := "KEY\tVALUE\n" +
+		"configured\ttrue\n" +
+		"account\ta@b.com\n" +
+		"configPath\t" + configPath + "\n" +
+		"workerURL\thttps://example.com\n" +
+		"workerName\t" + testTrackingWorkerName + "\n" +
+		"databaseName\t" + testTrackingWorkerName + "\n" +
+		"databaseID\t\n" +
+		"adminConfigured\ttrue\n"
+	if out != want {
+		t.Fatalf("status plain output = %q, want %q", out, want)
+	}
+}
+
+func TestGmailTrackStatus_JSONNotConfigured(t *testing.T) {
+	setupTrackingEnv(t)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "gmail", "track", "status"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("status output is not valid JSON: %v\n%s", err, out)
+	}
+	configPath, err := tracking.ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	want := map[string]any{
+		"configured":      false,
+		"account":         "a@b.com",
+		"configPath":      configPath,
+		"workerURL":       "",
+		"workerName":      "",
+		"databaseName":    "",
+		"databaseID":      "",
+		"adminConfigured": false,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unconfigured status JSON = %#v, want %#v", got, want)
+	}
+}
+
+func TestGmailTrackStatus_PlainNotConfigured(t *testing.T) {
+	setupTrackingEnv(t)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "gmail", "track", "status"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	configPath, err := tracking.ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	want := "KEY\tVALUE\n" +
+		"configured\tfalse\n" +
+		"account\ta@b.com\n" +
+		"configPath\t" + configPath + "\n" +
+		"workerURL\t\n" +
+		"workerName\t\n" +
+		"databaseName\t\n" +
+		"databaseID\t\n" +
+		"adminConfigured\tfalse\n"
+	if out != want {
+		t.Fatalf("unconfigured status plain output = %q, want %q", out, want)
 	}
 }
 

--- a/internal/cmd/gmail_track_setup.go
+++ b/internal/cmd/gmail_track_setup.go
@@ -12,9 +12,33 @@ import (
 	"strings"
 
 	"github.com/steipete/gogcli/internal/input"
+	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/tracking"
 	"github.com/steipete/gogcli/internal/ui"
 )
+
+type gmailTrackOutput struct {
+	Configured      bool   `json:"configured"`
+	Account         string `json:"account"`
+	ConfigPath      string `json:"configPath"`
+	WorkerURL       string `json:"workerURL"`
+	WorkerName      string `json:"workerName"`
+	DatabaseName    string `json:"databaseName"`
+	DatabaseID      string `json:"databaseID"`
+	AdminConfigured bool   `json:"adminConfigured"`
+}
+
+func writeGmailTrackPlain(ctx context.Context, result gmailTrackOutput) {
+	writeTableRow(ctx, os.Stdout, []string{"KEY", "VALUE"})
+	writeTableRow(ctx, os.Stdout, []string{"configured", boolString(result.Configured)})
+	writeTableRow(ctx, os.Stdout, []string{"account", result.Account})
+	writeTableRow(ctx, os.Stdout, []string{"configPath", result.ConfigPath})
+	writeTableRow(ctx, os.Stdout, []string{"workerURL", result.WorkerURL})
+	writeTableRow(ctx, os.Stdout, []string{"workerName", result.WorkerName})
+	writeTableRow(ctx, os.Stdout, []string{"databaseName", result.DatabaseName})
+	writeTableRow(ctx, os.Stdout, []string{"databaseID", result.DatabaseID})
+	writeTableRow(ctx, os.Stdout, []string{"adminConfigured", boolString(result.AdminConfigured)})
+}
 
 type GmailTrackSetupCmd struct {
 	WorkerName   string `name:"worker-name" help:"Cloudflare Worker name (defaults to gog-email-tracker-<account>)"`
@@ -132,16 +156,35 @@ func (c *GmailTrackSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	path, _ := tracking.ConfigPath()
-	u.Out().Printf("configured\ttrue")
-	u.Out().Printf("account\t%s", account)
-	if path != "" {
-		u.Out().Printf("config_path\t%s", path)
+	result := gmailTrackOutput{
+		Configured:      true,
+		Account:         account,
+		ConfigPath:      path,
+		WorkerURL:       cfg.WorkerURL,
+		WorkerName:      cfg.WorkerName,
+		DatabaseName:    cfg.DatabaseName,
+		DatabaseID:      cfg.DatabaseID,
+		AdminConfigured: true,
 	}
-	u.Out().Printf("worker_url\t%s", cfg.WorkerURL)
-	u.Out().Printf("worker_name\t%s", cfg.WorkerName)
-	u.Out().Printf("database_name\t%s", cfg.DatabaseName)
-	if cfg.DatabaseID != "" {
-		u.Out().Printf("database_id\t%s", cfg.DatabaseID)
+	switch {
+	case outfmt.IsJSON(ctx):
+		if err := outfmt.WriteJSON(os.Stdout, result); err != nil {
+			return err
+		}
+	case outfmt.IsPlain(ctx):
+		writeGmailTrackPlain(ctx, result)
+	default:
+		u.Out().Printf("configured\ttrue")
+		u.Out().Printf("account\t%s", account)
+		if path != "" {
+			u.Out().Printf("config_path\t%s", path)
+		}
+		u.Out().Printf("worker_url\t%s", cfg.WorkerURL)
+		u.Out().Printf("worker_name\t%s", cfg.WorkerName)
+		u.Out().Printf("database_name\t%s", cfg.DatabaseName)
+		if cfg.DatabaseID != "" {
+			u.Out().Printf("database_id\t%s", cfg.DatabaseID)
+		}
 	}
 
 	if !c.Deploy {

--- a/internal/cmd/gmail_track_status.go
+++ b/internal/cmd/gmail_track_status.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"context"
+	"os"
 	"strings"
 
+	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/tracking"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -18,6 +20,24 @@ func (c *GmailTrackStatusCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	path, _ := tracking.ConfigPath()
+	result := gmailTrackOutput{
+		Configured:      cfg.IsConfigured(),
+		Account:         account,
+		ConfigPath:      path,
+		WorkerURL:       cfg.WorkerURL,
+		WorkerName:      cfg.WorkerName,
+		DatabaseName:    cfg.DatabaseName,
+		DatabaseID:      cfg.DatabaseID,
+		AdminConfigured: strings.TrimSpace(cfg.AdminKey) != "",
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, result)
+	}
+	if outfmt.IsPlain(ctx) {
+		writeGmailTrackPlain(ctx, result)
+		return nil
+	}
+
 	if path != "" {
 		u.Out().Printf("config_path\t%s", path)
 	}


### PR DESCRIPTION
## Summary
- Honor global `--json` and `--plain` for `gmail track setup` and `gmail track status` while keeping the existing human default stdout and stderr deploy guidance.
- Emit one camelCase JSON object and a deterministic `KEY\tVALUE` plain table covering configured state, account, config path, worker URL/name, database name/ID, and admin-key configuration.
- Cover configured and unconfigured status cases in focused tests and note the fix in Unreleased CHANGELOG.

Closes #60

## Test plan
- [x] `go test ./internal/cmd/ -count=1 -run 'GmailTrack'`
- [x] `make ci` (Go toolchain outside repo)
- [x] Independent standards + exact-spec review (no confirmed findings)