### PR TITLE
fix(analytics): include measurement IDs in stream detail TSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Sheets: require shared destructive confirmation before deleting a sheet tab. (#58)
 - Sheets: require shared destructive confirmation before `sheets clear` removes values from a range. (#59)
 - Gmail: honor `--json` and `--plain` for tracking setup and status. (#60)
+- Analytics: include measurement IDs in the stable six-column data-stream detail TSV schema. (#61)
 
 ## 0.10.0 - 2026-08-07
 

--- a/internal/cmd/analytics_admin_streams.go
+++ b/internal/cmd/analytics_admin_streams.go
@@ -184,16 +184,12 @@ func (c *AADataStreamsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	fmt.Fprintln(w, "NAME\tTYPE\tDISPLAY_NAME\tCREATED\tUPDATED")
+	fmt.Fprintln(w, "NAME\tTYPE\tDISPLAY_NAME\tCREATED\tUPDATED\tMEASUREMENT_ID")
 	measurementID := ""
 	if resp.WebStreamData != nil {
 		measurementID = resp.WebStreamData.MeasurementId
 	}
-	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", resp.Name, resp.Type, resp.DisplayName, resp.CreateTime, resp.UpdateTime)
-	if measurementID != "" {
-		u := ui.FromContext(ctx)
-		u.Out().Printf("Measurement ID: %s", measurementID)
-	}
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", resp.Name, resp.Type, resp.DisplayName, resp.CreateTime, resp.UpdateTime, measurementID)
 	return nil
 }
 

--- a/internal/cmd/analytics_admin_streams.go
+++ b/internal/cmd/analytics_admin_streams.go
@@ -184,12 +184,12 @@ func (c *AADataStreamsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	fmt.Fprintln(w, "NAME\tTYPE\tDISPLAY_NAME\tCREATED\tUPDATED\tMEASUREMENT_ID")
+	writeTableRow(ctx, w, []string{"NAME", "TYPE", "DISPLAY_NAME", "CREATED", "UPDATED", "MEASUREMENT_ID"})
 	measurementID := ""
 	if resp.WebStreamData != nil {
 		measurementID = resp.WebStreamData.MeasurementId
 	}
-	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", resp.Name, resp.Type, resp.DisplayName, resp.CreateTime, resp.UpdateTime, measurementID)
+	writeTableRow(ctx, w, []string{resp.Name, resp.Type, resp.DisplayName, resp.CreateTime, resp.UpdateTime, measurementID})
 	return nil
 }
 

--- a/internal/cmd/analytics_admin_streams_test.go
+++ b/internal/cmd/analytics_admin_streams_test.go
@@ -380,7 +380,7 @@ func TestExecute_AADataStreamsGet_PlainStableSchema(t *testing.T) {
 				response := map[string]any{
 					"name":        "properties/123/dataStreams/456",
 					"type":        tt.streamType,
-					"displayName": "Healthcare LP",
+					"displayName": "Healthcare\tLP\r\nTeam",
 					"createTime":  "2026-01-01T00:00:00Z",
 					"updateTime":  "2026-01-02T00:00:00Z",
 				}
@@ -406,7 +406,7 @@ func TestExecute_AADataStreamsGet_PlainStableSchema(t *testing.T) {
 			})
 
 			want := "NAME\tTYPE\tDISPLAY_NAME\tCREATED\tUPDATED\tMEASUREMENT_ID\n" +
-				"properties/123/dataStreams/456\t" + tt.streamType + "\tHealthcare LP\t2026-01-01T00:00:00Z\t2026-01-02T00:00:00Z\t" + tt.measurementID + "\n"
+				"properties/123/dataStreams/456\t" + tt.streamType + "\tHealthcare LP Team\t2026-01-01T00:00:00Z\t2026-01-02T00:00:00Z\t" + tt.measurementID + "\n"
 			if out != want {
 				t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
 			}

--- a/internal/cmd/analytics_admin_streams_test.go
+++ b/internal/cmd/analytics_admin_streams_test.go
@@ -343,6 +343,77 @@ func TestExecute_AADataStreamsGet_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_AADataStreamsGet_PlainStableSchema(t *testing.T) {
+	tests := []struct {
+		name          string
+		streamType    string
+		streamData    map[string]any
+		measurementID string
+	}{
+		{
+			name:       "web stream",
+			streamType: "WEB_DATA_STREAM",
+			streamData: map[string]any{
+				"webStreamData": map[string]any{
+					"defaultUri":    "https://healthcare.itallyllc.com",
+					"measurementId": "G-ABC123",
+				},
+			},
+			measurementID: "G-ABC123",
+		},
+		{
+			name:       "non-web stream",
+			streamType: "ANDROID_APP_DATA_STREAM",
+			streamData: map[string]any{
+				"androidAppStreamData": map[string]any{
+					"packageName": "com.example.app",
+				},
+			},
+			measurementID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				response := map[string]any{
+					"name":        "properties/123/dataStreams/456",
+					"type":        tt.streamType,
+					"displayName": "Healthcare LP",
+					"createTime":  "2026-01-01T00:00:00Z",
+					"updateTime":  "2026-01-02T00:00:00Z",
+				}
+				for key, value := range tt.streamData {
+					response[key] = value
+				}
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			defer srv.Close()
+			setupAnalyticsServices(t, srv)
+
+			out := captureStdout(t, func() {
+				_ = captureStderr(t, func() {
+					if err := Execute([]string{
+						"--plain", "--account", "a@b.com",
+						"analytics", "admin", "data-streams", "get",
+						"--property", "123",
+						"456",
+					}); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+
+			want := "NAME\tTYPE\tDISPLAY_NAME\tCREATED\tUPDATED\tMEASUREMENT_ID\n" +
+				"properties/123/dataStreams/456\t" + tt.streamType + "\tHealthcare LP\t2026-01-01T00:00:00Z\t2026-01-02T00:00:00Z\t" + tt.measurementID + "\n"
+			if out != want {
+				t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+			}
+		})
+	}
+}
+
 func TestExecute_AADataStreamsDelete_WithoutForce(t *testing.T) {
 	srv := analyticsAdminStreamsTestServer()
 	defer srv.Close()


### PR DESCRIPTION
## Summary
- add `MEASUREMENT_ID` to the fixed Analytics data-stream detail TSV schema
- populate web stream IDs and preserve an empty final field for non-web streams
- sanitize API-provided fields so plain TSV remains one physical row
- document the fix in the changelog

## Testing
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" go test ./internal/cmd -run 'TestExecute_AADataStreamsGet_(PlainStableSchema|JSON)$'`
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci`

Closes #61
