### PR TITLE
fix(auth): keep plain setup advice on stderr

### DIFF
--- a/internal/cmd/auth_service_account.go
+++ b/internal/cmd/auth_service_account.go
@@ -113,7 +113,12 @@ func (c *AuthServiceAccountSetCmd) Run(ctx context.Context) error {
 	if info.ClientID != "" {
 		u.Out().Printf("client_id\t%s", info.ClientID)
 	}
-	u.Out().Println("Service account configured. Use: gog <cmd> --account " + email)
+	advice := "Service account configured. Use: gog <cmd> --account " + email
+	if outfmt.IsPlain(ctx) {
+		u.Err().Println(advice)
+	} else {
+		u.Out().Println(advice)
+	}
 	return nil
 }
 

--- a/internal/cmd/auth_service_account_more_test.go
+++ b/internal/cmd/auth_service_account_more_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,6 +55,75 @@ func TestAuthServiceAccountSet_AndList_Text(t *testing.T) {
 	})
 	if !strings.Contains(listOut, "user@example.com") || !strings.Contains(listOut, "service_account") {
 		t.Fatalf("unexpected list output: %q", listOut)
+	}
+}
+
+func TestAuthServiceAccountSet_PlainKeepsAdviceOffStdout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	const email = "user@example.com"
+	keyPath := filepath.Join(t.TempDir(), "sa.json")
+	if err := os.WriteFile(keyPath, []byte(`{"type":"service_account","client_email":"svc@example.com","client_id":"12345"}`), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	var stderr string
+	stdout := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "auth", "service-account", "set", email, "--key", keyPath}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	storedPath, err := config.ServiceAccountPath(email)
+	if err != nil {
+		t.Fatalf("ServiceAccountPath: %v", err)
+	}
+	wantStdout := "email\t" + email + "\n" +
+		"path\t" + storedPath + "\n" +
+		"client_email\tsvc@example.com\n" +
+		"client_id\t12345\n"
+	if stdout != wantStdout {
+		t.Fatalf("plain stdout mismatch:\n got: %q\nwant: %q", stdout, wantStdout)
+	}
+	wantAdvice := "Service account configured. Use: gog <cmd> --account " + email
+	if !strings.Contains(stderr, wantAdvice) {
+		t.Fatalf("plain stderr missing usage advice %q: %q", wantAdvice, stderr)
+	}
+}
+
+func TestAuthServiceAccountSet_JSONExcludesNarrativeAdvice(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	const email = "user@example.com"
+	keyPath := filepath.Join(t.TempDir(), "sa.json")
+	if err := os.WriteFile(keyPath, []byte(`{"type":"service_account","client_email":"svc@example.com","client_id":"12345"}`), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	var stderr string
+	stdout := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "auth", "service-account", "set", email, "--key", keyPath}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode JSON output %q: %v", stdout, err)
+	}
+	if got["stored"] != true || got["email"] != email || got["client_email"] != "svc@example.com" || got["client_id"] != "12345" {
+		t.Fatalf("unexpected JSON result: %#v", got)
+	}
+	if strings.Contains(stdout, "Service account configured") || strings.Contains(stderr, "Service account configured") {
+		t.Fatalf("JSON output included narrative advice: stdout=%q stderr=%q", stdout, stderr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep service-account setup `--plain` stdout limited to deterministic TSV fields
- send follow-up account usage guidance to stderr in plain mode
- preserve JSON and default human behavior

## Testing
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" go test ./internal/cmd -run 'TestAuthServiceAccountSet_(PlainKeepsAdviceOffStdout|JSONExcludesNarrativeAdvice|AndList_Text)$' -count=1`
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci`

Closes #63
