### PR TITLE
fix(calendar): keep propose-time plain output parseable

### DIFF
--- a/internal/cmd/calendar_propose_time.go
+++ b/internal/cmd/calendar_propose_time.go
@@ -209,8 +209,13 @@ func (c *CalendarProposeTimeCmd) Run(ctx context.Context, flags *RootFlags) erro
 
 	// Open browser if requested.
 	if c.Open {
-		u.Err().Printf("")
-		u.Err().Printf("Opening browser...")
+		if outfmt.IsPlain(ctx) {
+			u.Err().Printf("")
+			u.Err().Printf("Opening browser...")
+		} else {
+			u.Out().Printf("")
+			u.Out().Printf("Opening browser...")
+		}
 		if err := openProposeTimeBrowser(proposeURL); err != nil {
 			u.Err().Printf("Failed to open browser: %v", err)
 			u.Err().Printf("Please open the propose_url manually.")

--- a/internal/cmd/calendar_propose_time.go
+++ b/internal/cmd/calendar_propose_time.go
@@ -136,16 +136,13 @@ func (c *CalendarProposeTimeCmd) Run(ctx context.Context, flags *RootFlags) erro
 		return outfmt.WriteJSON(os.Stdout, result)
 	}
 
-	// Text output
-	u.Out().Printf("# API Limitation: %s", proposeTimeAPILimitation)
-	u.Out().Printf("# Issue tracker: %s", proposeTimeIssueTrackerURL)
-	u.Out().Printf("# Action: %s", proposeTimeUpvoteAction)
-	u.Out().Printf("")
-	u.Out().Printf("event\t%s", orEmpty(event.Summary, "(no title)"))
-	if event.Start != nil {
-		start := event.Start.DateTime
-		if start == "" {
-			start = event.Start.Date
+	if outfmt.IsPlain(ctx) {
+		start := ""
+		if event.Start != nil {
+			start = event.Start.DateTime
+			if start == "" {
+				start = event.Start.Date
+			}
 		}
 		end := ""
 		if event.End != nil {
@@ -154,26 +151,66 @@ func (c *CalendarProposeTimeCmd) Run(ctx context.Context, flags *RootFlags) erro
 				end = event.End.Date
 			}
 		}
-		u.Out().Printf("current\t%s - %s", start, end)
-	}
-	u.Out().Printf("propose_url\t%s", proposeURL)
 
-	if decline {
-		u.Out().Printf("")
-		u.Out().Printf("declined\tyes")
-		if strings.TrimSpace(c.Comment) != "" {
-			u.Out().Printf("comment\t%s", strings.TrimSpace(c.Comment))
+		writeTableRow(ctx, os.Stdout, []string{"KEY", "VALUE"})
+		writeTableRow(ctx, os.Stdout, []string{"event_id", eventID})
+		writeTableRow(ctx, os.Stdout, []string{"calendar_id", calendarID})
+		writeTableRow(ctx, os.Stdout, []string{"summary", event.Summary})
+		writeTableRow(ctx, os.Stdout, []string{"current_start", start})
+		writeTableRow(ctx, os.Stdout, []string{"current_end", end})
+		writeTableRow(ctx, os.Stdout, []string{"propose_url", proposeURL})
+		writeTableRow(ctx, os.Stdout, []string{"declined", boolString(decline)})
+		if comment := strings.TrimSpace(c.Comment); comment != "" {
+			writeTableRow(ctx, os.Stdout, []string{"comment", comment})
+		}
+
+		u.Err().Printf("# API Limitation: %s", proposeTimeAPILimitation)
+		u.Err().Printf("# Issue tracker: %s", proposeTimeIssueTrackerURL)
+		u.Err().Printf("# Action: %s", proposeTimeUpvoteAction)
+		if !decline {
+			u.Err().Printf("Tip: To notify the organizer, decline with a comment:")
+			u.Err().Printf("  gog calendar propose-time %s %s --decline --comment \"Can we do 5pm instead?\"", calendarID, eventID)
 		}
 	} else {
+		// Human-readable text output.
+		u.Out().Printf("# API Limitation: %s", proposeTimeAPILimitation)
+		u.Out().Printf("# Issue tracker: %s", proposeTimeIssueTrackerURL)
+		u.Out().Printf("# Action: %s", proposeTimeUpvoteAction)
 		u.Out().Printf("")
-		u.Out().Printf("Tip: To notify the organizer, decline with a comment:")
-		u.Out().Printf("  gog calendar propose-time %s %s --decline --comment \"Can we do 5pm instead?\"", calendarID, eventID)
+		u.Out().Printf("event\t%s", orEmpty(event.Summary, "(no title)"))
+		if event.Start != nil {
+			start := event.Start.DateTime
+			if start == "" {
+				start = event.Start.Date
+			}
+			end := ""
+			if event.End != nil {
+				end = event.End.DateTime
+				if end == "" {
+					end = event.End.Date
+				}
+			}
+			u.Out().Printf("current\t%s - %s", start, end)
+		}
+		u.Out().Printf("propose_url\t%s", proposeURL)
+
+		if decline {
+			u.Out().Printf("")
+			u.Out().Printf("declined\tyes")
+			if strings.TrimSpace(c.Comment) != "" {
+				u.Out().Printf("comment\t%s", strings.TrimSpace(c.Comment))
+			}
+		} else {
+			u.Out().Printf("")
+			u.Out().Printf("Tip: To notify the organizer, decline with a comment:")
+			u.Out().Printf("  gog calendar propose-time %s %s --decline --comment \"Can we do 5pm instead?\"", calendarID, eventID)
+		}
 	}
 
-	// Open browser if requested
+	// Open browser if requested.
 	if c.Open {
-		u.Out().Printf("")
-		u.Out().Printf("Opening browser...")
+		u.Err().Printf("")
+		u.Err().Printf("Opening browser...")
 		if err := openProposeTimeBrowser(proposeURL); err != nil {
 			u.Err().Printf("Failed to open browser: %v", err)
 			u.Err().Printf("Please open the propose_url manually.")

--- a/internal/cmd/calendar_propose_time_test.go
+++ b/internal/cmd/calendar_propose_time_test.go
@@ -269,6 +269,9 @@ func TestCalendarProposeTimeCmd_Text(t *testing.T) {
 	if !strings.Contains(out, "Action: "+proposeTimeUpvoteAction) {
 		t.Errorf("output missing upvote action: %q", out)
 	}
+	if !strings.Contains(out, "Opening browser...") {
+		t.Errorf("output missing browser progress: %q", out)
+	}
 
 	// Verify browser was opened
 	if browserOpened == "" {

--- a/internal/cmd/calendar_propose_time_test.go
+++ b/internal/cmd/calendar_propose_time_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -49,6 +50,144 @@ func TestProposeTimeURLGeneration(t *testing.T) {
 				t.Errorf("URL mismatch:\ngot:  %s\nwant: %s", got, tt.wantURL)
 			}
 		})
+	}
+}
+
+func TestExecute_CalendarProposeTime_PlainKeepsGuidanceOffStdout(t *testing.T) {
+	origNew := newCalendarService
+	origOpen := openProposeTimeBrowser
+	t.Cleanup(func() {
+		newCalendarService = origNew
+		openProposeTimeBrowser = origOpen
+	})
+
+	openProposeTimeBrowser = func(string) error { return errors.New("browser unavailable") }
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/calendars/cal1/events/evt1") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "evt1",
+			"summary": "Team Meeting",
+			"start":   map[string]string{"dateTime": "2026-01-16T19:30:00-08:00"},
+			"end":     map[string]string{"dateTime": "2026-01-16T20:30:00-08:00"},
+			"attendees": []map[string]any{
+				{"email": "a@b.com", "self": true},
+				{"email": "organizer@b.com", "organizer": true},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		errOut := captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "calendar", "propose-time", "cal1", "evt1", "--open"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+		for _, message := range []string{
+			proposeTimeAPILimitation,
+			proposeTimeIssueTrackerURL,
+			proposeTimeUpvoteAction,
+			"Tip: To notify the organizer",
+			"Opening browser...",
+			"Failed to open browser: browser unavailable",
+			"Please open the propose_url manually.",
+		} {
+			if !strings.Contains(errOut, message) {
+				t.Errorf("stderr missing %q: %q", message, errOut)
+			}
+		}
+	})
+
+	want := "KEY\tVALUE\n" +
+		"event_id\tevt1\n" +
+		"calendar_id\tcal1\n" +
+		"summary\tTeam Meeting\n" +
+		"current_start\t2026-01-16T19:30:00-08:00\n" +
+		"current_end\t2026-01-16T20:30:00-08:00\n" +
+		"propose_url\thttps://calendar.google.com/calendar/u/0/r/proposetime/ZXZ0MSBjYWwx\n" +
+		"declined\tfalse\n"
+	if out != want {
+		t.Fatalf("plain stdout = %q, want %q", out, want)
+	}
+}
+
+func TestExecute_CalendarProposeTime_PlainIncludesDeclineAndComment(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/calendars/cal1/events/evt1") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "evt1",
+				"summary": "Team Meeting",
+				"start":   map[string]string{"date": "2026-01-16"},
+				"end":     map[string]string{"date": "2026-01-17"},
+				"attendees": []map[string]any{
+					{"email": "a@b.com", "self": true},
+					{"email": "organizer@b.com", "organizer": true},
+				},
+			})
+		case http.MethodPatch:
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "evt1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		errOut := captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "calendar", "propose-time", "cal1", "evt1", "--comment", "Can we do 5pm instead?"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+		if strings.Contains(errOut, "Tip: To notify the organizer") {
+			t.Fatalf("declined stderr contains decline tip: %q", errOut)
+		}
+	})
+
+	want := "KEY\tVALUE\n" +
+		"event_id\tevt1\n" +
+		"calendar_id\tcal1\n" +
+		"summary\tTeam Meeting\n" +
+		"current_start\t2026-01-16\n" +
+		"current_end\t2026-01-17\n" +
+		"propose_url\thttps://calendar.google.com/calendar/u/0/r/proposetime/ZXZ0MSBjYWwx\n" +
+		"declined\ttrue\n" +
+		"comment\tCan we do 5pm instead?\n"
+	if out != want {
+		t.Fatalf("plain stdout = %q, want %q", out, want)
 	}
 }
 


### PR DESCRIPTION
Summary: emit a deterministic KEY<TAB>VALUE schema for calendar propose-time --plain; route plain-mode limitation guidance, tips, and browser diagnostics to stderr; preserve JSON fields, default human output, proposal URL construction, and decline behavior. Testing: focused propose-time tests and PATH="/home/jeremy-johnson/.local/go-sdk/go/bin:/home/jeremy-johnson/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" make ci. Standards/Fowler and exact-spec reviews completed; the confirmed default browser-progress regression was fixed with regression coverage and spec re-review passed. Closes #64