### PR TITLE
fix(cli): add plain mutation receipts

### DIFF
--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -87,6 +87,11 @@ func (c *ConfigSetCmd) Run(ctx context.Context) error {
 		payload["saved"] = true
 		return outfmt.WriteJSON(os.Stdout, payload)
 	}
+	if outfmt.IsPlain(ctx) {
+		fmt.Fprintln(os.Stdout, "ACTION\tKEY\tVALUE")
+		writeTableRow(ctx, os.Stdout, []string{"set", key.String(), c.Value})
+		return nil
+	}
 	fmt.Fprintf(os.Stdout, "Set %s = %s\n", c.Key, c.Value)
 	return nil
 }
@@ -118,6 +123,11 @@ func (c *ConfigUnsetCmd) Run(ctx context.Context) error {
 		payload := outfmt.KeyValuePayload(key.String(), "")
 		payload["removed"] = true
 		return outfmt.WriteJSON(os.Stdout, payload)
+	}
+	if outfmt.IsPlain(ctx) {
+		fmt.Fprintln(os.Stdout, "ACTION\tKEY\tVALUE")
+		writeTableRow(ctx, os.Stdout, []string{"unset", key.String(), ""})
+		return nil
 	}
 	fmt.Fprintf(os.Stdout, "Unset %s\n", c.Key)
 	return nil

--- a/internal/cmd/config_cmd_test.go
+++ b/internal/cmd/config_cmd_test.go
@@ -105,6 +105,60 @@ func TestConfigCmd_JSONEmptyValues(t *testing.T) {
 	}
 }
 
+func TestConfigSet_PlainReceipt(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "config", "set", "timezone", "UTC"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if want := "ACTION\tKEY\tVALUE\nset\ttimezone\tUTC\n"; out != want {
+		t.Fatalf("plain config set output = %q, want %q", out, want)
+	}
+
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if cfg.DefaultTimezone != "UTC" {
+		t.Fatalf("persisted timezone = %q, want UTC", cfg.DefaultTimezone)
+	}
+}
+
+func TestConfigUnset_PlainReceipt(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := config.WriteConfig(config.File{DefaultTimezone: "UTC"}); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "config", "unset", "timezone"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if want := "ACTION\tKEY\tVALUE\nunset\ttimezone\t\n"; out != want {
+		t.Fatalf("plain config unset output = %q, want %q", out, want)
+	}
+
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if cfg.DefaultTimezone != "" {
+		t.Fatalf("persisted timezone = %q, want empty", cfg.DefaultTimezone)
+	}
+}
+
 func TestConfigList_PlainTSV(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/cmd/policy.go
+++ b/internal/cmd/policy.go
@@ -54,6 +54,14 @@ func (c *PolicyCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"policy":  saved,
 		})
 	}
+	if outfmt.IsPlain(ctx) {
+		fmt.Fprintln(os.Stdout, "ACTION\tNAME\tACCOUNT\tCLIENT\tALLOW\tDENY\tREASON")
+		writeTableRow(ctx, os.Stdout, []string{
+			"create", saved.Name, saved.Account, saved.Client,
+			joinCSV(saved.Allow), joinCSV(saved.Deny), saved.Reason,
+		})
+		return nil
+	}
 	fmt.Fprintf(os.Stdout, "Saved policy %s\n", saved.Name)
 	return nil
 }
@@ -131,6 +139,7 @@ func (c *PolicyDeleteCmd) Run(ctx context.Context) error {
 		return err
 	}
 
+	deleted, _ := config.GetPolicy(cfg, c.Name)
 	if err := config.DeletePolicy(&cfg, c.Name); err != nil {
 		return usage(err.Error())
 	}
@@ -143,6 +152,11 @@ func (c *PolicyDeleteCmd) Run(ctx context.Context) error {
 			"deleted": true,
 			"name":    c.Name,
 		})
+	}
+	if outfmt.IsPlain(ctx) {
+		fmt.Fprintln(os.Stdout, "ACTION\tNAME\tACCOUNT\tCLIENT\tALLOW\tDENY\tREASON")
+		writeTableRow(ctx, os.Stdout, []string{"delete", deleted.Name, "", "", "", "", ""})
+		return nil
 	}
 	fmt.Fprintf(os.Stdout, "Deleted policy %s\n", c.Name)
 	return nil

--- a/internal/cmd/policy_test.go
+++ b/internal/cmd/policy_test.go
@@ -75,6 +75,84 @@ func TestPolicyCreateListGetDelete(t *testing.T) {
 	})
 }
 
+func TestPolicyCreate_PlainReceiptUsesPersistedNormalizedPolicy(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain",
+				"--account", "USER@EXAMPLE.COM",
+				"--client", "personal",
+				"policy", "create", "Safe",
+				"--allow", "gmail:read,gmail:batch-modify",
+				"--deny", "gmail:send",
+				"--reason", "  Needed for triage  ",
+			}); err != nil {
+				t.Fatalf("policy create: %v", err)
+			}
+		})
+	})
+
+	want := "ACTION\tNAME\tACCOUNT\tCLIENT\tALLOW\tDENY\tREASON\n" +
+		"create\tsafe\tuser@example.com\tpersonal\tgmail:batch.modify,gmail:read\tgmail:send\tNeeded for triage\n"
+	if out != want {
+		t.Fatalf("plain policy create output = %q, want %q", out, want)
+	}
+
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	policy, ok := config.GetPolicy(cfg, "safe")
+	if !ok {
+		t.Fatal("expected persisted policy")
+	}
+	if policy.Name != "safe" || policy.Account != "user@example.com" || policy.Client != "personal" ||
+		strings.Join(policy.Allow, ",") != "gmail:batch.modify,gmail:read" ||
+		strings.Join(policy.Deny, ",") != "gmail:send" || policy.Reason != "Needed for triage" {
+		t.Fatalf("unexpected persisted policy: %#v", policy)
+	}
+}
+
+func TestPolicyDelete_PlainReceiptIdentifiesOnlyDeletedPolicy(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := config.WriteConfig(config.File{Policies: []config.Policy{
+		{Name: "keep", Account: "keep@example.com", Allow: []string{"gmail:read"}},
+		{Name: "safe", Account: "user@example.com", Client: "personal", Allow: []string{"gmail:read"}, Reason: "remove me"},
+	}}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "policy", "delete", "SAFE"}); err != nil {
+				t.Fatalf("policy delete: %v", err)
+			}
+		})
+	})
+
+	want := "ACTION\tNAME\tACCOUNT\tCLIENT\tALLOW\tDENY\tREASON\n" +
+		"delete\tsafe\t\t\t\t\t\n"
+	if out != want {
+		t.Fatalf("plain policy delete output = %q, want %q", out, want)
+	}
+
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if _, ok := config.GetPolicy(cfg, "safe"); ok {
+		t.Fatal("deleted policy remains persisted")
+	}
+	if _, ok := config.GetPolicy(cfg, "keep"); !ok {
+		t.Fatal("unrelated policy was removed")
+	}
+}
+
 func TestPolicyList_PlainTSV(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())


### PR DESCRIPTION
## Summary
- emit deterministic TSV receipts for config set and config unset in plain mode
- emit deterministic TSV receipts for policy create and policy delete in plain mode
- preserve existing human and JSON output while reporting normalized persisted policy values

## Testing
- focused internal/cmd mutation receipt tests
- PATH="/home/jeremy-johnson/.local/go-sdk/go/bin:/home/jeremy-johnson/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" make ci

Closes #68