### PR TITLE
fix(gmail): emit plain TSV receipts for CSE mutations

### DIFF
--- a/internal/cmd/gmail_cse.go
+++ b/internal/cmd/gmail_cse.go
@@ -160,6 +160,14 @@ func (c *GmailCseIdentitiesCreateCmd) Run(ctx context.Context, flags *RootFlags)
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseIdentity": created})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainReceipt(ctx,
+			[]string{"ACTION", "EMAIL", "PRIMARY_KEY_PAIR_ID", "STATUS"},
+			[]string{"create", created.EmailAddress, created.PrimaryKeyPairId, "ok"},
+		)
+		return nil
+	}
+
 	u.Out().Println("CSE identity created successfully")
 	u.Out().Printf("email_address\t%s", created.EmailAddress)
 	u.Out().Printf("primary_keypair_id\t%s", created.PrimaryKeyPairId)
@@ -203,6 +211,15 @@ func (c *GmailCseIdentitiesDeleteCmd) Run(ctx context.Context, flags *RootFlags)
 			"success": true,
 			"email":   email,
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		// Delete has no server primary key pair after success.
+		writePlainReceipt(ctx,
+			[]string{"ACTION", "EMAIL", "PRIMARY_KEY_PAIR_ID", "STATUS"},
+			[]string{"delete", email, "", "ok"},
+		)
+		return nil
 	}
 
 	u.Out().Printf("CSE identity deleted: %s", email)
@@ -270,6 +287,14 @@ func (c *GmailCseIdentitiesPatchCmd) Run(ctx context.Context, kctx *kong.Context
 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseIdentity": updated})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		writePlainReceipt(ctx,
+			[]string{"ACTION", "EMAIL", "PRIMARY_KEY_PAIR_ID", "STATUS"},
+			[]string{"patch", updated.EmailAddress, updated.PrimaryKeyPairId, "ok"},
+		)
+		return nil
 	}
 
 	u.Out().Println("CSE identity patched successfully")
@@ -429,6 +454,14 @@ func (c *GmailCseKeypairsCreateCmd) Run(ctx context.Context, flags *RootFlags) e
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseKeyPair": created})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainReceipt(ctx,
+			[]string{"ACTION", "KEY_PAIR_ID", "ENABLEMENT_STATE", "DISABLE_TIME", "STATUS"},
+			[]string{"create", created.KeyPairId, created.EnablementState, created.DisableTime, "ok"},
+		)
+		return nil
+	}
+
 	u.Out().Println("CSE key pair created successfully")
 	u.Out().Printf("key_pair_id\t%s", created.KeyPairId)
 	u.Out().Printf("enablement_state\t%s", created.EnablementState)
@@ -465,6 +498,14 @@ func (c *GmailCseKeypairsEnableCmd) Run(ctx context.Context, flags *RootFlags) e
 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseKeyPair": enabled})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		writePlainReceipt(ctx,
+			[]string{"ACTION", "KEY_PAIR_ID", "ENABLEMENT_STATE", "DISABLE_TIME", "STATUS"},
+			[]string{"enable", enabled.KeyPairId, enabled.EnablementState, enabled.DisableTime, "ok"},
+		)
+		return nil
 	}
 
 	u.Out().Printf("CSE key pair enabled: %s", keyPairID)
@@ -507,6 +548,14 @@ func (c *GmailCseKeypairsDisableCmd) Run(ctx context.Context, flags *RootFlags) 
 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseKeyPair": disabled})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		writePlainReceipt(ctx,
+			[]string{"ACTION", "KEY_PAIR_ID", "ENABLEMENT_STATE", "DISABLE_TIME", "STATUS"},
+			[]string{"disable", disabled.KeyPairId, disabled.EnablementState, disabled.DisableTime, "ok"},
+		)
+		return nil
 	}
 
 	u.Out().Printf("CSE key pair disabled: %s", keyPairID)
@@ -556,6 +605,15 @@ func (c *GmailCseKeypairsObliterateCmd) Run(ctx context.Context, flags *RootFlag
 			"keyPairId":   keyPairID,
 			"obliterated": true,
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		// Obliterate has no server enablement/disable fields after success.
+		writePlainReceipt(ctx,
+			[]string{"ACTION", "KEY_PAIR_ID", "ENABLEMENT_STATE", "DISABLE_TIME", "STATUS"},
+			[]string{"obliterate", keyPairID, "", "", "ok"},
+		)
+		return nil
 	}
 
 	u.Out().Printf("CSE key pair OBLITERATED: %s (this action is irreversible)", keyPairID)

--- a/internal/cmd/gmail_cse_plain_test.go
+++ b/internal/cmd/gmail_cse_plain_test.go
@@ -74,15 +74,15 @@ func TestGmailCseIdentitiesPatchCmd_PlainReceipt(t *testing.T) {
 	t.Cleanup(func() { newGmailService = origNew })
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == "GET":
+		switch r.Method {
+		case http.MethodGet:
 			resp := &gmail.CseIdentity{
 				EmailAddress:     "user@example.com",
 				PrimaryKeyPairId: "kp-old",
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(resp)
-		case r.Method == "PATCH" || r.Method == "POST" || r.Method == "PUT":
+		case http.MethodPatch, http.MethodPost, http.MethodPut:
 			resp := &gmail.CseIdentity{
 				EmailAddress:     "user@example.com",
 				PrimaryKeyPairId: "kp-new",

--- a/internal/cmd/gmail_cse_plain_test.go
+++ b/internal/cmd/gmail_cse_plain_test.go
@@ -1,0 +1,418 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// Plain mutation receipts for CSE identity / key-pair lifecycle (issue #71).
+
+func TestGmailCseIdentitiesCreateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		resp := &gmail.CseIdentity{
+			EmailAddress:     "user@example.com",
+			PrimaryKeyPairId: "kp123",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+	flags := &RootFlags{Account: "test@gmail.com"}
+
+	cmd := &GmailCseIdentitiesCreateCmd{
+		Email:            "user@example.com",
+		PrimaryKeyPairID: "kp123",
+	}
+	out := captureStdout(t, func() {
+		if runErr := cmd.Run(ctx, flags); runErr != nil {
+			t.Fatalf("Run failed: %v", runErr)
+		}
+	})
+
+	want := "ACTION\tEMAIL\tPRIMARY_KEY_PAIR_ID\tSTATUS\ncreate\tuser@example.com\tkp123\tok\n"
+	if out != want {
+		t.Fatalf("plain identity create output = %q, want %q", out, want)
+	}
+}
+
+func TestGmailCseIdentitiesPatchCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET":
+			resp := &gmail.CseIdentity{
+				EmailAddress:     "user@example.com",
+				PrimaryKeyPairId: "kp-old",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.Method == "PATCH" || r.Method == "POST" || r.Method == "PUT":
+			resp := &gmail.CseIdentity{
+				EmailAddress:     "user@example.com",
+				PrimaryKeyPairId: "kp-new",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			t.Errorf("unexpected method %s path %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+	flags := &RootFlags{Account: "test@gmail.com"}
+
+	cmd := &GmailCseIdentitiesPatchCmd{
+		Email:            "user@example.com",
+		PrimaryKeyPairID: "kp-new",
+	}
+	out := captureStdout(t, func() {
+		if runErr := runKong(t, cmd, []string{"user@example.com", "--primary-keypair-id", "kp-new"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run failed: %v", runErr)
+		}
+	})
+
+	want := "ACTION\tEMAIL\tPRIMARY_KEY_PAIR_ID\tSTATUS\npatch\tuser@example.com\tkp-new\tok\n"
+	if out != want {
+		t.Fatalf("plain identity patch output = %q, want %q", out, want)
+	}
+}
+
+func TestGmailCseIdentitiesDeleteCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+	flags := &RootFlags{Account: "test@gmail.com", Force: true}
+
+	cmd := &GmailCseIdentitiesDeleteCmd{Email: "user@example.com"}
+	out := captureStdout(t, func() {
+		if runErr := cmd.Run(ctx, flags); runErr != nil {
+			t.Fatalf("Run failed: %v", runErr)
+		}
+	})
+
+	// Delete has no server primary key pair id after success.
+	want := "ACTION\tEMAIL\tPRIMARY_KEY_PAIR_ID\tSTATUS\ndelete\tuser@example.com\t\tok\n"
+	if out != want {
+		t.Fatalf("plain identity delete output = %q, want %q", out, want)
+	}
+}
+
+func TestGmailCseKeypairsCreateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		resp := &gmail.CseKeyPair{
+			KeyPairId:       "kp123",
+			EnablementState: "enabled",
+			DisableTime:     "",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+	flags := &RootFlags{Account: "test@gmail.com"}
+
+	cmd := &GmailCseKeypairsCreateCmd{
+		Pkcs7: "-----BEGIN PKCS7-----\ntest\n-----END PKCS7-----",
+	}
+	out := captureStdout(t, func() {
+		if runErr := cmd.Run(ctx, flags); runErr != nil {
+			t.Fatalf("Run failed: %v", runErr)
+		}
+	})
+
+	want := "ACTION\tKEY_PAIR_ID\tENABLEMENT_STATE\tDISABLE_TIME\tSTATUS\ncreate\tkp123\tenabled\t\tok\n"
+	if out != want {
+		t.Fatalf("plain keypair create output = %q, want %q", out, want)
+	}
+}
+
+func TestGmailCseKeypairsEnableCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/cse/keypairs/kp123:enable") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		resp := &gmail.CseKeyPair{
+			KeyPairId:       "kp123",
+			EnablementState: "enabled",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+	flags := &RootFlags{Account: "test@gmail.com"}
+
+	cmd := &GmailCseKeypairsEnableCmd{KeyPairID: "kp123"}
+	out := captureStdout(t, func() {
+		if runErr := cmd.Run(ctx, flags); runErr != nil {
+			t.Fatalf("Run failed: %v", runErr)
+		}
+	})
+
+	want := "ACTION\tKEY_PAIR_ID\tENABLEMENT_STATE\tDISABLE_TIME\tSTATUS\nenable\tkp123\tenabled\t\tok\n"
+	if out != want {
+		t.Fatalf("plain keypair enable output = %q, want %q", out, want)
+	}
+}
+
+func TestGmailCseKeypairsDisableCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/cse/keypairs/kp123:disable") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		resp := &gmail.CseKeyPair{
+			KeyPairId:       "kp123",
+			EnablementState: "disabled",
+			DisableTime:     "2024-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+	flags := &RootFlags{Account: "test@gmail.com", Force: true}
+
+	cmd := &GmailCseKeypairsDisableCmd{KeyPairID: "kp123"}
+	out := captureStdout(t, func() {
+		if runErr := cmd.Run(ctx, flags); runErr != nil {
+			t.Fatalf("Run failed: %v", runErr)
+		}
+	})
+
+	want := "ACTION\tKEY_PAIR_ID\tENABLEMENT_STATE\tDISABLE_TIME\tSTATUS\ndisable\tkp123\tdisabled\t2024-01-01T00:00:00Z\tok\n"
+	if out != want {
+		t.Fatalf("plain keypair disable output = %q, want %q", out, want)
+	}
+}
+
+func TestGmailCseKeypairsObliterateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/cse/keypairs/kp123:obliterate") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+	flags := &RootFlags{Account: "test@gmail.com", Force: true}
+
+	cmd := &GmailCseKeypairsObliterateCmd{KeyPairID: "kp123"}
+	out := captureStdout(t, func() {
+		if runErr := cmd.Run(ctx, flags); runErr != nil {
+			t.Fatalf("Run failed: %v", runErr)
+		}
+	})
+
+	// Obliterate has no server enablement state / disable time after success.
+	want := "ACTION\tKEY_PAIR_ID\tENABLEMENT_STATE\tDISABLE_TIME\tSTATUS\nobliterate\tkp123\t\t\tok\n"
+	if out != want {
+		t.Fatalf("plain keypair obliterate output = %q, want %q", out, want)
+	}
+}
+
+func TestGmailCseIdentitiesCreateCmd_HumanUnchanged(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := &gmail.CseIdentity{
+			EmailAddress:     "user@example.com",
+			PrimaryKeyPairId: "kp123",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	var stdout strings.Builder
+	u, err := ui.New(ui.Options{Stdout: &stdout, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	flags := &RootFlags{Account: "test@gmail.com"}
+
+	cmd := &GmailCseIdentitiesCreateCmd{
+		Email:            "user@example.com",
+		PrimaryKeyPairID: "kp123",
+	}
+	if runErr := cmd.Run(ctx, flags); runErr != nil {
+		t.Fatalf("Run failed: %v", runErr)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "CSE identity created successfully") {
+		t.Fatalf("human create output missing success prose: %q", out)
+	}
+	if strings.Contains(out, "ACTION\tEMAIL") {
+		t.Fatalf("human create output unexpectedly used plain receipt: %q", out)
+	}
+}

--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -46,6 +46,15 @@ func sanitizePlainField(s string) string {
 	return plainFieldReplacer.Replace(s)
 }
 
+// writePlainReceipt writes a fixed-schema TSV receipt (header + one data row)
+// for --plain mutation output. Fields are sanitized for tab/newline safety.
+func writePlainReceipt(ctx context.Context, headers []string, fields []string) {
+	w, flush := tableWriter(ctx)
+	defer flush()
+	writeTableRow(ctx, w, headers)
+	writeTableRow(ctx, w, fields)
+}
+
 func printNextPageHint(u *ui.UI, nextPageToken string) {
 	printNextPageHintWithFlag(u, "--page", nextPageToken)
 }


### PR DESCRIPTION
## Summary
- emit fixed-schema plain TSV receipts for Gmail CSE identity mutations
- emit fixed-schema plain TSV receipts for Gmail CSE key-pair lifecycle mutations
- preserve JSON shapes, destructive confirmations, cryptographic handling, and human output

## Testing
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" go test ./internal/cmd -run 'TestGmailCse(Identities|Keypairs)'`
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci`

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)