### PR TITLE
fix(gmail): emit stable plain batch receipts

### DIFF
--- a/internal/cmd/gmail_batch.go
+++ b/internal/cmd/gmail_batch.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"google.golang.org/api/gmail/v1"
 
@@ -53,6 +54,10 @@ func (c *GmailBatchDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"deleted": c.MessageIDs,
 			"count":   len(c.MessageIDs),
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		return writeGmailBatchPlainReceipt(ctx, "delete", len(c.MessageIDs), nil, nil)
 	}
 
 	u.Out().Printf("Deleted %d messages", len(c.MessageIDs))
@@ -109,6 +114,23 @@ func (c *GmailBatchModifyCmd) Run(ctx context.Context, flags *RootFlags) error {
 		})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		return writeGmailBatchPlainReceipt(ctx, "modify", len(c.MessageIDs), addIDs, removeIDs)
+	}
+
 	u.Out().Printf("Modified %d messages", len(c.MessageIDs))
+	return nil
+}
+
+func writeGmailBatchPlainReceipt(ctx context.Context, action string, count int, addedLabels, removedLabels []string) error {
+	w, flush := tableWriter(ctx)
+	defer flush()
+	writeTableRow(ctx, w, []string{"ACTION", "COUNT", "ADDED_LABELS", "REMOVED_LABELS"})
+	writeTableRow(ctx, w, []string{
+		action,
+		strconv.Itoa(count),
+		joinCSV(addedLabels),
+		joinCSV(removedLabels),
+	})
 	return nil
 }

--- a/internal/cmd/gmail_batch_test.go
+++ b/internal/cmd/gmail_batch_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestGmailBatchDeleteCmd_Plain(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/messages/batchDelete") && r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+
+		if runErr := runKong(t, &GmailBatchDeleteCmd{}, []string{"msg1", "msg2", "msg3"}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	const want = "ACTION\tCOUNT\tADDED_LABELS\tREMOVED_LABELS\ndelete\t3\t\t\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+	}
+	if strings.Contains(strings.ToLower(out), "deleted") {
+		t.Fatalf("plain stdout must not include prose, got %q", out)
+	}
+}
+
+func TestGmailBatchModifyCmd_Plain(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/users/me/labels"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"labels": []map[string]any{
+					{"id": "Label_1", "name": "Work", "type": "user"},
+					{"id": "INBOX", "name": "INBOX", "type": "system"},
+					{"id": "SPAM", "name": "SPAM", "type": "system"},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/messages/batchModify") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+
+		if runErr := runKong(t, &GmailBatchModifyCmd{}, []string{
+			"msg1", "msg2",
+			"--add", "Work,INBOX",
+			"--remove", "SPAM",
+		}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	const want = "ACTION\tCOUNT\tADDED_LABELS\tREMOVED_LABELS\nmodify\t2\tLabel_1,INBOX\tSPAM\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+	}
+	if strings.Contains(strings.ToLower(out), "modified") {
+		t.Fatalf("plain stdout must not include prose, got %q", out)
+	}
+}

--- a/internal/cmd/gmail_batch_test.go
+++ b/internal/cmd/gmail_batch_test.go
@@ -39,7 +39,7 @@ func TestGmailBatchDeleteCmd_Plain(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
 		if uiErr != nil {
@@ -96,7 +96,7 @@ func TestGmailBatchModifyCmd_Plain(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
 		if uiErr != nil {

--- a/internal/cmd/gmail_batch_test.go
+++ b/internal/cmd/gmail_batch_test.go
@@ -17,40 +17,14 @@ import (
 )
 
 func TestGmailBatchDeleteCmd_Plain(t *testing.T) {
-	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	out := captureGmailBatchPlainOutput(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/messages/batchDelete") && r.Method == http.MethodPost {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		http.NotFound(w, r)
-	}))
-	defer srv.Close()
-
-	svc, err := gmail.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
-
-	flags := &RootFlags{Account: "a@b.com", Force: true}
-	out := captureStdout(t, func() {
-		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
-		if uiErr != nil {
-			t.Fatalf("ui.New: %v", uiErr)
-		}
-		ctx := ui.WithUI(context.Background(), u)
-		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
-
-		if runErr := runKong(t, &GmailBatchDeleteCmd{}, []string{"msg1", "msg2", "msg3"}, ctx, flags); runErr != nil {
-			t.Fatalf("execute: %v", runErr)
-		}
+	}), func(ctx context.Context, flags *RootFlags) error {
+		return runKong(t, &GmailBatchDeleteCmd{}, []string{"msg1", "msg2", "msg3"}, ctx, flags)
 	})
 
 	const want = "ACTION\tCOUNT\tADDED_LABELS\tREMOVED_LABELS\ndelete\t3\t\t\n"
@@ -63,10 +37,7 @@ func TestGmailBatchDeleteCmd_Plain(t *testing.T) {
 }
 
 func TestGmailBatchModifyCmd_Plain(t *testing.T) {
-	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	out := captureGmailBatchPlainOutput(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/users/me/labels"):
 			w.Header().Set("Content-Type", "application/json")
@@ -83,8 +54,31 @@ func TestGmailBatchModifyCmd_Plain(t *testing.T) {
 			return
 		}
 		http.NotFound(w, r)
-	}))
-	defer srv.Close()
+	}), func(ctx context.Context, flags *RootFlags) error {
+		return runKong(t, &GmailBatchModifyCmd{}, []string{
+			"msg1", "msg2",
+			"--add", "Work,INBOX",
+			"--remove", "SPAM",
+		}, ctx, flags)
+	})
+
+	const want = "ACTION\tCOUNT\tADDED_LABELS\tREMOVED_LABELS\nmodify\t2\tLabel_1,INBOX\tSPAM\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+	}
+	if strings.Contains(strings.ToLower(out), "modified") {
+		t.Fatalf("plain stdout must not include prose, got %q", out)
+	}
+}
+
+func captureGmailBatchPlainOutput(t *testing.T, handler http.Handler, run func(context.Context, *RootFlags) error) string {
+	t.Helper()
+
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
 
 	svc, err := gmail.NewService(context.Background(),
 		option.WithoutAuthentication(),
@@ -97,7 +91,7 @@ func TestGmailBatchModifyCmd_Plain(t *testing.T) {
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com", Force: true}
-	out := captureStdout(t, func() {
+	return captureStdout(t, func() {
 		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
 		if uiErr != nil {
 			t.Fatalf("ui.New: %v", uiErr)
@@ -105,20 +99,8 @@ func TestGmailBatchModifyCmd_Plain(t *testing.T) {
 		ctx := ui.WithUI(context.Background(), u)
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
 
-		if runErr := runKong(t, &GmailBatchModifyCmd{}, []string{
-			"msg1", "msg2",
-			"--add", "Work,INBOX",
-			"--remove", "SPAM",
-		}, ctx, flags); runErr != nil {
+		if runErr := run(ctx, flags); runErr != nil {
 			t.Fatalf("execute: %v", runErr)
 		}
 	})
-
-	const want = "ACTION\tCOUNT\tADDED_LABELS\tREMOVED_LABELS\nmodify\t2\tLabel_1,INBOX\tSPAM\n"
-	if out != want {
-		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
-	}
-	if strings.Contains(strings.ToLower(out), "modified") {
-		t.Fatalf("plain stdout must not include prose, got %q", out)
-	}
 }


### PR DESCRIPTION
Emits deterministic TSV receipts for Gmail batch delete and modify under --plain while preserving JSON, selection, batching, and confirmation behavior. Tested with focused Gmail batch tests and full make ci. Closes #70