### PR TITLE
fix(gmail): emit plain TSV receipt for labels create

### DIFF
--- a/internal/cmd/gmail_labels.go
+++ b/internal/cmd/gmail_labels.go
@@ -104,10 +104,7 @@ func (c *GmailLabelsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"label": label})
 	}
 	if outfmt.IsPlain(ctx) {
-		w, flush := tableWriter(ctx)
-		defer flush()
-		writeTableRow(ctx, w, []string{"ID", "NAME"})
-		writeTableRow(ctx, w, []string{label.Id, label.Name})
+		writePlainReceipt(ctx, []string{"ID", "NAME"}, []string{label.Id, label.Name})
 		return nil
 	}
 	u.Out().Printf("Created label: %s (id: %s)", label.Name, label.Id)

--- a/internal/cmd/gmail_labels.go
+++ b/internal/cmd/gmail_labels.go
@@ -103,6 +103,13 @@ func (c *GmailLabelsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"label": label})
 	}
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		writeTableRow(ctx, w, []string{"ID", "NAME"})
+		writeTableRow(ctx, w, []string{label.Id, label.Name})
+		return nil
+	}
 	u.Out().Printf("Created label: %s (id: %s)", label.Name, label.Id)
 	return nil
 }

--- a/internal/cmd/gmail_labels_cmd_test.go
+++ b/internal/cmd/gmail_labels_cmd_test.go
@@ -424,6 +424,72 @@ func TestGmailLabelsCreateCmd_Text(t *testing.T) {
 	}
 }
 
+func TestExecute_GmailLabelsCreate_Plain(t *testing.T) {
+	srv := newLabelsServer(t, []map[string]any{}, func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Name string `json:"name"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Name != "My Label" {
+			http.Error(w, "unexpected name", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   "Label_789",
+			"name": body.Name,
+			"type": "user",
+		})
+	})
+	defer srv.Close()
+	stubGmailService(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"gmail", "labels", "create", "My Label",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	const want = "ID\tNAME\nLabel_789\tMy Label\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+	}
+}
+
+func TestExecute_GmailLabelsCreate_Plain_SanitizesTSVFields(t *testing.T) {
+	srv := newLabelsServer(t, []map[string]any{}, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   "Label_1\tX",
+			"name": "A\tB\nC\rD",
+			"type": "user",
+		})
+	})
+	defer srv.Close()
+	stubGmailService(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"gmail", "labels", "create", "A",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	const want = "ID\tNAME\nLabel_1 X\tA B C D\n"
+	if out != want {
+		t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", want, out)
+	}
+}
+
 func TestGmailLabelsCreateCmd_EmptyName(t *testing.T) {
 	origNew := newGmailService
 	t.Cleanup(func() { newGmailService = origNew })


### PR DESCRIPTION
## Summary
- emit a fixed ID/NAME TSV receipt for gmail labels create --plain
- use the server-returned label ID and name with shared TSV field sanitization
- preserve existing JSON and default human output

## Testing
- focused Gmail label creation tests
- PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci

Closes #73