### PR TITLE
fix(gmail): emit stable routing mutation receipts

### DIFF
--- a/internal/cmd/gmail_delegates.go
+++ b/internal/cmd/gmail_delegates.go
@@ -126,6 +126,11 @@ func (c *GmailDelegatesAddCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"delegate": created})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainRoutingReceipt(ctx, "delegate", "create", created.DelegateEmail, created.VerificationStatus)
+		return nil
+	}
+
 	u.Out().Println("Delegate added successfully")
 	u.Out().Printf("delegate_email\t%s", created.DelegateEmail)
 	u.Out().Printf("verification_status\t%s", created.VerificationStatus)
@@ -167,6 +172,11 @@ func (c *GmailDelegatesRemoveCmd) Run(ctx context.Context, flags *RootFlags) err
 			"success":       true,
 			"delegateEmail": delegateEmail,
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		writePlainRoutingReceipt(ctx, "delegate", "delete", delegateEmail, "success")
+		return nil
 	}
 
 	u.Out().Printf("Delegate %s removed successfully", delegateEmail)

--- a/internal/cmd/gmail_filters.go
+++ b/internal/cmd/gmail_filters.go
@@ -296,6 +296,11 @@ func (c *GmailFiltersCreateCmd) Run(ctx context.Context, flags *RootFlags) error
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"filter": created})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainRoutingReceipt(ctx, "filter", "create", created.Id, "success")
+		return nil
+	}
+
 	u.Out().Println("Filter created successfully")
 	u.Out().Printf("id\t%s", created.Id)
 	if created.Criteria != nil {
@@ -350,6 +355,11 @@ func (c *GmailFiltersDeleteCmd) Run(ctx context.Context, flags *RootFlags) error
 			"success":  true,
 			"filterId": filterID,
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		writePlainRoutingReceipt(ctx, "filter", "delete", filterID, "success")
+		return nil
 	}
 
 	u.Out().Printf("Filter %s deleted successfully", filterID)

--- a/internal/cmd/gmail_forwarding.go
+++ b/internal/cmd/gmail_forwarding.go
@@ -126,6 +126,11 @@ func (c *GmailForwardingCreateCmd) Run(ctx context.Context, flags *RootFlags) er
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"forwardingAddress": created})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainRoutingReceipt(ctx, "forwarding_address", "create", created.ForwardingEmail, created.VerificationStatus)
+		return nil
+	}
+
 	u.Out().Println("Forwarding address created successfully")
 	u.Out().Printf("forwarding_email\t%s", created.ForwardingEmail)
 	u.Out().Printf("verification_status\t%s", created.VerificationStatus)
@@ -168,6 +173,11 @@ func (c *GmailForwardingDeleteCmd) Run(ctx context.Context, flags *RootFlags) er
 			"success":         true,
 			"forwardingEmail": forwardingEmail,
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		writePlainRoutingReceipt(ctx, "forwarding_address", "delete", forwardingEmail, "success")
+		return nil
 	}
 
 	u.Out().Printf("Forwarding address %s deleted successfully", forwardingEmail)

--- a/internal/cmd/gmail_routing_plain_test.go
+++ b/internal/cmd/gmail_routing_plain_test.go
@@ -1,0 +1,497 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// Plain mutation receipts for Gmail routing settings (issue #75):
+// RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS (+ one data row).
+
+func TestGmailDelegatesAddCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/settings/delegates") {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"delegateEmail":      "del\teg@example.com",
+			"verificationStatus": "pending",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailDelegatesAddCmd{}, []string{"del\teg@example.com"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+
+	want := "RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS\ndelegate\tcreate\tdel eg@example.com\tpending\n"
+	if out != want {
+		t.Fatalf("plain delegates add = %q, want %q", out, want)
+	}
+	if strings.Contains(out, "invitation") || strings.Contains(out, "successfully") {
+		t.Fatalf("plain stdout leaked advice/prose: %q", out)
+	}
+}
+
+func TestGmailDelegatesRemoveCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailDelegatesRemoveCmd{}, []string{"d@b.com"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+
+	want := "RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS\ndelegate\tdelete\td@b.com\tsuccess\n"
+	if out != want {
+		t.Fatalf("plain delegates remove = %q, want %q", out, want)
+	}
+}
+
+func TestGmailForwardingCreateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/forwardingAddresses") {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"forwardingEmail":    "fwd@example.com",
+			"verificationStatus": "pending",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailForwardingCreateCmd{}, []string{"fwd@example.com"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+
+	want := "RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS\nforwarding_address\tcreate\tfwd@example.com\tpending\n"
+	if out != want {
+		t.Fatalf("plain forwarding create = %q, want %q", out, want)
+	}
+	if strings.Contains(out, "verification email") || strings.Contains(out, "successfully") {
+		t.Fatalf("plain stdout leaked advice/prose: %q", out)
+	}
+}
+
+func TestGmailForwardingDeleteCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailForwardingDeleteCmd{}, []string{"fwd@example.com"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+
+	want := "RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS\nforwarding_address\tdelete\tfwd@example.com\tsuccess\n"
+	if out != want {
+		t.Fatalf("plain forwarding delete = %q, want %q", out, want)
+	}
+}
+
+func TestGmailSendAsCreateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/settings/sendAs") {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"sendAsEmail":        "alias@example.com",
+			"verificationStatus": "pending",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailSendAsCreateCmd{}, []string{"alias@example.com", "--display-name", "Alias"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+
+	want := "RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS\nsend_as\tcreate\talias@example.com\tpending\n"
+	if out != want {
+		t.Fatalf("plain send-as create = %q, want %q", out, want)
+	}
+	// Advice may stay on stderr; must not appear on stdout.
+	if strings.Contains(out, "Verification email") {
+		t.Fatalf("plain stdout leaked advice: %q", out)
+	}
+}
+
+func TestGmailSendAsVerifyCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/verify") {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailSendAsVerifyCmd{}, []string{"alias@example.com"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+
+	want := "RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS\nsend_as\tverify\talias@example.com\tsuccess\n"
+	if out != want {
+		t.Fatalf("plain send-as verify = %q, want %q", out, want)
+	}
+}
+
+func TestGmailSendAsUpdateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/settings/sendAs/"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sendAsEmail":        "alias@example.com",
+				"displayName":        "Old",
+				"verificationStatus": "accepted",
+			})
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/settings/sendAs/"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sendAsEmail":        "alias@example.com",
+				"displayName":        "New",
+				"verificationStatus": "accepted",
+			})
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailSendAsUpdateCmd{}, []string{"alias@example.com", "--display-name", "New"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+
+	want := "RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS\nsend_as\tupdate\talias@example.com\taccepted\n"
+	if out != want {
+		t.Fatalf("plain send-as update = %q, want %q", out, want)
+	}
+}
+
+func TestGmailSendAsDeleteCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailSendAsDeleteCmd{}, []string{"alias@example.com"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+
+	want := "RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS\nsend_as\tdelete\talias@example.com\tsuccess\n"
+	if out != want {
+		t.Fatalf("plain send-as delete = %q, want %q", out, want)
+	}
+}
+
+func TestGmailFiltersCreateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/settings/filters") {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "filter-123",
+			"criteria": map[string]any{
+				"from": "a@example.com",
+			},
+			"action": map[string]any{
+				"addLabelIds": []string{"STARRED"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailFiltersCreateCmd{}, []string{"--from", "a@example.com", "--star"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+
+	want := "RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS\nfilter\tcreate\tfilter-123\tsuccess\n"
+	if out != want {
+		t.Fatalf("plain filter create = %q, want %q", out, want)
+	}
+	if strings.Contains(out, "successfully") {
+		t.Fatalf("plain stdout leaked prose: %q", out)
+	}
+}
+
+func TestGmailFiltersDeleteCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailFiltersDeleteCmd{}, []string{"filter-123"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+
+	want := "RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS\nfilter\tdelete\tfilter-123\tsuccess\n"
+	if out != want {
+		t.Fatalf("plain filter delete = %q, want %q", out, want)
+	}
+}
+
+func TestGmailDelegatesAddCmd_JSONUnchanged(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"delegateEmail":      "d@b.com",
+			"verificationStatus": "pending",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		ctx := ui.WithUI(context.Background(), mustUI(t))
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+		if runErr := runKong(t, &GmailDelegatesAddCmd{}, []string{"d@b.com"}, ctx, flags); runErr != nil {
+			t.Fatalf("Run: %v", runErr)
+		}
+	})
+	if !strings.Contains(out, `"delegate"`) || !strings.Contains(out, `"d@b.com"`) {
+		t.Fatalf("json shape changed: %q", out)
+	}
+	if strings.Contains(out, "RESOURCE_TYPE") {
+		t.Fatalf("json path emitted plain receipt: %q", out)
+	}
+}
+
+func mustUI(t *testing.T) *ui.UI {
+	t.Helper()
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	return u
+}

--- a/internal/cmd/gmail_routing_plain_test.go
+++ b/internal/cmd/gmail_routing_plain_test.go
@@ -47,7 +47,7 @@ func TestGmailDelegatesAddCmd_PlainReceipt(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
@@ -87,7 +87,7 @@ func TestGmailDelegatesRemoveCmd_PlainReceipt(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
@@ -130,7 +130,7 @@ func TestGmailForwardingCreateCmd_PlainReceipt(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
@@ -170,7 +170,7 @@ func TestGmailForwardingDeleteCmd_PlainReceipt(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
@@ -213,7 +213,7 @@ func TestGmailSendAsCreateCmd_PlainReceipt(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
@@ -256,7 +256,7 @@ func TestGmailSendAsVerifyCmd_PlainReceipt(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
@@ -308,7 +308,7 @@ func TestGmailSendAsUpdateCmd_PlainReceipt(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
@@ -345,7 +345,7 @@ func TestGmailSendAsDeleteCmd_PlainReceipt(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
@@ -393,7 +393,7 @@ func TestGmailFiltersCreateCmd_PlainReceipt(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
@@ -433,7 +433,7 @@ func TestGmailFiltersDeleteCmd_PlainReceipt(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
@@ -471,7 +471,7 @@ func TestGmailDelegatesAddCmd_JSONUnchanged(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	flags := &RootFlags{Account: "a@b.com"}
+	flags := &RootFlags{Account: "a@b.com", Force: true}
 	out := captureStdout(t, func() {
 		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})

--- a/internal/cmd/gmail_sendas.go
+++ b/internal/cmd/gmail_sendas.go
@@ -157,6 +157,11 @@ func (c *GmailSendAsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"sendAs": created})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainRoutingReceipt(ctx, "send_as", "create", created.SendAsEmail, created.VerificationStatus)
+		return nil
+	}
+
 	u.Out().Printf("send_as_email\t%s", created.SendAsEmail)
 	u.Out().Printf("verification_status\t%s", created.VerificationStatus)
 	u.Err().Println("Verification email sent. Check your inbox to complete setup.")
@@ -193,6 +198,11 @@ func (c *GmailSendAsVerifyCmd) Run(ctx context.Context, flags *RootFlags) error 
 			"email":   sendAsEmail,
 			"message": "Verification email sent",
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		writePlainRoutingReceipt(ctx, "send_as", "verify", sendAsEmail, "success")
+		return nil
 	}
 
 	u.Out().Printf("Verification email sent to %s", sendAsEmail)
@@ -232,6 +242,11 @@ func (c *GmailSendAsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 			"email":   sendAsEmail,
 			"deleted": true,
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		writePlainRoutingReceipt(ctx, "send_as", "delete", sendAsEmail, "success")
+		return nil
 	}
 
 	u.Out().Printf("Deleted send-as alias: %s", sendAsEmail)
@@ -293,6 +308,11 @@ func (c *GmailSendAsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flag
 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"sendAs": updated})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		writePlainRoutingReceipt(ctx, "send_as", "update", updated.SendAsEmail, updated.VerificationStatus)
+		return nil
 	}
 
 	u.Out().Printf("Updated send-as alias: %s", updated.SendAsEmail)

--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -55,6 +55,20 @@ func writePlainReceipt(ctx context.Context, headers []string, fields []string) {
 	writeTableRow(ctx, w, fields)
 }
 
+// writePlainRoutingReceipt emits the shared Gmail routing mutation receipt:
+// RESOURCE_TYPE\tACTION\tRESOURCE\tSTATUS (header + one row).
+// resourceType/action are machine tokens (lowercase); status is a server
+// verification/lifecycle value when available, otherwise "success".
+func writePlainRoutingReceipt(ctx context.Context, resourceType, action, resource, status string) {
+	if status == "" {
+		status = "success"
+	}
+	writePlainReceipt(ctx,
+		[]string{"RESOURCE_TYPE", "ACTION", "RESOURCE", "STATUS"},
+		[]string{resourceType, action, resource, status},
+	)
+}
+
 func printNextPageHint(u *ui.UI, nextPageToken string) {
 	printNextPageHintWithFlag(u, "--page", nextPageToken)
 }


### PR DESCRIPTION
## Summary
- emit deterministic plain TSV receipts for Gmail delegate and forwarding-address create/delete mutations
- cover send-as create/update/verify/delete and filter create/delete with the same receipt schema
- preserve JSON, validation, confirmation, and default output behavior

## Testing
- focused Gmail routing plain receipt tests
- full make ci with the requested Go SDK PATH

Closes #75