### PR TITLE
fix(chat): emit stable plain media download receipt

### DIFF
--- a/internal/cmd/chat_media.go
+++ b/internal/cmd/chat_media.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"google.golang.org/api/chat/v1"
@@ -201,6 +202,14 @@ func (c *ChatMediaDownloadCmd) Run(ctx context.Context, flags *RootFlags) error 
 			"path":     destPath,
 			"size":     n,
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		writeTableRow(ctx, w, []string{"RESOURCE", "PATH", "BYTES"})
+		writeTableRow(ctx, w, []string{resource, destPath, strconv.FormatInt(n, 10)})
+		return nil
 	}
 
 	u.Out().Printf("Downloaded %s to %s (%s)", resource, destPath, formatDriveSize(n))

--- a/internal/cmd/chat_media.go
+++ b/internal/cmd/chat_media.go
@@ -189,7 +189,7 @@ func (c *ChatMediaDownloadCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return fmt.Errorf("expanding output path: %w", err)
 	}
 
-	n, err := writeDownloadFile(destPath, 0o644, func(w io.Writer) (int64, error) {
+	n, committedPath, err := writeDownloadFile(destPath, 0o644, func(w io.Writer) (int64, error) {
 		return io.Copy(w, resp.Body)
 	})
 	if err != nil {
@@ -205,10 +205,11 @@ func (c *ChatMediaDownloadCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsPlain(ctx) {
-		w, flush := tableWriter(ctx)
-		defer flush()
-		writeTableRow(ctx, w, []string{"RESOURCE", "PATH", "BYTES"})
-		writeTableRow(ctx, w, []string{resource, destPath, strconv.FormatInt(n, 10)})
+		writePlainReceipt(
+			ctx,
+			[]string{"RESOURCE", "PATH", "BYTES"},
+			[]string{resource, committedPath, strconv.FormatInt(n, 10)},
+		)
 		return nil
 	}
 

--- a/internal/cmd/chat_media_test.go
+++ b/internal/cmd/chat_media_test.go
@@ -303,8 +303,20 @@ func TestExecute_ChatMediaDownload_PlainTSV(t *testing.T) {
 	}
 	newChatService = func(context.Context, string) (*chat.Service, error) { return svc, nil }
 
-	outputPath := filepath.Join(t.TempDir(), "plain-download.txt")
-
+	dir := t.TempDir()
+	committedPath := filepath.Join(dir, "plain-download.txt")
+	requestedPath := filepath.Join(dir, "requested-download.txt")
+	if symlinkErr := os.Symlink(filepath.Base(committedPath), requestedPath); symlinkErr != nil {
+		t.Fatalf("Symlink: %v", symlinkErr)
+	}
+	unusedDir := filepath.Join(dir, "unused")
+	if mkdirErr := os.Mkdir(unusedDir, 0o700); mkdirErr != nil {
+		t.Fatalf("Mkdir: %v", mkdirErr)
+	}
+	outputPath := unusedDir + string(filepath.Separator) + ".." + string(filepath.Separator) + filepath.Base(requestedPath)
+	if _, statErr := os.Lstat(outputPath); statErr != nil {
+		t.Fatalf("Lstat noncanonical symlink path: %v", statErr)
+	}
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
 			// Resource without media/ prefix should be normalized in the receipt.
@@ -314,7 +326,7 @@ func TestExecute_ChatMediaDownload_PlainTSV(t *testing.T) {
 		})
 	})
 
-	want := "RESOURCE\tPATH\tBYTES\nmedia/abc123\t" + outputPath + "\t" + strconv.Itoa(len(testContent)) + "\n"
+	want := "RESOURCE\tPATH\tBYTES\nmedia/abc123\t" + committedPath + "\t" + strconv.Itoa(len(testContent)) + "\n"
 	if out != want {
 		t.Fatalf("plain download output = %q, want %q", out, want)
 	}

--- a/internal/cmd/chat_media_test.go
+++ b/internal/cmd/chat_media_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -273,6 +274,99 @@ func TestExecute_ChatMediaDownload_InterruptedPreservesDestinationWithoutReceipt
 	}
 	if len(entries) != 1 || entries[0].Name() != "downloaded.txt" {
 		t.Fatalf("temporary artifact left behind: %#v", entries)
+	}
+}
+
+func TestExecute_ChatMediaDownload_PlainTSV(t *testing.T) {
+	origNew := newChatService
+	t.Cleanup(func() { newChatService = origNew })
+
+	testContent := "plain download bytes"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/media/")) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(testContent))
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := chat.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newChatService = func(context.Context, string) (*chat.Service, error) { return svc, nil }
+
+	outputPath := filepath.Join(t.TempDir(), "plain-download.txt")
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			// Resource without media/ prefix should be normalized in the receipt.
+			if execErr := Execute([]string{"--plain", "--account", "a@b.com", "chat", "media", "download", "abc123", "--output", outputPath}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+	})
+
+	want := "RESOURCE\tPATH\tBYTES\nmedia/abc123\t" + outputPath + "\t" + strconv.Itoa(len(testContent)) + "\n"
+	if out != want {
+		t.Fatalf("plain download output = %q, want %q", out, want)
+	}
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("reading downloaded file: %v", err)
+	}
+	if string(content) != testContent {
+		t.Fatalf("downloaded content = %q, want %q", string(content), testContent)
+	}
+}
+
+func TestExecute_ChatMediaDownload_HumanReceiptUnchanged(t *testing.T) {
+	origNew := newChatService
+	t.Cleanup(func() { newChatService = origNew })
+
+	testContent := "human receipt content"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/media/")) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(testContent))
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := chat.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newChatService = func(context.Context, string) (*chat.Service, error) { return svc, nil }
+
+	outputPath := filepath.Join(t.TempDir(), "human-download.txt")
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if execErr := Execute([]string{"--account", "a@b.com", "chat", "media", "download", "media/abc123", "--output", outputPath}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+	})
+
+	want := "Downloaded media/abc123 to " + outputPath + " (" + formatDriveSize(int64(len(testContent))) + ")\n"
+	if out != want {
+		t.Fatalf("human download output = %q, want %q", out, want)
 	}
 }
 

--- a/internal/cmd/download_file.go
+++ b/internal/cmd/download_file.go
@@ -20,23 +20,23 @@ var (
 	replaceDownloadFile = replaceFile
 )
 
-func writeDownloadFile(destPath string, newFileMode os.FileMode, write func(io.Writer) (int64, error)) (int64, error) {
+func writeDownloadFile(destPath string, newFileMode os.FileMode, write func(io.Writer) (int64, error)) (int64, string, error) {
 	resolvedPath, err := resolveDownloadDestination(destPath)
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 
 	finalMode := modeForNewDownload(newFileMode)
 	if info, statErr := os.Stat(resolvedPath); statErr == nil {
 		finalMode = info.Mode().Perm()
 	} else if !os.IsNotExist(statErr) {
-		return 0, statErr
+		return 0, "", statErr
 	}
 
 	dir := filepath.Dir(resolvedPath)
 	temp, err := createDownloadTempFile(dir, "."+filepath.Base(resolvedPath)+".tmp-*")
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 	tempPath := temp.Name()
 	closed := false
@@ -52,20 +52,20 @@ func writeDownloadFile(destPath string, newFileMode os.FileMode, write func(io.W
 
 	n, err := write(temp)
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 	if err := temp.Close(); err != nil {
-		return 0, fmt.Errorf("closing temporary file: %w", err)
+		return 0, "", fmt.Errorf("closing temporary file: %w", err)
 	}
 	closed = true
 	if err := os.Chmod(tempPath, finalMode); err != nil {
-		return 0, fmt.Errorf("setting destination permissions: %w", err)
+		return 0, "", fmt.Errorf("setting destination permissions: %w", err)
 	}
 	if err := replaceDownloadFile(tempPath, resolvedPath); err != nil {
-		return 0, fmt.Errorf("replacing destination: %w", err)
+		return 0, "", fmt.Errorf("replacing destination: %w", err)
 	}
 	committed = true
-	return n, nil
+	return n, resolvedPath, nil
 }
 
 func applyDownloadModeMask(mode, mask os.FileMode) os.FileMode {

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -913,7 +913,7 @@ func downloadDriveFile(ctx context.Context, svc *drive.Service, meta *drive.File
 		return "", 0, fmt.Errorf("download failed: %s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 
-	n, err := writeDownloadFile(outPath, 0o644, func(w io.Writer) (int64, error) {
+	n, _, err := writeDownloadFile(outPath, 0o644, func(w io.Writer) (int64, error) {
 		return io.Copy(w, resp.Body)
 	})
 	if err != nil {

--- a/internal/cmd/drive_download_test.go
+++ b/internal/cmd/drive_download_test.go
@@ -320,7 +320,7 @@ func TestWriteDownloadFile_RetriesCloseBeforeCleanup(t *testing.T) {
 	}
 
 	dest := filepath.Join(t.TempDir(), "file.bin")
-	if _, err := writeDownloadFile(dest, 0o644, func(w io.Writer) (int64, error) {
+	if _, _, err := writeDownloadFile(dest, 0o644, func(w io.Writer) (int64, error) {
 		n, writeErr := io.WriteString(w, "replacement")
 		return int64(n), writeErr
 	}); err == nil {
@@ -434,7 +434,7 @@ func TestWriteDownloadFile_FollowsSymlinkAndPreservesTargetMode(t *testing.T) {
 		t.Fatalf("create symlink: %v", err)
 	}
 
-	if _, err := writeDownloadFile(link, 0o644, func(w io.Writer) (int64, error) {
+	if _, _, err := writeDownloadFile(link, 0o644, func(w io.Writer) (int64, error) {
 		n, writeErr := io.WriteString(w, "replacement")
 		return int64(n), writeErr
 	}); err != nil {
@@ -475,7 +475,7 @@ func TestWriteDownloadFile_FollowsDanglingSymlinkChain(t *testing.T) {
 		t.Fatalf("create destination symlink: %v", err)
 	}
 
-	if _, err := writeDownloadFile(link, 0o644, func(w io.Writer) (int64, error) {
+	if _, _, err := writeDownloadFile(link, 0o644, func(w io.Writer) (int64, error) {
 		n, writeErr := io.WriteString(w, "replacement")
 		return int64(n), writeErr
 	}); err != nil {
@@ -508,7 +508,7 @@ func TestWriteDownloadFile_PreservesZeroMode(t *testing.T) {
 		t.Fatalf("chmod destination: %v", err)
 	}
 
-	if _, err := writeDownloadFile(dest, 0o644, func(w io.Writer) (int64, error) {
+	if _, _, err := writeDownloadFile(dest, 0o644, func(w io.Writer) (int64, error) {
 		n, writeErr := io.WriteString(w, "replacement")
 		return int64(n), writeErr
 	}); err != nil {

--- a/internal/cmd/drive_revisions.go
+++ b/internal/cmd/drive_revisions.go
@@ -170,7 +170,7 @@ func downloadRevision(ctx context.Context, svc *drive.Service, fileID, revisionI
 		outputPath = fmt.Sprintf("%s-revision-%s", fileID, revisionID)
 	}
 
-	size, err := writeDownloadFile(outputPath, 0o644, func(w io.Writer) (int64, error) {
+	size, _, err := writeDownloadFile(outputPath, 0o644, func(w io.Writer) (int64, error) {
 		return io.Copy(w, resp.Body)
 	})
 	if err != nil {

--- a/internal/cmd/gmail_attachment.go
+++ b/internal/cmd/gmail_attachment.go
@@ -127,7 +127,7 @@ func downloadAttachmentToPath(
 	if mkdirErr := os.MkdirAll(filepath.Dir(outPath), 0o700); mkdirErr != nil {
 		return "", false, 0, mkdirErr
 	}
-	written, err := writeDownloadFile(outPath, 0o600, func(w io.Writer) (int64, error) {
+	written, _, err := writeDownloadFile(outPath, 0o600, func(w io.Writer) (int64, error) {
 		return io.Copy(w, stdbytes.NewReader(data))
 	})
 	if err != nil {

--- a/internal/cmd/keep.go
+++ b/internal/cmd/keep.go
@@ -260,7 +260,7 @@ func (c *KeepAttachmentCmd) Run(ctx context.Context, flags *RootFlags, keep *Kee
 		}
 	}
 
-	written, err := writeDownloadFile(outPath, 0o644, func(w io.Writer) (int64, error) {
+	written, _, err := writeDownloadFile(outPath, 0o644, func(w io.Writer) (int64, error) {
 		return io.Copy(w, resp.Body)
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- emit a fixed RESOURCE/PATH/BYTES TSV receipt for Chat media downloads under --plain
- report the exact resolved destination committed by the atomic download helper
- preserve JSON and default human receipts

## Testing
- PATH="$HOME/.local/go-sdk/go/bin:$PATH" go test ./internal/cmd -run 'TestExecute_ChatMediaDownload_(PlainTSV|HumanReceiptUnchanged|InterruptedPreservesDestinationWithoutReceipt)$|TestWriteDownloadFile_(FollowsSymlinkAndPreservesTargetMode|FollowsDanglingSymlinkChain|PreservesZeroMode)'
- PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci

Closes #67