### PR TITLE
fix(gmail): make draft detail valid TSV

### DIFF
--- a/internal/cmd/gmail_attachments.go
+++ b/internal/cmd/gmail_attachments.go
@@ -29,6 +29,7 @@ type attachmentDownloadOutput struct {
 	MessageID string `json:"messageId"`
 	attachmentOutput
 	Path   string `json:"path,omitempty"`
+	Bytes  int64  `json:"-"`
 	Cached bool   `json:"cached,omitempty"`
 }
 
@@ -159,7 +160,7 @@ func downloadAttachmentOutputs(ctx context.Context, svc *gmail.Service, messageI
 	}
 	out := make([]attachmentDownloadOutput, 0, len(attachments))
 	for _, a := range attachments {
-		outPath, cached, err := downloadAttachment(ctx, svc, messageID, a, dir)
+		outPath, cached, bytes, err := downloadAttachment(ctx, svc, messageID, a, dir)
 		if err != nil {
 			return nil, err
 		}
@@ -167,6 +168,7 @@ func downloadAttachmentOutputs(ctx context.Context, svc *gmail.Service, messageI
 			MessageID:        messageID,
 			attachmentOutput: attachmentOutputFromInfo(a),
 			Path:             outPath,
+			Bytes:            bytes,
 			Cached:           cached,
 		})
 	}

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -128,13 +128,9 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if outfmt.IsJSON(ctx) {
 		out := map[string]any{"draft": draft}
 		if c.Download {
-			attachDir, err := config.EnsureGmailAttachmentsDir()
-			if err != nil {
-				return err
-			}
-			downloads, err := downloadAttachmentOutputs(ctx, svc, msg.Id, collectAttachments(msg.Payload), attachDir)
-			if err != nil {
-				return err
+			downloads, downloadErr := downloadDraftAttachments(ctx, svc, msg.Id, collectAttachments(msg.Payload))
+			if downloadErr != nil {
+				return downloadErr
 			}
 			out["downloaded"] = attachmentDownloadDraftOutputs(downloads)
 		}
@@ -145,11 +141,7 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if outfmt.IsPlain(ctx) {
 		var downloads []attachmentDownloadOutput
 		if c.Download && msg.Id != "" && len(attachments) > 0 {
-			attachDir, err := config.EnsureGmailAttachmentsDir()
-			if err != nil {
-				return err
-			}
-			downloads, err = downloadAttachmentOutputs(ctx, svc, msg.Id, attachments, attachDir)
+			downloads, err = downloadDraftAttachments(ctx, svc, msg.Id, attachments)
 			if err != nil {
 				return err
 			}
@@ -174,13 +166,9 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	printAttachmentSection(u.Out(), attachments)
 
 	if c.Download && msg.Id != "" && len(attachments) > 0 {
-		attachDir, err := config.EnsureGmailAttachmentsDir()
-		if err != nil {
-			return err
-		}
-		downloads, err := downloadAttachmentOutputs(ctx, svc, msg.Id, attachments, attachDir)
-		if err != nil {
-			return err
+		downloads, downloadErr := downloadDraftAttachments(ctx, svc, msg.Id, attachments)
+		if downloadErr != nil {
+			return downloadErr
 		}
 		for _, a := range downloads {
 			if a.Cached {
@@ -192,6 +180,19 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	return nil
+}
+
+func downloadDraftAttachments(
+	ctx context.Context,
+	svc *gmail.Service,
+	messageID string,
+	attachments []attachmentInfo,
+) ([]attachmentDownloadOutput, error) {
+	attachDir, err := config.EnsureGmailAttachmentsDir()
+	if err != nil {
+		return nil, err
+	}
+	return downloadAttachmentOutputs(ctx, svc, messageID, attachments, attachDir)
 }
 
 func writeGmailDraftGetPlain(

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -142,19 +142,18 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	attachments := collectAttachments(msg.Payload)
-	var downloads []attachmentDownloadOutput
-	if c.Download && msg.Id != "" && len(attachments) > 0 {
-		attachDir, err := config.EnsureGmailAttachmentsDir()
-		if err != nil {
-			return err
-		}
-		downloads, err = downloadAttachmentOutputs(ctx, svc, msg.Id, attachments, attachDir)
-		if err != nil {
-			return err
-		}
-	}
-
 	if outfmt.IsPlain(ctx) {
+		var downloads []attachmentDownloadOutput
+		if c.Download && msg.Id != "" && len(attachments) > 0 {
+			attachDir, err := config.EnsureGmailAttachmentsDir()
+			if err != nil {
+				return err
+			}
+			downloads, err = downloadAttachmentOutputs(ctx, svc, msg.Id, attachments, attachDir)
+			if err != nil {
+				return err
+			}
+		}
 		return writeGmailDraftGetPlain(ctx, os.Stdout, draft, attachments, downloads)
 	}
 
@@ -174,11 +173,21 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	printAttachmentSection(u.Out(), attachments)
 
-	for _, a := range downloads {
-		if a.Cached {
-			u.Out().Printf("Cached: %s", a.Path)
-		} else {
-			u.Out().Successf("Saved: %s", a.Path)
+	if c.Download && msg.Id != "" && len(attachments) > 0 {
+		attachDir, err := config.EnsureGmailAttachmentsDir()
+		if err != nil {
+			return err
+		}
+		downloads, err := downloadAttachmentOutputs(ctx, svc, msg.Id, attachments, attachDir)
+		if err != nil {
+			return err
+		}
+		for _, a := range downloads {
+			if a.Cached {
+				u.Out().Printf("Cached: %s", a.Path)
+			} else {
+				u.Out().Successf("Saved: %s", a.Path)
+			}
 		}
 	}
 

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"google.golang.org/api/gmail/v1"
@@ -115,6 +117,9 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if outfmt.IsJSON(ctx) {
 			return outfmt.WriteJSON(os.Stdout, map[string]any{"draft": draft})
 		}
+		if outfmt.IsPlain(ctx) {
+			return writeGmailDraftGetPlain(ctx, os.Stdout, draft, nil, nil)
+		}
 		u.Err().Println("Empty draft")
 		return nil
 	}
@@ -136,6 +141,23 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return outfmt.WriteJSON(os.Stdout, out)
 	}
 
+	attachments := collectAttachments(msg.Payload)
+	var downloads []attachmentDownloadOutput
+	if c.Download && msg.Id != "" && len(attachments) > 0 {
+		attachDir, err := config.EnsureGmailAttachmentsDir()
+		if err != nil {
+			return err
+		}
+		downloads, err = downloadAttachmentOutputs(ctx, svc, msg.Id, attachments, attachDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	if outfmt.IsPlain(ctx) {
+		return writeGmailDraftGetPlain(ctx, os.Stdout, draft, attachments, downloads)
+	}
+
 	u.Out().Printf("Draft-ID: %s", draft.Id)
 	u.Out().Printf("Message-ID: %s", msg.Id)
 	u.Out().Printf("To: %s", headerValue(msg.Payload, "To"))
@@ -150,25 +172,67 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		u.Out().Println("")
 	}
 
-	attachments := collectAttachments(msg.Payload)
 	printAttachmentSection(u.Out(), attachments)
 
-	if c.Download && msg.Id != "" && len(attachments) > 0 {
-		attachDir, err := config.EnsureGmailAttachmentsDir()
-		if err != nil {
-			return err
+	for _, a := range downloads {
+		if a.Cached {
+			u.Out().Printf("Cached: %s", a.Path)
+		} else {
+			u.Out().Successf("Saved: %s", a.Path)
 		}
-		downloads, err := downloadAttachmentOutputs(ctx, svc, msg.Id, attachments, attachDir)
-		if err != nil {
-			return err
-		}
-		for _, a := range downloads {
-			if a.Cached {
-				u.Out().Printf("Cached: %s", a.Path)
-			} else {
-				u.Out().Successf("Saved: %s", a.Path)
-			}
-		}
+	}
+
+	return nil
+}
+
+func writeGmailDraftGetPlain(
+	ctx context.Context,
+	w io.Writer,
+	draft *gmail.Draft,
+	attachments []attachmentInfo,
+	downloads []attachmentDownloadOutput,
+) error {
+	writeTableRow(ctx, w, []string{"RECORD_TYPE", "DRAFT_ID", "MESSAGE_ID", "NAME", "VALUE", "PATH", "BYTES", "CACHED"})
+	if draft == nil || draft.Message == nil {
+		return nil
+	}
+
+	draftID := draft.Id
+	msg := draft.Message
+	messageID := msg.Id
+
+	writeDraftPlainRecord := func(recordType, name, value, path, bytes, cached string) {
+		writeTableRow(ctx, w, []string{recordType, draftID, messageID, name, value, path, bytes, cached})
+	}
+
+	for _, name := range []string{"To", "Cc", "Bcc", "Subject"} {
+		writeDraftPlainRecord("metadata", name, headerValue(msg.Payload, name), "", "", "")
+	}
+
+	if body := bestBodyText(msg.Payload); body != "" {
+		writeDraftPlainRecord("body", "", body, "", "", "")
+	}
+
+	for _, a := range attachments {
+		writeDraftPlainRecord(
+			"attachment",
+			a.Filename,
+			a.MimeType,
+			"",
+			strconv.FormatInt(a.Size, 10),
+			"",
+		)
+	}
+
+	for _, a := range downloads {
+		writeDraftPlainRecord(
+			"download",
+			a.Filename,
+			"",
+			a.Path,
+			strconv.FormatInt(a.Bytes, 10),
+			boolString(a.Cached),
+		)
 	}
 
 	return nil

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -171,6 +171,64 @@ func TestGmailDraftsGetCmd_Text(t *testing.T) {
 	}
 }
 
+func TestGmailDraftsGetCmd_TextPrintsDetailsBeforeDownloadError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
+	payloadText := base64.RawURLEncoding.EncodeToString([]byte("Hello"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "d1",
+				"message": map[string]any{
+					"id": "m1",
+					"payload": map[string]any{
+						"mimeType": "multipart/mixed",
+						"headers":  []map[string]any{{"name": "Subject", "value": "Draft"}},
+						"parts": []map[string]any{
+							{"mimeType": "text/plain", "body": map[string]any{"data": payloadText}},
+							{
+								"filename": "file.txt",
+								"mimeType": "text/plain",
+								"body":     map[string]any{"attachmentId": "att1", "size": 10},
+							},
+						},
+					},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m1/attachments/att1"):
+			http.Error(w, "download failed", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	stubGmailService(t, srv)
+
+	var runErr error
+	out := captureStdout(t, func() {
+		u, err := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+		if err != nil {
+			t.Fatalf("ui.New: %v", err)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{})
+		runErr = runKong(t, &GmailDraftsGetCmd{}, []string{"d1", "--download"}, ctx, &RootFlags{Account: "a@b.com"})
+	})
+
+	if runErr == nil {
+		t.Fatal("expected attachment download error")
+	}
+	for _, want := range []string{"Draft-ID: d1", "Subject: Draft", "Hello", "Attachments:", "file.txt"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text output lost %q before download error: %q", want, out)
+		}
+	}
+}
+
 func TestExecute_GmailDraftsGet_Plain(t *testing.T) {
 	payloadText := base64.RawURLEncoding.EncodeToString([]byte("Hello\nworld\tline"))
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -171,6 +171,251 @@ func TestGmailDraftsGetCmd_Text(t *testing.T) {
 	}
 }
 
+func TestExecute_GmailDraftsGet_Plain(t *testing.T) {
+	payloadText := base64.RawURLEncoding.EncodeToString([]byte("Hello\nworld\tline"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "d1",
+				"message": map[string]any{
+					"id": "m1",
+					"payload": map[string]any{
+						"mimeType": "multipart/mixed",
+						"headers": []map[string]any{
+							{"name": "To", "value": "a@example.com"},
+							{"name": "Cc", "value": "b@example.com"},
+							{"name": "Bcc", "value": "c@example.com"},
+							{"name": "Subject", "value": "Draft\tSubject\nNext"},
+						},
+						"parts": []map[string]any{
+							{"mimeType": "text/plain", "body": map[string]any{"data": payloadText}},
+							{
+								"filename": "file\tname.txt",
+								"mimeType": "text/plain",
+								"body":     map[string]any{"attachmentId": "att1", "size": 10},
+							},
+						},
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	stubGmailService(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"gmail", "drafts", "get", "d1",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	wantHeader := "RECORD_TYPE\tDRAFT_ID\tMESSAGE_ID\tNAME\tVALUE\tPATH\tBYTES\tCACHED\n"
+	if !strings.HasPrefix(out, wantHeader) {
+		t.Fatalf("missing plain header:\nwant prefix %q\ngot %q", wantHeader, out)
+	}
+	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected records after header, got %q", out)
+	}
+	for i, line := range lines {
+		cols := strings.Split(line, "\t")
+		if len(cols) != 8 {
+			t.Fatalf("line %d has %d columns (want 8): %q", i, len(cols), line)
+		}
+		if strings.ContainsAny(cols[3], "\r\n") || strings.ContainsAny(cols[4], "\r\n") {
+			t.Fatalf("free-form field not sanitized on line %d: %q", i, line)
+		}
+		if i == 0 {
+			continue
+		}
+		if cols[1] != "d1" || cols[2] != "m1" {
+			t.Fatalf("line %d missing repeated IDs: %q", i, line)
+		}
+	}
+
+	joined := out
+	for _, want := range []string{
+		"metadata\td1\tm1\tTo\ta@example.com\t\t\t",
+		"metadata\td1\tm1\tCc\tb@example.com\t\t\t",
+		"metadata\td1\tm1\tBcc\tc@example.com\t\t\t",
+		"metadata\td1\tm1\tSubject\tDraft Subject Next\t\t\t",
+		"body\td1\tm1\t\tHello world line\t\t\t",
+		"attachment\td1\tm1\tfile name.txt\ttext/plain\t\t10\t",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("missing record %q in output:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(out, "Draft-ID:") || strings.Contains(out, "Attachments:") || strings.Contains(out, "Empty draft") {
+		t.Fatalf("plain mode leaked prose: %q", out)
+	}
+}
+
+func TestExecute_GmailDraftsGet_Plain_EmptyDraft(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "d1"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	stubGmailService(t, srv)
+
+	stdout := captureStdout(t, func() {
+		stderr := captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"gmail", "drafts", "get", "d1",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+		if strings.Contains(stderr, "Empty draft") {
+			t.Fatalf("plain empty draft should not print narrative stderr: %q", stderr)
+		}
+	})
+
+	want := "RECORD_TYPE\tDRAFT_ID\tMESSAGE_ID\tNAME\tVALUE\tPATH\tBYTES\tCACHED\n"
+	if stdout != want {
+		t.Fatalf("plain empty draft mismatch:\nwant %q\ngot  %q", want, stdout)
+	}
+}
+
+func TestExecute_GmailDraftsGet_Plain_Download(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
+	attData := []byte("hello-bytes")
+	attEncoded := base64.RawURLEncoding.EncodeToString(attData)
+	payloadText := base64.RawURLEncoding.EncodeToString([]byte("Body"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "d1",
+				"message": map[string]any{
+					"id": "m-draft-1",
+					"payload": map[string]any{
+						"mimeType": "multipart/mixed",
+						"headers": []map[string]any{
+							{"name": "To", "value": "x@y.com"},
+							{"name": "Subject", "value": "S"},
+						},
+						"parts": []map[string]any{
+							{"mimeType": "text/plain", "body": map[string]any{"data": payloadText}},
+							{
+								"filename": "a.txt",
+								"mimeType": "text/plain",
+								"body":     map[string]any{"attachmentId": "a-draft-1", "size": len(attData)},
+							},
+						},
+					},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m-draft-1/attachments/a-draft-1"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": attEncoded})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+	stubGmailService(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"gmail", "drafts", "get", "d1", "--download",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	wantHeader := "RECORD_TYPE\tDRAFT_ID\tMESSAGE_ID\tNAME\tVALUE\tPATH\tBYTES\tCACHED\n"
+	if !strings.HasPrefix(out, wantHeader) {
+		t.Fatalf("missing plain header:\nwant prefix %q\ngot %q", wantHeader, out)
+	}
+	if !strings.Contains(out, "attachment\td1\tm-draft-1\ta.txt\ttext/plain\t\t11\t") {
+		t.Fatalf("missing attachment record: %q", out)
+	}
+
+	var downloadLine string
+	for _, line := range strings.Split(strings.TrimSuffix(out, "\n"), "\n") {
+		if strings.HasPrefix(line, "download\t") {
+			downloadLine = line
+			break
+		}
+	}
+	if downloadLine == "" {
+		t.Fatalf("missing download record: %q", out)
+	}
+	cols := strings.Split(downloadLine, "\t")
+	if len(cols) != 8 {
+		t.Fatalf("download columns=%d line=%q", len(cols), downloadLine)
+	}
+	if cols[0] != "download" || cols[1] != "d1" || cols[2] != "m-draft-1" {
+		t.Fatalf("download identity mismatch: %q", downloadLine)
+	}
+	if cols[3] != "a.txt" {
+		t.Fatalf("download name mismatch: %q", downloadLine)
+	}
+	if cols[5] == "" {
+		t.Fatalf("download path empty: %q", downloadLine)
+	}
+	if cols[6] != "11" {
+		t.Fatalf("download bytes mismatch: %q", downloadLine)
+	}
+	if cols[7] != "false" && cols[7] != "true" {
+		t.Fatalf("download cached not bool: %q", downloadLine)
+	}
+	if strings.Contains(out, "Saved:") || strings.Contains(out, "Cached:") {
+		t.Fatalf("plain download leaked prose: %q", out)
+	}
+
+	// Second run should hit cache and report exact path/bytes/cached=true.
+	out2 := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"gmail", "drafts", "get", "d1", "--download",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	var cachedLine string
+	for _, line := range strings.Split(strings.TrimSuffix(out2, "\n"), "\n") {
+		if strings.HasPrefix(line, "download\t") {
+			cachedLine = line
+			break
+		}
+	}
+	if cachedLine == "" {
+		t.Fatalf("missing cached download record: %q", out2)
+	}
+	cachedCols := strings.Split(cachedLine, "\t")
+	if len(cachedCols) != 8 || cachedCols[5] != cols[5] || cachedCols[6] != "11" || cachedCols[7] != "true" {
+		t.Fatalf("cached download mismatch:\nfirst %q\nsecond %q", downloadLine, cachedLine)
+	}
+}
+
 func TestGmailDraftsDeleteCmd_JSON(t *testing.T) {
 	origNew := newGmailService
 	t.Cleanup(func() { newGmailService = origNew })

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -647,9 +647,9 @@ func decodeBase64URL(s string) (string, error) {
 	return string(b), nil
 }
 
-func downloadAttachment(ctx context.Context, svc *gmail.Service, messageID string, a attachmentInfo, dir string) (string, bool, error) {
+func downloadAttachment(ctx context.Context, svc *gmail.Service, messageID string, a attachmentInfo, dir string) (string, bool, int64, error) {
 	if strings.TrimSpace(messageID) == "" || strings.TrimSpace(a.AttachmentID) == "" {
-		return "", false, errors.New("missing messageID/attachmentID")
+		return "", false, 0, errors.New("missing messageID/attachmentID")
 	}
 	if strings.TrimSpace(dir) == "" {
 		dir = "."
@@ -665,9 +665,9 @@ func downloadAttachment(ctx context.Context, svc *gmail.Service, messageID strin
 	}
 	filename := fmt.Sprintf("%s_%s_%s", messageID, shortID, safeFilename)
 	outPath := filepath.Join(dir, filename)
-	path, cached, _, err := downloadAttachmentToPath(ctx, svc, messageID, a.AttachmentID, outPath, a.Size)
+	path, cached, bytes, err := downloadAttachmentToPath(ctx, svc, messageID, a.AttachmentID, outPath, a.Size)
 	if err != nil {
-		return "", false, err
+		return "", false, 0, err
 	}
-	return path, cached, nil
+	return path, cached, bytes, nil
 }

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -665,9 +665,9 @@ func downloadAttachment(ctx context.Context, svc *gmail.Service, messageID strin
 	}
 	filename := fmt.Sprintf("%s_%s_%s", messageID, shortID, safeFilename)
 	outPath := filepath.Join(dir, filename)
-	path, cached, bytes, err := downloadAttachmentToPath(ctx, svc, messageID, a.AttachmentID, outPath, a.Size)
+	path, cached, byteCount, err := downloadAttachmentToPath(ctx, svc, messageID, a.AttachmentID, outPath, a.Size)
 	if err != nil {
 		return "", false, 0, err
 	}
-	return path, cached, bytes, nil
+	return path, cached, byteCount, nil
 }

--- a/internal/cmd/gmail_thread_helpers_more_test.go
+++ b/internal/cmd/gmail_thread_helpers_more_test.go
@@ -88,7 +88,7 @@ func TestGmailThreadHelpers_Misc(t *testing.T) {
 }
 
 func TestDownloadAttachment_ErrorsAndSafeFilename(t *testing.T) {
-	if _, _, err := downloadAttachment(context.Background(), nil, "", attachmentInfo{AttachmentID: "a"}, "."); err == nil {
+	if _, _, _, err := downloadAttachment(context.Background(), nil, "", attachmentInfo{AttachmentID: "a"}, "."); err == nil {
 		t.Fatalf("expected missing messageID error")
 	}
 
@@ -103,12 +103,12 @@ func TestDownloadAttachment_ErrorsAndSafeFilename(t *testing.T) {
 	if err := os.WriteFile(expectedPath, []byte("data"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	path, cached, err := downloadAttachment(context.Background(), nil, "m1", att, dir)
+	path, cached, bytes, err := downloadAttachment(context.Background(), nil, "m1", att, dir)
 	if err != nil {
 		t.Fatalf("downloadAttachment: %v", err)
 	}
-	if path != expectedPath || !cached {
-		t.Fatalf("unexpected download result: path=%q cached=%v", path, cached)
+	if path != expectedPath || !cached || bytes != 4 {
+		t.Fatalf("unexpected download result: path=%q cached=%v bytes=%d", path, cached, bytes)
 	}
 }
 
@@ -132,7 +132,7 @@ func TestDownloadAttachment_ServiceError(t *testing.T) {
 		Size:         1,
 		AttachmentID: "att1",
 	}
-	if _, _, err := downloadAttachment(context.Background(), svc, "m1", att, t.TempDir()); err == nil {
+	if _, _, _, err := downloadAttachment(context.Background(), svc, "m1", att, t.TempDir()); err == nil {
 		t.Fatalf("expected error")
 	}
 }

--- a/internal/cmd/gmail_thread_helpers_test.go
+++ b/internal/cmd/gmail_thread_helpers_test.go
@@ -322,11 +322,11 @@ func TestDownloadAttachment_Cached(t *testing.T) {
 		AttachmentID: attachmentID,
 		Size:         3,
 	}
-	gotPath, cached, err := downloadAttachment(context.Background(), nil, messageID, info, dir)
+	gotPath, cached, bytes, err := downloadAttachment(context.Background(), nil, messageID, info, dir)
 	if err != nil {
 		t.Fatalf("downloadAttachment: %v", err)
 	}
-	if !cached || gotPath != outPath {
-		t.Fatalf("expected cached path %q, got %q cached=%v", outPath, gotPath, cached)
+	if !cached || gotPath != outPath || bytes != 3 {
+		t.Fatalf("expected cached path %q bytes=3, got %q cached=%v bytes=%d", outPath, gotPath, cached, bytes)
 	}
 }


### PR DESCRIPTION
## Summary
- emit a fixed eight-column record stream for gmail drafts get --plain
- distinguish metadata, body, attachment, and download rows while sanitizing free-form fields
- report exact download paths, byte counts, and cache status without changing JSON, text, or transfer behavior

## Testing
- focused Gmail draft and attachment tests
- PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci

Closes #72