### PR TITLE
fix(gmail): make watch checkpoints durable

### DIFF
--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -21,6 +21,22 @@ type gmailWatchStore struct {
 	state gmailWatchState
 }
 
+// watchTempFile is the temp-file surface used by Save for injectable failure tests.
+type watchTempFile interface {
+	Name() string
+	Write(p []byte) (int, error)
+	Close() error
+	Chmod(mode os.FileMode) error
+}
+
+var (
+	watchCreateTemp = func(dir, pattern string) (watchTempFile, error) {
+		return os.CreateTemp(dir, pattern)
+	}
+	watchRename = os.Rename
+	watchRemove = os.Remove
+)
+
 func gmailWatchStatePath(account string) (string, error) {
 	dir, err := config.EnsureGmailWatchDir()
 	if err != nil {
@@ -89,21 +105,65 @@ func (s *gmailWatchStore) Get() gmailWatchState {
 func (s *gmailWatchStore) Update(fn func(*gmailWatchState) error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := fn(&s.state); err != nil {
+
+	next := s.state
+	if err := fn(&next); err != nil {
 		return err
 	}
-	return s.Save()
+	if err := s.saveState(next); err != nil {
+		return err
+	}
+	s.state = next
+	return nil
 }
 
 func (s *gmailWatchStore) Save() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saveState(s.state)
+}
+
+// saveState persists state atomically. Caller must hold s.mu when coordinating
+// with in-memory updates; Save holds the lock, Update holds it around save+publish.
+func (s *gmailWatchStore) saveState(state gmailWatchState) error {
 	if s.path == "" {
 		return errors.New("missing watch state path")
 	}
-	payload, err := json.MarshalIndent(s.state, "", "  ")
+	payload, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.path, append(payload, '\n'), 0o600)
+	payload = append(payload, '\n')
+
+	dir := filepath.Dir(s.path)
+	tmp, err := watchCreateTemp(dir, "gmail-watch-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create watch state temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = watchRemove(tmpName)
+		}
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod watch state temp: %w", err)
+	}
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write watch state temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close watch state temp: %w", err)
+	}
+	if err := watchRename(tmpName, s.path); err != nil {
+		return fmt.Errorf("replace watch state: %w", err)
+	}
+	cleanup = false
+	return nil
 }
 
 func (s *gmailWatchStore) StartHistoryID(pushHistory string) (uint64, error) {
@@ -123,9 +183,13 @@ func (s *gmailWatchStore) StartHistoryID(pushHistory string) (uint64, error) {
 		if pushErr != nil {
 			return 0, pushErr
 		}
-		s.state.HistoryID = formatHistoryID(pushID)
-		s.state.UpdatedAtMs = time.Now().UnixMilli()
-		_ = s.Save()
+		next := s.state
+		next.HistoryID = formatHistoryID(pushID)
+		next.UpdatedAtMs = time.Now().UnixMilli()
+		if err := s.saveState(next); err != nil {
+			return 0, err
+		}
+		s.state = next
 		return pushID, nil
 	}
 

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -33,8 +33,8 @@ var (
 	watchCreateTemp = func(dir, pattern string) (watchTempFile, error) {
 		return os.CreateTemp(dir, pattern)
 	}
-	watchRename = os.Rename
-	watchRemove = os.Remove
+	watchReplace = replaceFile
+	watchRemove  = os.Remove
 )
 
 func gmailWatchStatePath(account string) (string, error) {
@@ -99,14 +99,23 @@ func loadGmailWatchStore(account string) (*gmailWatchStore, error) {
 func (s *gmailWatchStore) Get() gmailWatchState {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.state
+	return cloneGmailWatchState(s.state)
+}
+
+func cloneGmailWatchState(state gmailWatchState) gmailWatchState {
+	state.Labels = append([]string(nil), state.Labels...)
+	if state.Hook != nil {
+		hook := *state.Hook
+		state.Hook = &hook
+	}
+	return state
 }
 
 func (s *gmailWatchStore) Update(fn func(*gmailWatchState) error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	next := s.state
+	next := cloneGmailWatchState(s.state)
 	if err := fn(&next); err != nil {
 		return err
 	}
@@ -159,7 +168,7 @@ func (s *gmailWatchStore) saveState(state gmailWatchState) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close watch state temp: %w", err)
 	}
-	if err := watchRename(tmpName, s.path); err != nil {
+	if err := watchReplace(tmpName, s.path); err != nil {
 		return fmt.Errorf("replace watch state: %w", err)
 	}
 	cleanup = false

--- a/internal/cmd/gmail_watch_state_persist_test.go
+++ b/internal/cmd/gmail_watch_state_persist_test.go
@@ -1,0 +1,285 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var (
+	errTestWatchWrite   = errors.New("injected watch write failure")
+	errTestWatchClose   = errors.New("injected watch close failure")
+	errTestWatchReplace = errors.New("injected watch replace failure")
+)
+
+type failingWatchTempFile struct {
+	watchTempFile
+	writeErr error
+	closeErr error
+}
+
+func (f *failingWatchTempFile) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return f.watchTempFile.Write(p)
+}
+
+func (f *failingWatchTempFile) Close() error {
+	if err := f.watchTempFile.Close(); err != nil {
+		return err
+	}
+	return f.closeErr
+}
+
+func restoreWatchFS(t *testing.T) {
+	t.Helper()
+	origCreate := watchCreateTemp
+	origRename := watchRename
+	origRemove := watchRemove
+	t.Cleanup(func() {
+		watchCreateTemp = origCreate
+		watchRename = origRename
+		watchRemove = origRemove
+	})
+}
+
+func seedWatchStateFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+}
+
+func listWatchTemps(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var temps []string
+	for _, e := range entries {
+		name := e.Name()
+		if strings.Contains(name, "gmail-watch-") && strings.HasSuffix(name, ".tmp") {
+			temps = append(temps, name)
+		}
+	}
+	return temps
+}
+
+func TestGmailWatchStore_Save_AtomicOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acct.json")
+	seedWatchStateFile(t, path, `{"account":"old@example.com","historyId":"1"}`+"\n")
+
+	store := &gmailWatchStore{
+		path: path,
+		state: gmailWatchState{
+			Account:   "new@example.com",
+			HistoryID: "42",
+		},
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("permissions = %04o, want 0600", info.Mode().Perm())
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), `"historyId": "42"`) {
+		t.Fatalf("unexpected content: %s", got)
+	}
+	if temps := listWatchTemps(t, dir); len(temps) != 0 {
+		t.Fatalf("leftover temps: %v", temps)
+	}
+}
+
+func TestGmailWatchStore_Save_WriteFailurePreservesPriorAndCleansTemp(t *testing.T) {
+	restoreWatchFS(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acct.json")
+	prior := `{"account":"old@example.com","historyId":"1"}` + "\n"
+	seedWatchStateFile(t, path, prior)
+
+	watchCreateTemp = func(d, pattern string) (watchTempFile, error) {
+		f, err := os.CreateTemp(d, pattern)
+		if err != nil {
+			return nil, err
+		}
+		return &failingWatchTempFile{watchTempFile: f, writeErr: errTestWatchWrite}, nil
+	}
+
+	store := &gmailWatchStore{
+		path:  path,
+		state: gmailWatchState{Account: "new@example.com", HistoryID: "99"},
+	}
+	err := store.Save()
+	if err == nil || !errors.Is(err, errTestWatchWrite) {
+		t.Fatalf("Save error = %v, want %v", err, errTestWatchWrite)
+	}
+	if !strings.Contains(err.Error(), "write") {
+		t.Fatalf("expected actionable write error, got %v", err)
+	}
+
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read prior: %v", readErr)
+	}
+	if string(got) != prior {
+		t.Fatalf("prior file changed: %q", got)
+	}
+	if temps := listWatchTemps(t, dir); len(temps) != 0 {
+		t.Fatalf("leftover temps: %v", temps)
+	}
+}
+
+func TestGmailWatchStore_Save_CloseFailurePreservesPriorAndCleansTemp(t *testing.T) {
+	restoreWatchFS(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acct.json")
+	prior := `{"account":"old@example.com","historyId":"1"}` + "\n"
+	seedWatchStateFile(t, path, prior)
+
+	watchCreateTemp = func(d, pattern string) (watchTempFile, error) {
+		f, err := os.CreateTemp(d, pattern)
+		if err != nil {
+			return nil, err
+		}
+		return &failingWatchTempFile{watchTempFile: f, closeErr: errTestWatchClose}, nil
+	}
+
+	store := &gmailWatchStore{
+		path:  path,
+		state: gmailWatchState{Account: "new@example.com", HistoryID: "99"},
+	}
+	err := store.Save()
+	if err == nil || !errors.Is(err, errTestWatchClose) {
+		t.Fatalf("Save error = %v, want %v", err, errTestWatchClose)
+	}
+	if !strings.Contains(err.Error(), "close") {
+		t.Fatalf("expected actionable close error, got %v", err)
+	}
+
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read prior: %v", readErr)
+	}
+	if string(got) != prior {
+		t.Fatalf("prior file changed: %q", got)
+	}
+	if temps := listWatchTemps(t, dir); len(temps) != 0 {
+		t.Fatalf("leftover temps: %v", temps)
+	}
+}
+
+func TestGmailWatchStore_Save_ReplaceFailurePreservesPriorAndCleansTemp(t *testing.T) {
+	restoreWatchFS(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acct.json")
+	prior := `{"account":"old@example.com","historyId":"1"}` + "\n"
+	seedWatchStateFile(t, path, prior)
+
+	watchRename = func(_, _ string) error { return errTestWatchReplace }
+
+	store := &gmailWatchStore{
+		path:  path,
+		state: gmailWatchState{Account: "new@example.com", HistoryID: "99"},
+	}
+	err := store.Save()
+	if err == nil || !errors.Is(err, errTestWatchReplace) {
+		t.Fatalf("Save error = %v, want %v", err, errTestWatchReplace)
+	}
+	if !strings.Contains(err.Error(), "replace") {
+		t.Fatalf("expected actionable replace error, got %v", err)
+	}
+
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read prior: %v", readErr)
+	}
+	if string(got) != prior {
+		t.Fatalf("prior file changed: %q", got)
+	}
+	if temps := listWatchTemps(t, dir); len(temps) != 0 {
+		t.Fatalf("leftover temps: %v", temps)
+	}
+}
+
+func TestGmailWatchStore_Update_MemoryUnchangedOnPersistFailure(t *testing.T) {
+	restoreWatchFS(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acct.json")
+	prior := `{"account":"old@example.com","historyId":"1"}` + "\n"
+	seedWatchStateFile(t, path, prior)
+
+	watchRename = func(_, _ string) error { return errTestWatchReplace }
+
+	store := &gmailWatchStore{
+		path: path,
+		state: gmailWatchState{
+			Account:   "old@example.com",
+			HistoryID: "1",
+		},
+	}
+	err := store.Update(func(s *gmailWatchState) error {
+		s.Account = "new@example.com"
+		s.HistoryID = "99"
+		return nil
+	})
+	if err == nil || !errors.Is(err, errTestWatchReplace) {
+		t.Fatalf("Update error = %v, want %v", err, errTestWatchReplace)
+	}
+
+	got := store.Get()
+	if got.Account != "old@example.com" || got.HistoryID != "1" {
+		t.Fatalf("in-memory state changed on failed persist: %+v", got)
+	}
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read prior: %v", readErr)
+	}
+	if string(data) != prior {
+		t.Fatalf("prior file changed: %q", data)
+	}
+}
+
+func TestGmailWatchStore_StartHistoryID_ReturnsSaveError(t *testing.T) {
+	restoreWatchFS(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acct.json")
+
+	watchRename = func(_, _ string) error { return errTestWatchReplace }
+
+	store := &gmailWatchStore{path: path}
+	id, err := store.StartHistoryID("123")
+	if err == nil || !errors.Is(err, errTestWatchReplace) {
+		t.Fatalf("StartHistoryID error = %v, want %v", err, errTestWatchReplace)
+	}
+	if id != 0 {
+		t.Fatalf("id = %d, want 0 on save failure", id)
+	}
+	got := store.Get()
+	if got.HistoryID != "" {
+		t.Fatalf("in-memory history advanced despite save failure: %+v", got)
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no state file after failed initial save, stat=%v", statErr)
+	}
+	if temps := listWatchTemps(t, dir); len(temps) != 0 {
+		t.Fatalf("leftover temps: %v", temps)
+	}
+}

--- a/internal/cmd/gmail_watch_state_persist_test.go
+++ b/internal/cmd/gmail_watch_state_persist_test.go
@@ -37,20 +37,21 @@ func (f *failingWatchTempFile) Close() error {
 func restoreWatchFS(t *testing.T) {
 	t.Helper()
 	origCreate := watchCreateTemp
-	origRename := watchRename
+	origReplace := watchReplace
 	origRemove := watchRemove
 	t.Cleanup(func() {
 		watchCreateTemp = origCreate
-		watchRename = origRename
+		watchReplace = origReplace
 		watchRemove = origRemove
 	})
 }
 
-func seedWatchStateFile(t *testing.T, path, body string) {
+func seedWatchStateFile(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+	body := `{"account":"old@example.com","historyId":"1"}` + "\n"
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatalf("seed state: %v", err)
 	}
@@ -75,7 +76,7 @@ func listWatchTemps(t *testing.T, dir string) []string {
 func TestGmailWatchStore_Save_AtomicOwnerOnly(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "acct.json")
-	seedWatchStateFile(t, path, `{"account":"old@example.com","historyId":"1"}`+"\n")
+	seedWatchStateFile(t, path)
 
 	store := &gmailWatchStore{
 		path: path,
@@ -113,7 +114,7 @@ func TestGmailWatchStore_Save_WriteFailurePreservesPriorAndCleansTemp(t *testing
 	dir := t.TempDir()
 	path := filepath.Join(dir, "acct.json")
 	prior := `{"account":"old@example.com","historyId":"1"}` + "\n"
-	seedWatchStateFile(t, path, prior)
+	seedWatchStateFile(t, path)
 
 	watchCreateTemp = func(d, pattern string) (watchTempFile, error) {
 		f, err := os.CreateTemp(d, pattern)
@@ -152,7 +153,7 @@ func TestGmailWatchStore_Save_CloseFailurePreservesPriorAndCleansTemp(t *testing
 	dir := t.TempDir()
 	path := filepath.Join(dir, "acct.json")
 	prior := `{"account":"old@example.com","historyId":"1"}` + "\n"
-	seedWatchStateFile(t, path, prior)
+	seedWatchStateFile(t, path)
 
 	watchCreateTemp = func(d, pattern string) (watchTempFile, error) {
 		f, err := os.CreateTemp(d, pattern)
@@ -191,9 +192,9 @@ func TestGmailWatchStore_Save_ReplaceFailurePreservesPriorAndCleansTemp(t *testi
 	dir := t.TempDir()
 	path := filepath.Join(dir, "acct.json")
 	prior := `{"account":"old@example.com","historyId":"1"}` + "\n"
-	seedWatchStateFile(t, path, prior)
+	seedWatchStateFile(t, path)
 
-	watchRename = func(_, _ string) error { return errTestWatchReplace }
+	watchReplace = func(_, _ string) error { return errTestWatchReplace }
 
 	store := &gmailWatchStore{
 		path:  path,
@@ -224,9 +225,9 @@ func TestGmailWatchStore_Update_MemoryUnchangedOnPersistFailure(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "acct.json")
 	prior := `{"account":"old@example.com","historyId":"1"}` + "\n"
-	seedWatchStateFile(t, path, prior)
+	seedWatchStateFile(t, path)
 
-	watchRename = func(_, _ string) error { return errTestWatchReplace }
+	watchReplace = func(_, _ string) error { return errTestWatchReplace }
 
 	store := &gmailWatchStore{
 		path: path,
@@ -257,12 +258,43 @@ func TestGmailWatchStore_Update_MemoryUnchangedOnPersistFailure(t *testing.T) {
 	}
 }
 
+func TestGmailWatchStore_Update_ReferenceFieldsUnchangedOnPersistFailure(t *testing.T) {
+	restoreWatchFS(t)
+	path := filepath.Join(t.TempDir(), "acct.json")
+	seedWatchStateFile(t, path)
+	watchReplace = func(_, _ string) error { return errTestWatchReplace }
+
+	store := &gmailWatchStore{
+		path: path,
+		state: gmailWatchState{
+			Labels: []string{"INBOX"},
+			Hook:   &gmailWatchHook{URL: "https://old.example"},
+		},
+	}
+	err := store.Update(func(s *gmailWatchState) error {
+		s.Labels[0] = "TRASH"
+		s.Hook.URL = "https://new.example"
+		return nil
+	})
+	if err == nil || !errors.Is(err, errTestWatchReplace) {
+		t.Fatalf("Update error = %v, want %v", err, errTestWatchReplace)
+	}
+
+	got := store.Get()
+	if len(got.Labels) != 1 || got.Labels[0] != "INBOX" {
+		t.Fatalf("labels changed on failed persist: %v", got.Labels)
+	}
+	if got.Hook == nil || got.Hook.URL != "https://old.example" {
+		t.Fatalf("hook changed on failed persist: %+v", got.Hook)
+	}
+}
+
 func TestGmailWatchStore_StartHistoryID_ReturnsSaveError(t *testing.T) {
 	restoreWatchFS(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "acct.json")
 
-	watchRename = func(_, _ string) error { return errTestWatchReplace }
+	watchReplace = func(_, _ string) error { return errTestWatchReplace }
 
 	store := &gmailWatchStore{path: path}
 	id, err := store.StartHistoryID("123")


### PR DESCRIPTION
## Summary
- persist Gmail watch state through private same-directory temporary files and atomic replacement
- keep observable in-memory state unchanged when persistence fails
- surface initial history checkpoint save failures and clean temporary files

## Testing
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" go test ./internal/cmd -run "TestGmailWatchStore_(Save|Update|StartHistoryID)" -count=1`
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci`

Closes #79