### PR TITLE
fix(gmail): emit stable plain account settings receipts

### DIFF
--- a/internal/cmd/gmail_autoforward.go
+++ b/internal/cmd/gmail_autoforward.go
@@ -137,14 +137,9 @@ func (c *GmailAutoForwardUpdateCmd) Run(ctx context.Context, kctx *kong.Context,
 }
 
 func writePlainAutoForwardSetting(ctx context.Context, autoForward *gmail.AutoForwarding) {
-	fields := [][2]string{
+	writePlainSettingRows(ctx, "auto_forwarding", [][2]string{
 		{"enabled", strconv.FormatBool(autoForward.Enabled)},
-	}
-	if autoForward.EmailAddress != "" {
-		fields = append(fields, [2]string{"email_address", autoForward.EmailAddress})
-	}
-	if autoForward.Disposition != "" {
-		fields = append(fields, [2]string{"disposition", autoForward.Disposition})
-	}
-	writePlainSettingRows(ctx, "auto_forwarding", fields)
+		{"email_address", autoForward.EmailAddress},
+		{"disposition", autoForward.Disposition},
+	})
 }

--- a/internal/cmd/gmail_autoforward.go
+++ b/internal/cmd/gmail_autoforward.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/gmail/v1"
@@ -119,6 +120,11 @@ func (c *GmailAutoForwardUpdateCmd) Run(ctx context.Context, kctx *kong.Context,
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"autoForwarding": updated})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainAutoForwardSetting(ctx, updated)
+		return nil
+	}
+
 	u.Out().Println("Auto-forwarding settings updated successfully")
 	u.Out().Printf("enabled\t%t", updated.Enabled)
 	if updated.EmailAddress != "" {
@@ -128,4 +134,17 @@ func (c *GmailAutoForwardUpdateCmd) Run(ctx context.Context, kctx *kong.Context,
 		u.Out().Printf("disposition\t%s", updated.Disposition)
 	}
 	return nil
+}
+
+func writePlainAutoForwardSetting(ctx context.Context, autoForward *gmail.AutoForwarding) {
+	fields := [][2]string{
+		{"enabled", strconv.FormatBool(autoForward.Enabled)},
+	}
+	if autoForward.EmailAddress != "" {
+		fields = append(fields, [2]string{"email_address", autoForward.EmailAddress})
+	}
+	if autoForward.Disposition != "" {
+		fields = append(fields, [2]string{"disposition", autoForward.Disposition})
+	}
+	writePlainSettingRows(ctx, "auto_forwarding", fields)
 }

--- a/internal/cmd/gmail_imap_pop_language.go
+++ b/internal/cmd/gmail_imap_pop_language.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/gmail/v1"
@@ -150,6 +151,11 @@ func (c *GmailImapUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"imap": updated})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainImapSetting(ctx, updated)
+		return nil
+	}
+
 	u.Out().Println("IMAP settings updated successfully")
 	u.Out().Printf("enabled\t%t", updated.Enabled)
 	u.Out().Printf("auto_expunge\t%t", updated.AutoExpunge)
@@ -257,6 +263,11 @@ func (c *GmailPopUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"pop": updated})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainPopSetting(ctx, updated)
+		return nil
+	}
+
 	u.Out().Println("POP settings updated successfully")
 	u.Out().Printf("access_window\t%s", updated.AccessWindow)
 	if updated.Disposition != "" {
@@ -327,7 +338,42 @@ func (c *GmailLanguageUpdateCmd) Run(ctx context.Context, kctx *kong.Context, fl
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"language": updated})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainLanguageSetting(ctx, updated)
+		return nil
+	}
+
 	u.Out().Println("Language settings updated successfully")
 	u.Out().Printf("display_language\t%s", updated.DisplayLanguage)
 	return nil
+}
+
+func writePlainImapSetting(ctx context.Context, imap *gmail.ImapSettings) {
+	fields := [][2]string{
+		{"enabled", strconv.FormatBool(imap.Enabled)},
+		{"auto_expunge", strconv.FormatBool(imap.AutoExpunge)},
+	}
+	if imap.ExpungeBehavior != "" {
+		fields = append(fields, [2]string{"expunge_behavior", imap.ExpungeBehavior})
+	}
+	if imap.MaxFolderSize > 0 {
+		fields = append(fields, [2]string{"max_folder_size", strconv.FormatInt(imap.MaxFolderSize, 10)})
+	}
+	writePlainSettingRows(ctx, "imap", fields)
+}
+
+func writePlainPopSetting(ctx context.Context, pop *gmail.PopSettings) {
+	fields := [][2]string{
+		{"access_window", pop.AccessWindow},
+	}
+	if pop.Disposition != "" {
+		fields = append(fields, [2]string{"disposition", pop.Disposition})
+	}
+	writePlainSettingRows(ctx, "pop", fields)
+}
+
+func writePlainLanguageSetting(ctx context.Context, lang *gmail.LanguageSettings) {
+	writePlainSettingRows(ctx, "language", [][2]string{
+		{"display_language", lang.DisplayLanguage},
+	})
 }

--- a/internal/cmd/gmail_imap_pop_language.go
+++ b/internal/cmd/gmail_imap_pop_language.go
@@ -349,27 +349,19 @@ func (c *GmailLanguageUpdateCmd) Run(ctx context.Context, kctx *kong.Context, fl
 }
 
 func writePlainImapSetting(ctx context.Context, imap *gmail.ImapSettings) {
-	fields := [][2]string{
+	writePlainSettingRows(ctx, "imap", [][2]string{
 		{"enabled", strconv.FormatBool(imap.Enabled)},
 		{"auto_expunge", strconv.FormatBool(imap.AutoExpunge)},
-	}
-	if imap.ExpungeBehavior != "" {
-		fields = append(fields, [2]string{"expunge_behavior", imap.ExpungeBehavior})
-	}
-	if imap.MaxFolderSize > 0 {
-		fields = append(fields, [2]string{"max_folder_size", strconv.FormatInt(imap.MaxFolderSize, 10)})
-	}
-	writePlainSettingRows(ctx, "imap", fields)
+		{"expunge_behavior", imap.ExpungeBehavior},
+		{"max_folder_size", strconv.FormatInt(imap.MaxFolderSize, 10)},
+	})
 }
 
 func writePlainPopSetting(ctx context.Context, pop *gmail.PopSettings) {
-	fields := [][2]string{
+	writePlainSettingRows(ctx, "pop", [][2]string{
 		{"access_window", pop.AccessWindow},
-	}
-	if pop.Disposition != "" {
-		fields = append(fields, [2]string{"disposition", pop.Disposition})
-	}
-	writePlainSettingRows(ctx, "pop", fields)
+		{"disposition", pop.Disposition},
+	})
 }
 
 func writePlainLanguageSetting(ctx context.Context, lang *gmail.LanguageSettings) {

--- a/internal/cmd/gmail_settings_plain_test.go
+++ b/internal/cmd/gmail_settings_plain_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -19,11 +18,28 @@ import (
 // Public CLI seam: Gmail settings update commands under --plain emit a fixed
 // multi-row TSV receipt (SETTING/FIELD/VALUE) with no prose on stdout.
 
-func TestGmailImapUpdateCmd_PlainReceipt(t *testing.T) {
+func useGmailSettingsServer(t *testing.T, handler http.Handler) {
+	t.Helper()
 	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
+	srv := httptest.NewServer(handler)
+	t.Cleanup(func() {
+		newGmailService = origNew
+		srv.Close()
+	})
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+}
+
+func TestGmailImapUpdateCmd_PlainReceipt(t *testing.T) {
+	useGmailSettingsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/settings/imap") {
 			http.NotFound(w, r)
 			return
@@ -48,25 +64,10 @@ func TestGmailImapUpdateCmd_PlainReceipt(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer srv.Close()
-
-	svc, err := gmail.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com"}
 	out := captureStdout(t, func() {
-		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
-		if uiErr != nil {
-			t.Fatalf("ui.New: %v", uiErr)
-		}
-		ctx := ui.WithUI(context.Background(), u)
+		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
 		if runErr := runKong(t, &GmailImapUpdateCmd{}, []string{
 			"--enable",
@@ -92,11 +93,8 @@ func TestGmailImapUpdateCmd_PlainReceipt(t *testing.T) {
 	}
 }
 
-func TestGmailImapUpdateCmd_PlainReceiptOmitsEmptyOptionalFields(t *testing.T) {
-	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestGmailImapUpdateCmd_PlainReceiptIncludesZeroValues(t *testing.T) {
+	useGmailSettingsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/settings/imap") {
 			http.NotFound(w, r)
 			return
@@ -118,25 +116,10 @@ func TestGmailImapUpdateCmd_PlainReceiptOmitsEmptyOptionalFields(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer srv.Close()
-
-	svc, err := gmail.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com"}
 	out := captureStdout(t, func() {
-		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
-		if uiErr != nil {
-			t.Fatalf("ui.New: %v", uiErr)
-		}
-		ctx := ui.WithUI(context.Background(), u)
+		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
 		if runErr := runKong(t, &GmailImapUpdateCmd{}, []string{"--disable", "--no-auto-expunge"}, ctx, flags); runErr != nil {
 			t.Fatalf("execute: %v", runErr)
@@ -146,17 +129,16 @@ func TestGmailImapUpdateCmd_PlainReceiptOmitsEmptyOptionalFields(t *testing.T) {
 	want := "" +
 		"SETTING\tFIELD\tVALUE\n" +
 		"imap\tenabled\tfalse\n" +
-		"imap\tauto_expunge\tfalse\n"
+		"imap\tauto_expunge\tfalse\n" +
+		"imap\texpunge_behavior\t\n" +
+		"imap\tmax_folder_size\t0\n"
 	if out != want {
-		t.Fatalf("plain imap update optional fields = %q, want %q", out, want)
+		t.Fatalf("plain imap update zero values = %q, want %q", out, want)
 	}
 }
 
 func TestGmailPopUpdateCmd_PlainReceipt(t *testing.T) {
-	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	useGmailSettingsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/settings/pop") {
 			http.NotFound(w, r)
 			return
@@ -177,25 +159,10 @@ func TestGmailPopUpdateCmd_PlainReceipt(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer srv.Close()
-
-	svc, err := gmail.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com"}
 	out := captureStdout(t, func() {
-		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
-		if uiErr != nil {
-			t.Fatalf("ui.New: %v", uiErr)
-		}
-		ctx := ui.WithUI(context.Background(), u)
+		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
 		if runErr := runKong(t, &GmailPopUpdateCmd{}, []string{
 			"--access-window", "allMail",
@@ -218,10 +185,7 @@ func TestGmailPopUpdateCmd_PlainReceipt(t *testing.T) {
 }
 
 func TestGmailLanguageUpdateCmd_PlainReceipt(t *testing.T) {
-	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	useGmailSettingsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/settings/language") {
 			http.NotFound(w, r)
 			return
@@ -236,25 +200,10 @@ func TestGmailLanguageUpdateCmd_PlainReceipt(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer srv.Close()
-
-	svc, err := gmail.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com"}
 	out := captureStdout(t, func() {
-		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
-		if uiErr != nil {
-			t.Fatalf("ui.New: %v", uiErr)
-		}
-		ctx := ui.WithUI(context.Background(), u)
+		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
 		if runErr := runKong(t, &GmailLanguageUpdateCmd{}, []string{"--display-language", "ja"}, ctx, flags); runErr != nil {
 			t.Fatalf("execute: %v", runErr)
@@ -273,10 +222,7 @@ func TestGmailLanguageUpdateCmd_PlainReceipt(t *testing.T) {
 }
 
 func TestGmailAutoForwardUpdateCmd_PlainReceipt(t *testing.T) {
-	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	useGmailSettingsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/settings/autoForwarding") {
 			http.NotFound(w, r)
 			return
@@ -299,25 +245,10 @@ func TestGmailAutoForwardUpdateCmd_PlainReceipt(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer srv.Close()
-
-	svc, err := gmail.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com"}
 	out := captureStdout(t, func() {
-		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
-		if uiErr != nil {
-			t.Fatalf("ui.New: %v", uiErr)
-		}
-		ctx := ui.WithUI(context.Background(), u)
+		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
 		if runErr := runKong(t, &GmailAutoForwardUpdateCmd{}, []string{
 			"--enable",
@@ -341,11 +272,8 @@ func TestGmailAutoForwardUpdateCmd_PlainReceipt(t *testing.T) {
 	}
 }
 
-func TestGmailAutoForwardUpdateCmd_PlainReceiptOmitsEmptyOptionalFields(t *testing.T) {
-	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestGmailAutoForwardUpdateCmd_PlainReceiptIncludesEmptyValues(t *testing.T) {
+	useGmailSettingsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/settings/autoForwarding") {
 			http.NotFound(w, r)
 			return
@@ -364,25 +292,10 @@ func TestGmailAutoForwardUpdateCmd_PlainReceiptOmitsEmptyOptionalFields(t *testi
 			http.NotFound(w, r)
 		}
 	}))
-	defer srv.Close()
-
-	svc, err := gmail.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com"}
 	out := captureStdout(t, func() {
-		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
-		if uiErr != nil {
-			t.Fatalf("ui.New: %v", uiErr)
-		}
-		ctx := ui.WithUI(context.Background(), u)
+		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
 		if runErr := runKong(t, &GmailAutoForwardUpdateCmd{}, []string{"--disable"}, ctx, flags); runErr != nil {
 			t.Fatalf("execute: %v", runErr)
@@ -391,17 +304,16 @@ func TestGmailAutoForwardUpdateCmd_PlainReceiptOmitsEmptyOptionalFields(t *testi
 
 	want := "" +
 		"SETTING\tFIELD\tVALUE\n" +
-		"auto_forwarding\tenabled\tfalse\n"
+		"auto_forwarding\tenabled\tfalse\n" +
+		"auto_forwarding\temail_address\t\n" +
+		"auto_forwarding\tdisposition\t\n"
 	if out != want {
-		t.Fatalf("plain auto-forward optional fields = %q, want %q", out, want)
+		t.Fatalf("plain auto-forward empty values = %q, want %q", out, want)
 	}
 }
 
 func TestGmailVacationUpdateCmd_PlainReceiptSanitizesFreeForm(t *testing.T) {
-	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	useGmailSettingsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/settings/vacation") {
 			http.NotFound(w, r)
 			return
@@ -427,25 +339,10 @@ func TestGmailVacationUpdateCmd_PlainReceiptSanitizesFreeForm(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer srv.Close()
-
-	svc, err := gmail.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com"}
 	out := captureStdout(t, func() {
-		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
-		if uiErr != nil {
-			t.Fatalf("ui.New: %v", uiErr)
-		}
-		ctx := ui.WithUI(context.Background(), u)
+		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
 		if runErr := runKong(t, &GmailVacationUpdateCmd{}, []string{
 			"--enable",
@@ -480,11 +377,8 @@ func TestGmailVacationUpdateCmd_PlainReceiptSanitizesFreeForm(t *testing.T) {
 	}
 }
 
-func TestGmailVacationUpdateCmd_PlainReceiptOmitsZeroTimes(t *testing.T) {
-	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestGmailVacationUpdateCmd_PlainReceiptIncludesZeroTimes(t *testing.T) {
+	useGmailSettingsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/settings/vacation") {
 			http.NotFound(w, r)
 			return
@@ -508,51 +402,33 @@ func TestGmailVacationUpdateCmd_PlainReceiptOmitsZeroTimes(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer srv.Close()
-
-	svc, err := gmail.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com"}
 	out := captureStdout(t, func() {
-		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
-		if uiErr != nil {
-			t.Fatalf("ui.New: %v", uiErr)
-		}
-		ctx := ui.WithUI(context.Background(), u)
+		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
 		if runErr := runKong(t, &GmailVacationUpdateCmd{}, []string{"--disable"}, ctx, flags); runErr != nil {
 			t.Fatalf("execute: %v", runErr)
 		}
 	})
 
-	// Empty free-form fields are still emitted (server response fields);
-	// optional start/end times are omitted when zero.
 	want := "" +
 		"SETTING\tFIELD\tVALUE\n" +
 		"vacation\tenable_auto_reply\tfalse\n" +
 		"vacation\tresponse_subject\t\n" +
 		"vacation\tresponse_body_html\t\n" +
 		"vacation\tresponse_body_plain_text\t\n" +
+		"vacation\tstart_time\t0\n" +
+		"vacation\tend_time\t0\n" +
 		"vacation\trestrict_to_contacts\tfalse\n" +
 		"vacation\trestrict_to_domain\tfalse\n"
 	if out != want {
-		t.Fatalf("plain vacation optional times = %q, want %q", out, want)
+		t.Fatalf("plain vacation zero times = %q, want %q", out, want)
 	}
 }
 
 func TestGmailImapUpdateCmd_JSONUnchanged(t *testing.T) {
-	origNew := newGmailService
-	t.Cleanup(func() { newGmailService = origNew })
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	useGmailSettingsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/settings/imap") {
 			http.NotFound(w, r)
 			return
@@ -567,25 +443,10 @@ func TestGmailImapUpdateCmd_JSONUnchanged(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer srv.Close()
-
-	svc, err := gmail.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com"}
 	out := captureStdout(t, func() {
-		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
-		if uiErr != nil {
-			t.Fatalf("ui.New: %v", uiErr)
-		}
-		ctx := ui.WithUI(context.Background(), u)
+		ctx := ui.WithUI(context.Background(), mustUI(t))
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
 		if runErr := runKong(t, &GmailImapUpdateCmd{}, []string{"--enable"}, ctx, flags); runErr != nil {
 			t.Fatalf("execute: %v", runErr)

--- a/internal/cmd/gmail_settings_plain_test.go
+++ b/internal/cmd/gmail_settings_plain_test.go
@@ -1,0 +1,612 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// Public CLI seam: Gmail settings update commands under --plain emit a fixed
+// multi-row TSV receipt (SETTING/FIELD/VALUE) with no prose on stdout.
+
+func TestGmailImapUpdateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/imap") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled":         false,
+				"autoExpunge":     false,
+				"expungeBehavior": "archive",
+				"maxFolderSize":   1000,
+			})
+		case http.MethodPut:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled":         true,
+				"autoExpunge":     true,
+				"expungeBehavior": "trash",
+				"maxFolderSize":   2000,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailImapUpdateCmd{}, []string{
+			"--enable",
+			"--auto-expunge",
+			"--expunge-behavior", "trash",
+			"--max-folder-size", "2000",
+		}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	want := "" +
+		"SETTING\tFIELD\tVALUE\n" +
+		"imap\tenabled\ttrue\n" +
+		"imap\tauto_expunge\ttrue\n" +
+		"imap\texpunge_behavior\ttrash\n" +
+		"imap\tmax_folder_size\t2000\n"
+	if out != want {
+		t.Fatalf("plain imap update output = %q, want %q", out, want)
+	}
+	if strings.Contains(strings.ToLower(out), "updated successfully") {
+		t.Fatalf("plain stdout must not include prose, got %q", out)
+	}
+}
+
+func TestGmailImapUpdateCmd_PlainReceiptOmitsEmptyOptionalFields(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/imap") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled":     true,
+				"autoExpunge": true,
+			})
+		case http.MethodPut:
+			// Optional fields absent/zero in server response.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled":     false,
+				"autoExpunge": false,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailImapUpdateCmd{}, []string{"--disable", "--no-auto-expunge"}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	want := "" +
+		"SETTING\tFIELD\tVALUE\n" +
+		"imap\tenabled\tfalse\n" +
+		"imap\tauto_expunge\tfalse\n"
+	if out != want {
+		t.Fatalf("plain imap update optional fields = %q, want %q", out, want)
+	}
+}
+
+func TestGmailPopUpdateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/pop") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"accessWindow": "disabled",
+				"disposition":  "leaveInInbox",
+			})
+		case http.MethodPut:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"accessWindow": "allMail",
+				"disposition":  "archive",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailPopUpdateCmd{}, []string{
+			"--access-window", "allMail",
+			"--disposition", "archive",
+		}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	want := "" +
+		"SETTING\tFIELD\tVALUE\n" +
+		"pop\taccess_window\tallMail\n" +
+		"pop\tdisposition\tarchive\n"
+	if out != want {
+		t.Fatalf("plain pop update output = %q, want %q", out, want)
+	}
+	if strings.Contains(strings.ToLower(out), "updated successfully") {
+		t.Fatalf("plain stdout must not include prose, got %q", out)
+	}
+}
+
+func TestGmailLanguageUpdateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/language") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPut:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"displayLanguage": "ja",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailLanguageUpdateCmd{}, []string{"--display-language", "ja"}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	want := "" +
+		"SETTING\tFIELD\tVALUE\n" +
+		"language\tdisplay_language\tja\n"
+	if out != want {
+		t.Fatalf("plain language update output = %q, want %q", out, want)
+	}
+	if strings.Contains(strings.ToLower(out), "updated successfully") {
+		t.Fatalf("plain stdout must not include prose, got %q", out)
+	}
+}
+
+func TestGmailAutoForwardUpdateCmd_PlainReceipt(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/autoForwarding") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled":      false,
+				"emailAddress": "old@example.com",
+				"disposition":  "leaveInInbox",
+			})
+		case http.MethodPut:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled":      true,
+				"emailAddress": "new@example.com",
+				"disposition":  "archive",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailAutoForwardUpdateCmd{}, []string{
+			"--enable",
+			"--email", "new@example.com",
+			"--disposition", "archive",
+		}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	want := "" +
+		"SETTING\tFIELD\tVALUE\n" +
+		"auto_forwarding\tenabled\ttrue\n" +
+		"auto_forwarding\temail_address\tnew@example.com\n" +
+		"auto_forwarding\tdisposition\tarchive\n"
+	if out != want {
+		t.Fatalf("plain auto-forward update output = %q, want %q", out, want)
+	}
+	if strings.Contains(strings.ToLower(out), "updated successfully") {
+		t.Fatalf("plain stdout must not include prose, got %q", out)
+	}
+}
+
+func TestGmailAutoForwardUpdateCmd_PlainReceiptOmitsEmptyOptionalFields(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/autoForwarding") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled": true,
+			})
+		case http.MethodPut:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled": false,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailAutoForwardUpdateCmd{}, []string{"--disable"}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	want := "" +
+		"SETTING\tFIELD\tVALUE\n" +
+		"auto_forwarding\tenabled\tfalse\n"
+	if out != want {
+		t.Fatalf("plain auto-forward optional fields = %q, want %q", out, want)
+	}
+}
+
+func TestGmailVacationUpdateCmd_PlainReceiptSanitizesFreeForm(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/vacation") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enableAutoReply": false,
+			})
+		case http.MethodPut:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enableAutoReply":       true,
+				"responseSubject":       "Out\tof\toffice\nnow",
+				"responseBodyHtml":      "<p>Back\r\nsoon</p>",
+				"responseBodyPlainText": "Back\rsoon",
+				"startTime":             "1704067200000",
+				"endTime":               "1704153600000",
+				"restrictToContacts":    true,
+				"restrictToDomain":      false,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailVacationUpdateCmd{}, []string{
+			"--enable",
+			"--subject", "ignored",
+			"--body", "<b>ignored</b>",
+			"--start", "2024-01-01T00:00:00Z",
+			"--end", "2024-01-02T00:00:00Z",
+			"--contacts-only",
+		}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	want := "" +
+		"SETTING\tFIELD\tVALUE\n" +
+		"vacation\tenable_auto_reply\ttrue\n" +
+		"vacation\tresponse_subject\tOut of office now\n" +
+		"vacation\tresponse_body_html\t<p>Back soon</p>\n" +
+		"vacation\tresponse_body_plain_text\tBack soon\n" +
+		"vacation\tstart_time\t1704067200000\n" +
+		"vacation\tend_time\t1704153600000\n" +
+		"vacation\trestrict_to_contacts\ttrue\n" +
+		"vacation\trestrict_to_domain\tfalse\n"
+	if out != want {
+		t.Fatalf("plain vacation update output = %q, want %q", out, want)
+	}
+	if strings.Contains(strings.ToLower(out), "updated successfully") {
+		t.Fatalf("plain stdout must not include prose, got %q", out)
+	}
+	if strings.Contains(out, "\tOut\tof") || strings.Contains(out, "Back\nsoon") {
+		t.Fatalf("free-form fields must be sanitized for TSV, got %q", out)
+	}
+}
+
+func TestGmailVacationUpdateCmd_PlainReceiptOmitsZeroTimes(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/vacation") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enableAutoReply": true,
+			})
+		case http.MethodPut:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enableAutoReply":       false,
+				"responseSubject":       "",
+				"responseBodyHtml":      "",
+				"responseBodyPlainText": "",
+				"restrictToContacts":    false,
+				"restrictToDomain":      false,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+		if runErr := runKong(t, &GmailVacationUpdateCmd{}, []string{"--disable"}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	// Empty free-form fields are still emitted (server response fields);
+	// optional start/end times are omitted when zero.
+	want := "" +
+		"SETTING\tFIELD\tVALUE\n" +
+		"vacation\tenable_auto_reply\tfalse\n" +
+		"vacation\tresponse_subject\t\n" +
+		"vacation\tresponse_body_html\t\n" +
+		"vacation\tresponse_body_plain_text\t\n" +
+		"vacation\trestrict_to_contacts\tfalse\n" +
+		"vacation\trestrict_to_domain\tfalse\n"
+	if out != want {
+		t.Fatalf("plain vacation optional times = %q, want %q", out, want)
+	}
+}
+
+func TestGmailImapUpdateCmd_JSONUnchanged(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/settings/imap") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{"enabled": false, "autoExpunge": true})
+		case http.MethodPut:
+			_ = json.NewEncoder(w).Encode(map[string]any{"enabled": true, "autoExpunge": true, "expungeBehavior": "archive", "maxFolderSize": 1000})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+		if runErr := runKong(t, &GmailImapUpdateCmd{}, []string{"--enable"}, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+
+	var parsed struct {
+		Imap struct {
+			Enabled         bool   `json:"enabled"`
+			AutoExpunge     bool   `json:"autoExpunge"`
+			ExpungeBehavior string `json:"expungeBehavior"`
+			MaxFolderSize   int64  `json:"maxFolderSize"`
+		} `json:"imap"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if !parsed.Imap.Enabled || !parsed.Imap.AutoExpunge || parsed.Imap.ExpungeBehavior != "archive" || parsed.Imap.MaxFolderSize != 1000 {
+		t.Fatalf("unexpected json payload: %#v", parsed.Imap)
+	}
+	if strings.Contains(out, "SETTING") {
+		t.Fatalf("json mode must not emit TSV receipt, got %q", out)
+	}
+}

--- a/internal/cmd/gmail_vacation.go
+++ b/internal/cmd/gmail_vacation.go
@@ -197,21 +197,14 @@ func stripHTML(html string) string {
 }
 
 func writePlainVacationSetting(ctx context.Context, vacation *gmail.VacationSettings) {
-	fields := [][2]string{
+	writePlainSettingRows(ctx, "vacation", [][2]string{
 		{"enable_auto_reply", strconv.FormatBool(vacation.EnableAutoReply)},
 		{"response_subject", vacation.ResponseSubject},
 		{"response_body_html", vacation.ResponseBodyHtml},
 		{"response_body_plain_text", vacation.ResponseBodyPlainText},
-	}
-	if vacation.StartTime != 0 {
-		fields = append(fields, [2]string{"start_time", strconv.FormatInt(vacation.StartTime, 10)})
-	}
-	if vacation.EndTime != 0 {
-		fields = append(fields, [2]string{"end_time", strconv.FormatInt(vacation.EndTime, 10)})
-	}
-	fields = append(fields,
-		[2]string{"restrict_to_contacts", strconv.FormatBool(vacation.RestrictToContacts)},
-		[2]string{"restrict_to_domain", strconv.FormatBool(vacation.RestrictToDomain)},
-	)
-	writePlainSettingRows(ctx, "vacation", fields)
+		{"start_time", strconv.FormatInt(vacation.StartTime, 10)},
+		{"end_time", strconv.FormatInt(vacation.EndTime, 10)},
+		{"restrict_to_contacts", strconv.FormatBool(vacation.RestrictToContacts)},
+		{"restrict_to_domain", strconv.FormatBool(vacation.RestrictToDomain)},
+	})
 }

--- a/internal/cmd/gmail_vacation.go
+++ b/internal/cmd/gmail_vacation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -147,6 +148,11 @@ func (c *GmailVacationUpdateCmd) Run(ctx context.Context, kctx *kong.Context, fl
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"vacation": updated})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		writePlainVacationSetting(ctx, updated)
+		return nil
+	}
+
 	u.Out().Println("Vacation responder updated successfully")
 	u.Out().Printf("enable_auto_reply\t%t", updated.EnableAutoReply)
 	u.Out().Printf("response_subject\t%s", updated.ResponseSubject)
@@ -188,4 +194,24 @@ func stripHTML(html string) string {
 		}
 	}
 	return string(out)
+}
+
+func writePlainVacationSetting(ctx context.Context, vacation *gmail.VacationSettings) {
+	fields := [][2]string{
+		{"enable_auto_reply", strconv.FormatBool(vacation.EnableAutoReply)},
+		{"response_subject", vacation.ResponseSubject},
+		{"response_body_html", vacation.ResponseBodyHtml},
+		{"response_body_plain_text", vacation.ResponseBodyPlainText},
+	}
+	if vacation.StartTime != 0 {
+		fields = append(fields, [2]string{"start_time", strconv.FormatInt(vacation.StartTime, 10)})
+	}
+	if vacation.EndTime != 0 {
+		fields = append(fields, [2]string{"end_time", strconv.FormatInt(vacation.EndTime, 10)})
+	}
+	fields = append(fields,
+		[2]string{"restrict_to_contacts", strconv.FormatBool(vacation.RestrictToContacts)},
+		[2]string{"restrict_to_domain", strconv.FormatBool(vacation.RestrictToDomain)},
+	)
+	writePlainSettingRows(ctx, "vacation", fields)
 }

--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -69,6 +69,18 @@ func writePlainRoutingReceipt(ctx context.Context, resourceType, action, resourc
 	)
 }
 
+// writePlainSettingRows writes a multi-row SETTINGS receipt for Gmail account
+// setting mutations under --plain. Header is always SETTING/FIELD/VALUE; each
+// field is one data row. Values are sanitized for tab/newline safety.
+func writePlainSettingRows(ctx context.Context, setting string, fields [][2]string) {
+	w, flush := tableWriter(ctx)
+	defer flush()
+	writeTableRow(ctx, w, []string{"SETTING", "FIELD", "VALUE"})
+	for _, field := range fields {
+		writeTableRow(ctx, w, []string{setting, field[0], field[1]})
+	}
+}
+
 func printNextPageHint(u *ui.UI, nextPageToken string) {
 	printNextPageHintWithFlag(u, "--page", nextPageToken)
 }


### PR DESCRIPTION
Summary: emit deterministic SETTING/FIELD/VALUE plain receipts for Gmail IMAP, POP, language, auto-forwarding, and vacation updates from server responses; sanitize free-form values; preserve JSON and request semantics. Testing: focused Gmail settings receipt tests; full make ci with the required Go SDK PATH. Closes #76