### PR TITLE
fix(gtm): make tag detail plain output valid TSV

### DIFF
--- a/internal/cmd/tagmanager.go
+++ b/internal/cmd/tagmanager.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"google.golang.org/api/tagmanager/v2"
@@ -14,6 +16,8 @@ import (
 )
 
 var newTagManagerService = googleapi.NewTagManager
+
+const tagManagerParameterTypeList = "list"
 
 type TagManagerCmd struct {
 	Accounts         TagManagerAccountsCmd         `cmd:"" name:"accounts" group:"Read" help:"List GTM accounts"`
@@ -202,6 +206,9 @@ func (c *TagManagerTagCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"tag": tag})
 	}
+	if outfmt.IsPlain(ctx) {
+		return writeTagManagerTagPlain(ctx, tag)
+	}
 
 	u.Out().Printf("tagId\t%s", tag.TagId)
 	u.Out().Printf("name\t%s", tag.Name)
@@ -219,6 +226,77 @@ func (c *TagManagerTagCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 	}
 	return nil
+}
+
+// writeTagManagerTagPlain emits stable TSV for a single tag detail:
+// RECORD_TYPE<TAB>TAG_ID<TAB>KEY<TAB>TYPE<TAB>VALUE
+// with one row per metadata field, firing/blocking trigger, and parameter leaf.
+func writeTagManagerTagPlain(ctx context.Context, tag *tagmanager.Tag) error {
+	w, flush := tableWriter(ctx)
+	defer flush()
+	writeTableRow(ctx, w, []string{"RECORD_TYPE", "TAG_ID", "KEY", "TYPE", "VALUE"})
+	if tag == nil {
+		return nil
+	}
+	tagID := tag.TagId
+	writeTableRow(ctx, w, []string{"METADATA", tagID, "name", "", tag.Name})
+	writeTableRow(ctx, w, []string{"METADATA", tagID, "type", "", tag.Type})
+	for _, id := range tag.FiringTriggerId {
+		writeTableRow(ctx, w, []string{"FIRING_TRIGGER", tagID, "", "", id})
+	}
+	for _, id := range tag.BlockingTriggerId {
+		writeTableRow(ctx, w, []string{"BLOCKING_TRIGGER", tagID, "", "", id})
+	}
+	for _, p := range tag.Parameter {
+		writeTagManagerParameterLeaves(ctx, w, tagID, "", p, false)
+	}
+	return nil
+}
+
+func tagManagerParamPath(prefix, segment string) string {
+	if segment == "" {
+		return prefix
+	}
+	if prefix == "" {
+		return segment
+	}
+	return prefix + "." + segment
+}
+
+// writeTagManagerParameterLeaves flattens nested GTM parameters into leaf rows.
+// List indexes and map keys form deterministic path-like keys (e.g. list.0.mapKey).
+// ignoreKey is set for list children because GTM ignores keys on list values.
+func writeTagManagerParameterLeaves(ctx context.Context, w io.Writer, tagID, prefix string, p *tagmanager.Parameter, ignoreKey bool) {
+	if p == nil {
+		return
+	}
+	segment := p.Key
+	if ignoreKey {
+		segment = ""
+	}
+	path := tagManagerParamPath(prefix, segment)
+	paramType := strings.ToLower(p.Type)
+	switch {
+	case len(p.List) > 0 || paramType == tagManagerParameterTypeList:
+		if len(p.List) == 0 {
+			writeTableRow(ctx, w, []string{"PARAMETER", tagID, path, p.Type, p.Value})
+			return
+		}
+		for i, child := range p.List {
+			childPrefix := tagManagerParamPath(path, strconv.Itoa(i))
+			writeTagManagerParameterLeaves(ctx, w, tagID, childPrefix, child, true)
+		}
+	case len(p.Map) > 0 || paramType == "map":
+		if len(p.Map) == 0 {
+			writeTableRow(ctx, w, []string{"PARAMETER", tagID, path, p.Type, p.Value})
+			return
+		}
+		for _, child := range p.Map {
+			writeTagManagerParameterLeaves(ctx, w, tagID, path, child, false)
+		}
+	default:
+		writeTableRow(ctx, w, []string{"PARAMETER", tagID, path, p.Type, p.Value})
+	}
 }
 
 // --- triggers ---

--- a/internal/cmd/tagmanager.go
+++ b/internal/cmd/tagmanager.go
@@ -272,8 +272,9 @@ func tagManagerParamListPath(prefix string, index int) string {
 }
 
 // writeTagManagerParameterLeaves flattens nested GTM parameters into leaf rows.
-// List indexes and escaped map keys form unambiguous paths (e.g. list[0].mapKey).
-// ignoreKey is set for list children because GTM ignores keys on list values.
+// Map keys are dot-separated with backslash-escaped `\\.[]`; list indexes use
+// brackets, producing unambiguous paths such as list[0].mapKey. ignoreKey is set
+// for list children because GTM ignores keys on list values.
 func writeTagManagerParameterLeaves(ctx context.Context, w io.Writer, tagID, prefix string, p *tagmanager.Parameter, ignoreKey bool) {
 	if p == nil {
 		return

--- a/internal/cmd/tagmanager.go
+++ b/internal/cmd/tagmanager.go
@@ -257,14 +257,22 @@ func tagManagerParamPath(prefix, segment string) string {
 	if segment == "" {
 		return prefix
 	}
+	segment = strings.ReplaceAll(segment, `\`, `\\`)
+	segment = strings.ReplaceAll(segment, ".", `\.`)
+	segment = strings.ReplaceAll(segment, "[", `\[`)
+	segment = strings.ReplaceAll(segment, "]", `\]`)
 	if prefix == "" {
 		return segment
 	}
 	return prefix + "." + segment
 }
 
+func tagManagerParamListPath(prefix string, index int) string {
+	return prefix + "[" + strconv.Itoa(index) + "]"
+}
+
 // writeTagManagerParameterLeaves flattens nested GTM parameters into leaf rows.
-// List indexes and map keys form deterministic path-like keys (e.g. list.0.mapKey).
+// List indexes and escaped map keys form unambiguous paths (e.g. list[0].mapKey).
 // ignoreKey is set for list children because GTM ignores keys on list values.
 func writeTagManagerParameterLeaves(ctx context.Context, w io.Writer, tagID, prefix string, p *tagmanager.Parameter, ignoreKey bool) {
 	if p == nil {
@@ -283,7 +291,7 @@ func writeTagManagerParameterLeaves(ctx context.Context, w io.Writer, tagID, pre
 			return
 		}
 		for i, child := range p.List {
-			childPrefix := tagManagerParamPath(path, strconv.Itoa(i))
+			childPrefix := tagManagerParamListPath(path, i)
 			writeTagManagerParameterLeaves(ctx, w, tagID, childPrefix, child, true)
 		}
 	case len(p.Map) > 0 || paramType == "map":

--- a/internal/cmd/tagmanager_test.go
+++ b/internal/cmd/tagmanager_test.go
@@ -336,3 +336,122 @@ func TestExecute_TagManagerTag_JSON(t *testing.T) {
 		t.Fatalf("unexpected tag name: %q", parsed.Tag.Name)
 	}
 }
+
+func TestExecute_TagManagerTag_PlainTSV(t *testing.T) {
+	// Seam: public CLI plain output for `gtm tag --plain`.
+	// Schema: RECORD_TYPE\tTAG_ID\tKEY\tTYPE\tVALUE
+	origNew := newTagManagerService
+	t.Cleanup(func() { newTagManagerService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !(strings.Contains(r.URL.Path, "/tags/") && r.Method == http.MethodGet) {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tagId":             "t1",
+			"name":              "GA4\tConfig\nProd",
+			"type":              "gaawc",
+			"firingTriggerId":   []string{"tr1", "tr2"},
+			"blockingTriggerId": []string{"tr9"},
+			"parameter": []map[string]any{
+				{"key": "trackingId", "type": "template", "value": "G-XXXXX"},
+				{
+					"key":  "eventSettingsTable",
+					"type": "list",
+					"list": []map[string]any{
+						{
+							"type": "map",
+							"map": []map[string]any{
+								{"key": "parameter", "type": "template", "value": "page_path"},
+								{"key": "parameterValue", "type": "template", "value": "/home\tmain"},
+							},
+						},
+						{
+							"type": "map",
+							"map": []map[string]any{
+								{"key": "parameter", "type": "template", "value": "page_title"},
+								{"key": "parameterValue", "type": "template", "value": "Home"},
+							},
+						},
+					},
+				},
+				{
+					"key":  "fieldsToSet",
+					"type": "map",
+					"map": []map[string]any{
+						{"key": "user_id", "type": "template", "value": "{{User ID}}"},
+					},
+				},
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := tagmanager.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTagManagerService = func(context.Context, string) (*tagmanager.Service, error) { return svc, nil }
+
+	want := strings.Join([]string{
+		"RECORD_TYPE\tTAG_ID\tKEY\tTYPE\tVALUE",
+		"METADATA\tt1\tname\t\tGA4 Config Prod",
+		"METADATA\tt1\ttype\t\tgaawc",
+		"FIRING_TRIGGER\tt1\t\t\ttr1",
+		"FIRING_TRIGGER\tt1\t\t\ttr2",
+		"BLOCKING_TRIGGER\tt1\t\t\ttr9",
+		"PARAMETER\tt1\ttrackingId\ttemplate\tG-XXXXX",
+		"PARAMETER\tt1\teventSettingsTable.0.parameter\ttemplate\tpage_path",
+		"PARAMETER\tt1\teventSettingsTable.0.parameterValue\ttemplate\t/home main",
+		"PARAMETER\tt1\teventSettingsTable.1.parameter\ttemplate\tpage_title",
+		"PARAMETER\tt1\teventSettingsTable.1.parameterValue\ttemplate\tHome",
+		"PARAMETER\tt1\tfieldsToSet.user_id\ttemplate\t{{User ID}}",
+		"",
+	}, "\n")
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com", "gtm", "tag",
+				"accounts/111/containers/c1/workspaces/0/tags/t1",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	if out != want {
+		t.Fatalf("plain tag detail =\n%q\nwant\n%q", out, want)
+	}
+}
+
+func TestExecute_TagManagerTag_PlainNoDecorativeCounts(t *testing.T) {
+	setupTagManagerTest(t)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com", "gtm", "tag",
+				"accounts/111/containers/c1/workspaces/0/tags/t1",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	if strings.Contains(out, "parameters\t(") || strings.Contains(out, " parameters)") {
+		t.Fatalf("decorative parameter count present in plain output: %q", out)
+	}
+	if !strings.HasPrefix(out, "RECORD_TYPE\tTAG_ID\tKEY\tTYPE\tVALUE\n") {
+		t.Fatalf("missing TSV header, got %q", out)
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(out, "\n"), "\n") {
+		if strings.HasPrefix(line, " ") {
+			t.Fatalf("indented plain row: %q", line)
+		}
+	}
+}

--- a/internal/cmd/tagmanager_test.go
+++ b/internal/cmd/tagmanager_test.go
@@ -422,6 +422,22 @@ func TestExecute_TagManagerTag_PlainTSV(t *testing.T) {
 	}
 }
 
+func TestTagManagerParamPathsAreUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	literalDottedKey := tagManagerParamPath("", "a.b")
+	nestedKeys := tagManagerParamPath(tagManagerParamPath("", "a"), "b")
+	if literalDottedKey == nestedKeys {
+		t.Fatalf("literal dotted key %q collides with nested path %q", literalDottedKey, nestedKeys)
+	}
+
+	numericMapKey := tagManagerParamPath("items", "0")
+	listIndex := tagManagerParamListPath("items", 0)
+	if numericMapKey == listIndex {
+		t.Fatalf("numeric map key %q collides with list index %q", numericMapKey, listIndex)
+	}
+}
+
 func TestExecute_TagManagerTag_PlainNoDecorativeCounts(t *testing.T) {
 	setupTagManagerTest(t)
 

--- a/internal/cmd/tagmanager_test.go
+++ b/internal/cmd/tagmanager_test.go
@@ -94,10 +94,13 @@ func newTestTagManagerServer(t *testing.T) *httptest.Server {
 
 func setupTagManagerTest(t *testing.T) {
 	t.Helper()
+	setupTagManagerTestServer(t, newTestTagManagerServer(t))
+}
+
+func setupTagManagerTestServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
 	origNew := newTagManagerService
 	t.Cleanup(func() { newTagManagerService = origNew })
-
-	srv := newTestTagManagerServer(t)
 	t.Cleanup(srv.Close)
 
 	svc, err := tagmanager.NewService(context.Background(),
@@ -340,9 +343,6 @@ func TestExecute_TagManagerTag_JSON(t *testing.T) {
 func TestExecute_TagManagerTag_PlainTSV(t *testing.T) {
 	// Seam: public CLI plain output for `gtm tag --plain`.
 	// Schema: RECORD_TYPE\tTAG_ID\tKEY\tTYPE\tVALUE
-	origNew := newTagManagerService
-	t.Cleanup(func() { newTagManagerService = origNew })
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if !(strings.Contains(r.URL.Path, "/tags/") && r.Method == http.MethodGet) {
@@ -357,6 +357,7 @@ func TestExecute_TagManagerTag_PlainTSV(t *testing.T) {
 			"blockingTriggerId": []string{"tr9"},
 			"parameter": []map[string]any{
 				{"key": "trackingId", "type": "template", "value": "G-XXXXX"},
+				{"key": "eventSettingsTable.0.parameter", "type": "template", "value": "literal-key"},
 				{
 					"key":  "eventSettingsTable",
 					"type": "list",
@@ -387,17 +388,7 @@ func TestExecute_TagManagerTag_PlainTSV(t *testing.T) {
 			},
 		})
 	}))
-	t.Cleanup(srv.Close)
-
-	svc, err := tagmanager.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newTagManagerService = func(context.Context, string) (*tagmanager.Service, error) { return svc, nil }
+	setupTagManagerTestServer(t, srv)
 
 	want := strings.Join([]string{
 		"RECORD_TYPE\tTAG_ID\tKEY\tTYPE\tVALUE",
@@ -407,10 +398,11 @@ func TestExecute_TagManagerTag_PlainTSV(t *testing.T) {
 		"FIRING_TRIGGER\tt1\t\t\ttr2",
 		"BLOCKING_TRIGGER\tt1\t\t\ttr9",
 		"PARAMETER\tt1\ttrackingId\ttemplate\tG-XXXXX",
-		"PARAMETER\tt1\teventSettingsTable.0.parameter\ttemplate\tpage_path",
-		"PARAMETER\tt1\teventSettingsTable.0.parameterValue\ttemplate\t/home main",
-		"PARAMETER\tt1\teventSettingsTable.1.parameter\ttemplate\tpage_title",
-		"PARAMETER\tt1\teventSettingsTable.1.parameterValue\ttemplate\tHome",
+		"PARAMETER\tt1\teventSettingsTable\\.0\\.parameter\ttemplate\tliteral-key",
+		"PARAMETER\tt1\teventSettingsTable[0].parameter\ttemplate\tpage_path",
+		"PARAMETER\tt1\teventSettingsTable[0].parameterValue\ttemplate\t/home main",
+		"PARAMETER\tt1\teventSettingsTable[1].parameter\ttemplate\tpage_title",
+		"PARAMETER\tt1\teventSettingsTable[1].parameterValue\ttemplate\tHome",
 		"PARAMETER\tt1\tfieldsToSet.user_id\ttemplate\t{{User ID}}",
 		"",
 	}, "\n")


### PR DESCRIPTION
## Summary
- emit a fixed `RECORD_TYPE<TAB>TAG_ID<TAB>KEY<TAB>TYPE<TAB>VALUE` schema for `gtm tag --plain`
- emit one row per firing trigger, blocking trigger, and flattened parameter leaf
- preserve nested list/map hierarchy with escaped map keys and bracketed list indexes
- keep JSON, tag list, and mutation behavior unchanged

## Testing
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" go test ./internal/cmd -run 'TestExecute_TagManagerTag_(PlainTSV|PlainNoDecorativeCounts|JSON)$'`
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci`

## Review
- Standards/Fowler review: clean after consolidating duplicated test service setup
- Exact-spec review: clean after adding unambiguous parameter path encoding

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
