### PR TITLE
fix(auth): install service account keys atomically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/yosuke-furukawa/json5 v0.1.1
 	golang.org/x/net v0.49.0
 	golang.org/x/oauth2 v0.34.0
+	golang.org/x/sys v0.40.0
 	golang.org/x/term v0.39.0
 	google.golang.org/api v0.260.0
 )
@@ -41,7 +42,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260114163908-3f89685c29c3 // indirect
 	google.golang.org/grpc v1.78.0 // indirect

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -1063,10 +1063,7 @@ func (c *AuthKeepCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	if err := os.WriteFile(destPath, data, 0o600); err != nil {
-		return fmt.Errorf("write service account: %w", err)
-	}
-	if err := os.WriteFile(genericPath, data, 0o600); err != nil {
+	if err := writeServiceAccountFiles([]string{destPath, genericPath}, data); err != nil {
 		return fmt.Errorf("write service account: %w", err)
 	}
 

--- a/internal/cmd/auth_service_account.go
+++ b/internal/cmd/auth_service_account.go
@@ -65,6 +65,7 @@ type stagedServiceAccountFile struct {
 	backupPath     string
 	existed        bool
 	committed      bool
+	preserveTemp   bool
 	preserveBackup bool
 }
 
@@ -76,7 +77,9 @@ func writeServiceAccountFiles(paths []string, data []byte) error {
 	files := make([]stagedServiceAccountFile, 0, len(paths))
 	defer func() {
 		for _, file := range files {
-			_ = os.Remove(file.tmpPath)
+			if !file.preserveTemp {
+				_ = os.Remove(file.tmpPath)
+			}
 			if !file.preserveBackup {
 				_ = os.Remove(file.backupPath)
 			}
@@ -113,9 +116,22 @@ func writeServiceAccountFiles(paths []string, data []byte) error {
 		for i := len(files) - 1; i >= 0; i-- {
 			file := &files[i]
 			if file.backupPath != "" {
+				if file.committed {
+					if err := renameServiceAccountFile(file.path, file.tmpPath); err != nil {
+						file.preserveBackup = true
+						rollbackErr = errors.Join(rollbackErr, fmt.Errorf("stage failed install %s for rollback: %w", file.path, err))
+						continue
+					}
+				}
 				if err := renameServiceAccountFile(file.backupPath, file.path); err != nil {
 					file.preserveBackup = true
 					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore %s from %s: %w", file.path, file.backupPath, err))
+					if file.committed {
+						if restoreErr := renameServiceAccountFile(file.tmpPath, file.path); restoreErr != nil {
+							file.preserveTemp = true
+							rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore failed install %s: %w", file.path, restoreErr))
+						}
+					}
 					continue
 				}
 				file.backupPath = ""
@@ -135,6 +151,9 @@ func writeServiceAccountFiles(paths []string, data []byte) error {
 		file := &files[i]
 		if _, err := os.Stat(file.path); err == nil {
 			file.existed = true
+			if chmodErr := os.Chmod(file.path, 0o600); chmodErr != nil {
+				return errors.Join(chmodErr, rollback())
+			}
 			backup, createErr := os.CreateTemp(filepath.Dir(file.path), "."+filepath.Base(file.path)+".backup-*")
 			if createErr != nil {
 				return errors.Join(createErr, rollback())
@@ -161,7 +180,6 @@ func writeServiceAccountFiles(paths []string, data []byte) error {
 		if err := renameServiceAccountFile(file.tmpPath, file.path); err != nil {
 			return errors.Join(err, rollback())
 		}
-		file.tmpPath = ""
 		file.committed = true
 	}
 	return nil

--- a/internal/cmd/auth_service_account.go
+++ b/internal/cmd/auth_service_account.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/steipete/gogcli/internal/config"
@@ -23,6 +24,20 @@ type serviceAccountJSONInfo struct {
 	ClientID    string
 }
 
+type serviceAccountTempFile interface {
+	Write([]byte) (int, error)
+	Chmod(os.FileMode) error
+	Close() error
+	Name() string
+}
+
+var (
+	createServiceAccountTempFile = func(dir, pattern string) (serviceAccountTempFile, error) {
+		return os.CreateTemp(dir, pattern)
+	}
+	renameServiceAccountFile = os.Rename
+)
+
 func parseServiceAccountJSON(data []byte) (serviceAccountJSONInfo, error) {
 	var saJSON map[string]any
 	if err := json.Unmarshal(data, &saJSON); err != nil {
@@ -40,6 +55,104 @@ func parseServiceAccountJSON(data []byte) (serviceAccountJSONInfo, error) {
 		info.ClientID = strings.TrimSpace(v)
 	}
 	return info, nil
+}
+
+type stagedServiceAccountFile struct {
+	path       string
+	tmpPath    string
+	backupPath string
+	existed    bool
+	committed  bool
+}
+
+func writeServiceAccountFile(path string, data []byte) error {
+	return writeServiceAccountFiles([]string{path}, data)
+}
+
+func writeServiceAccountFiles(paths []string, data []byte) error {
+	files := make([]stagedServiceAccountFile, 0, len(paths))
+	defer func() {
+		for _, file := range files {
+			_ = os.Remove(file.tmpPath)
+			_ = os.Remove(file.backupPath)
+		}
+	}()
+
+	for _, path := range paths {
+		tmp, err := createServiceAccountTempFile(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+		if err != nil {
+			return err
+		}
+		file := stagedServiceAccountFile{path: path, tmpPath: tmp.Name()}
+		files = append(files, file)
+		if _, err := tmp.Write(data); err != nil {
+			_ = tmp.Close()
+			return err
+		}
+		if err := tmp.Chmod(0o600); err != nil {
+			_ = tmp.Close()
+			return err
+		}
+		if err := tmp.Close(); err != nil {
+			return err
+		}
+	}
+
+	rollback := func() {
+		for i := len(files) - 1; i >= 0; i-- {
+			file := &files[i]
+			if file.committed {
+				_ = os.Remove(file.path)
+			}
+			if file.backupPath != "" {
+				_ = renameServiceAccountFile(file.backupPath, file.path)
+				file.backupPath = ""
+			} else if !file.existed {
+				_ = os.Remove(file.path)
+			}
+		}
+	}
+
+	for i := range files {
+		file := &files[i]
+		if _, err := os.Stat(file.path); err == nil {
+			file.existed = true
+			backup, createErr := os.CreateTemp(filepath.Dir(file.path), "."+filepath.Base(file.path)+".backup-*")
+			if createErr != nil {
+				rollback()
+				return createErr
+			}
+			backupPath := backup.Name()
+			if closeErr := backup.Close(); closeErr != nil {
+				_ = os.Remove(backupPath)
+				rollback()
+				return closeErr
+			}
+			if removeErr := os.Remove(backupPath); removeErr != nil {
+				rollback()
+				return removeErr
+			}
+			if renameErr := renameServiceAccountFile(file.path, backupPath); renameErr != nil {
+				rollback()
+				return renameErr
+			}
+			file.backupPath = backupPath
+		} else if !os.IsNotExist(err) {
+			rollback()
+			return err
+		}
+	}
+
+	for i := range files {
+		file := &files[i]
+		if err := renameServiceAccountFile(file.tmpPath, file.path); err != nil {
+			rollback()
+			return err
+		}
+		file.tmpPath = ""
+		file.committed = true
+	}
+	return nil
 }
 
 func storeServiceAccountKey(impersonateEmail string, keyPath string) (string, serviceAccountJSONInfo, error) {
@@ -71,7 +184,7 @@ func storeServiceAccountKey(impersonateEmail string, keyPath string) (string, se
 		return "", serviceAccountJSONInfo{}, err
 	}
 
-	if err := os.WriteFile(destPath, data, 0o600); err != nil {
+	if err := writeServiceAccountFile(destPath, data); err != nil {
 		return "", serviceAccountJSONInfo{}, fmt.Errorf("write service account: %w", err)
 	}
 

--- a/internal/cmd/auth_service_account.go
+++ b/internal/cmd/auth_service_account.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,11 +60,12 @@ func parseServiceAccountJSON(data []byte) (serviceAccountJSONInfo, error) {
 }
 
 type stagedServiceAccountFile struct {
-	path       string
-	tmpPath    string
-	backupPath string
-	existed    bool
-	committed  bool
+	path           string
+	tmpPath        string
+	backupPath     string
+	existed        bool
+	committed      bool
+	preserveBackup bool
 }
 
 func writeServiceAccountFile(path string, data []byte) error {
@@ -74,7 +77,9 @@ func writeServiceAccountFiles(paths []string, data []byte) error {
 	defer func() {
 		for _, file := range files {
 			_ = os.Remove(file.tmpPath)
-			_ = os.Remove(file.backupPath)
+			if !file.preserveBackup {
+				_ = os.Remove(file.backupPath)
+			}
 		}
 	}()
 
@@ -85,9 +90,14 @@ func writeServiceAccountFiles(paths []string, data []byte) error {
 		}
 		file := stagedServiceAccountFile{path: path, tmpPath: tmp.Name()}
 		files = append(files, file)
-		if _, err := tmp.Write(data); err != nil {
+		n, err := tmp.Write(data)
+		if err != nil {
 			_ = tmp.Close()
 			return err
+		}
+		if n != len(data) {
+			_ = tmp.Close()
+			return io.ErrShortWrite
 		}
 		if err := tmp.Chmod(0o600); err != nil {
 			_ = tmp.Close()
@@ -98,19 +108,27 @@ func writeServiceAccountFiles(paths []string, data []byte) error {
 		}
 	}
 
-	rollback := func() {
+	rollback := func() error {
+		var rollbackErr error
 		for i := len(files) - 1; i >= 0; i-- {
 			file := &files[i]
-			if file.committed {
-				_ = os.Remove(file.path)
-			}
 			if file.backupPath != "" {
-				_ = renameServiceAccountFile(file.backupPath, file.path)
+				if err := renameServiceAccountFile(file.backupPath, file.path); err != nil {
+					file.preserveBackup = true
+					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore %s from %s: %w", file.path, file.backupPath, err))
+					continue
+				}
 				file.backupPath = ""
-			} else if !file.existed {
-				_ = os.Remove(file.path)
+				file.committed = false
+				continue
+			}
+			if file.committed && !file.existed {
+				if err := os.Remove(file.path); err != nil && !os.IsNotExist(err) {
+					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("remove newly installed %s: %w", file.path, err))
+				}
 			}
 		}
+		return rollbackErr
 	}
 
 	for i := range files {
@@ -119,35 +137,29 @@ func writeServiceAccountFiles(paths []string, data []byte) error {
 			file.existed = true
 			backup, createErr := os.CreateTemp(filepath.Dir(file.path), "."+filepath.Base(file.path)+".backup-*")
 			if createErr != nil {
-				rollback()
-				return createErr
+				return errors.Join(createErr, rollback())
 			}
 			backupPath := backup.Name()
 			if closeErr := backup.Close(); closeErr != nil {
 				_ = os.Remove(backupPath)
-				rollback()
-				return closeErr
+				return errors.Join(closeErr, rollback())
 			}
 			if removeErr := os.Remove(backupPath); removeErr != nil {
-				rollback()
-				return removeErr
+				return errors.Join(removeErr, rollback())
 			}
 			if renameErr := renameServiceAccountFile(file.path, backupPath); renameErr != nil {
-				rollback()
-				return renameErr
+				return errors.Join(renameErr, rollback())
 			}
 			file.backupPath = backupPath
 		} else if !os.IsNotExist(err) {
-			rollback()
-			return err
+			return errors.Join(err, rollback())
 		}
 	}
 
 	for i := range files {
 		file := &files[i]
 		if err := renameServiceAccountFile(file.tmpPath, file.path); err != nil {
-			rollback()
-			return err
+			return errors.Join(err, rollback())
 		}
 		file.tmpPath = ""
 		file.committed = true

--- a/internal/cmd/auth_service_account.go
+++ b/internal/cmd/auth_service_account.go
@@ -37,7 +37,8 @@ var (
 	createServiceAccountTempFile = func(dir, pattern string) (serviceAccountTempFile, error) {
 		return os.CreateTemp(dir, pattern)
 	}
-	renameServiceAccountFile = os.Rename
+	renameServiceAccountFile         = replaceServiceAccountFile
+	fallbackRenameServiceAccountFile = replaceServiceAccountFile
 )
 
 func parseServiceAccountJSON(data []byte) (serviceAccountJSONInfo, error) {
@@ -65,7 +66,6 @@ type stagedServiceAccountFile struct {
 	backupPath     string
 	existed        bool
 	committed      bool
-	preserveTemp   bool
 	preserveBackup bool
 }
 
@@ -73,13 +73,46 @@ func writeServiceAccountFile(path string, data []byte) error {
 	return writeServiceAccountFiles([]string{path}, data)
 }
 
+func stageServiceAccountFile(path, pattern string, data []byte) (string, error) {
+	tmp, err := createServiceAccountTempFile(filepath.Dir(path), pattern)
+	if err != nil {
+		return "", err
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}
+	if secureErr := secureServiceAccountFile(tmpPath); secureErr != nil {
+		cleanup()
+		return "", secureErr
+	}
+
+	n, err := tmp.Write(data)
+	if err != nil {
+		cleanup()
+		return "", err
+	}
+	if n != len(data) {
+		cleanup()
+		return "", io.ErrShortWrite
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		cleanup()
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	return tmpPath, nil
+}
+
 func writeServiceAccountFiles(paths []string, data []byte) error {
 	files := make([]stagedServiceAccountFile, 0, len(paths))
 	defer func() {
 		for _, file := range files {
-			if !file.preserveTemp {
-				_ = os.Remove(file.tmpPath)
-			}
+			_ = os.Remove(file.tmpPath)
 			if !file.preserveBackup {
 				_ = os.Remove(file.backupPath)
 			}
@@ -87,61 +120,75 @@ func writeServiceAccountFiles(paths []string, data []byte) error {
 	}()
 
 	for _, path := range paths {
-		tmp, err := createServiceAccountTempFile(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
-		if err != nil {
+		file := stagedServiceAccountFile{path: path}
+		info, err := os.Lstat(path)
+		switch {
+		case err == nil:
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("service account destination is not a regular file: %s", path)
+			}
+			prior, readErr := os.ReadFile(path) //nolint:gosec // stored credential path
+			if readErr != nil {
+				return readErr
+			}
+			file.existed = true
+			file.backupPath, err = stageServiceAccountFile(path, "."+filepath.Base(path)+".backup-*", prior)
+			if err != nil {
+				return err
+			}
+		case os.IsNotExist(err):
+		default:
 			return err
 		}
-		file := stagedServiceAccountFile{path: path, tmpPath: tmp.Name()}
+
+		file.tmpPath, err = stageServiceAccountFile(path, "."+filepath.Base(path)+".tmp-*", data)
+		if err != nil {
+			_ = os.Remove(file.backupPath)
+			return err
+		}
 		files = append(files, file)
-		n, err := tmp.Write(data)
-		if err != nil {
-			_ = tmp.Close()
-			return err
-		}
-		if n != len(data) {
-			_ = tmp.Close()
-			return io.ErrShortWrite
-		}
-		if err := tmp.Chmod(0o600); err != nil {
-			_ = tmp.Close()
-			return err
-		}
-		if err := tmp.Close(); err != nil {
-			return err
-		}
 	}
 
 	rollback := func() error {
 		var rollbackErr error
 		for i := len(files) - 1; i >= 0; i-- {
 			file := &files[i]
-			if file.backupPath != "" {
-				if file.committed {
-					if err := renameServiceAccountFile(file.path, file.tmpPath); err != nil {
+			if !file.committed {
+				continue
+			}
+			if file.existed {
+				if err := renameServiceAccountFile(file.backupPath, file.path); err == nil {
+					file.backupPath = ""
+					continue
+				} else {
+					prior, readErr := os.ReadFile(file.backupPath)
+					if readErr != nil {
 						file.preserveBackup = true
-						rollbackErr = errors.Join(rollbackErr, fmt.Errorf("stage failed install %s for rollback: %w", file.path, err))
+						rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore %s after initial rename failure; prior credential preserved at %s: %w", file.path, file.backupPath, errors.Join(err, readErr)))
 						continue
 					}
-				}
-				if err := renameServiceAccountFile(file.backupPath, file.path); err != nil {
-					file.preserveBackup = true
-					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore %s from %s: %w", file.path, file.backupPath, err))
-					if file.committed {
-						if restoreErr := renameServiceAccountFile(file.tmpPath, file.path); restoreErr != nil {
-							file.preserveTemp = true
-							rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore failed install %s: %w", file.path, restoreErr))
-						}
+					restorePath, stageErr := stageServiceAccountFile(file.path, "."+filepath.Base(file.path)+".restore-*", prior)
+					if stageErr != nil {
+						file.preserveBackup = true
+						rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore %s after initial rename failure; prior credential preserved at %s: %w", file.path, file.backupPath, errors.Join(err, stageErr)))
+						continue
+					}
+					restoreErr := renameServiceAccountFile(restorePath, file.path)
+					if restoreErr == nil {
+						continue
+					}
+					if directErr := fallbackRenameServiceAccountFile(restorePath, file.path); directErr == nil {
+						continue
+					} else {
+						_ = os.Remove(restorePath)
+						file.preserveBackup = true
+						rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore %s after atomic replacements failed; prior credential preserved at %s: %w", file.path, file.backupPath, errors.Join(err, restoreErr, directErr)))
 					}
 					continue
 				}
-				file.backupPath = ""
-				file.committed = false
-				continue
 			}
-			if file.committed && !file.existed {
-				if err := os.Remove(file.path); err != nil && !os.IsNotExist(err) {
-					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("remove newly installed %s: %w", file.path, err))
-				}
+			if err := os.Remove(file.path); err != nil && !os.IsNotExist(err) {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("remove newly installed %s: %w", file.path, err))
 			}
 		}
 		return rollbackErr
@@ -149,37 +196,10 @@ func writeServiceAccountFiles(paths []string, data []byte) error {
 
 	for i := range files {
 		file := &files[i]
-		if _, err := os.Stat(file.path); err == nil {
-			file.existed = true
-			if chmodErr := os.Chmod(file.path, 0o600); chmodErr != nil {
-				return errors.Join(chmodErr, rollback())
-			}
-			backup, createErr := os.CreateTemp(filepath.Dir(file.path), "."+filepath.Base(file.path)+".backup-*")
-			if createErr != nil {
-				return errors.Join(createErr, rollback())
-			}
-			backupPath := backup.Name()
-			if closeErr := backup.Close(); closeErr != nil {
-				_ = os.Remove(backupPath)
-				return errors.Join(closeErr, rollback())
-			}
-			if removeErr := os.Remove(backupPath); removeErr != nil {
-				return errors.Join(removeErr, rollback())
-			}
-			if renameErr := renameServiceAccountFile(file.path, backupPath); renameErr != nil {
-				return errors.Join(renameErr, rollback())
-			}
-			file.backupPath = backupPath
-		} else if !os.IsNotExist(err) {
-			return errors.Join(err, rollback())
-		}
-	}
-
-	for i := range files {
-		file := &files[i]
 		if err := renameServiceAccountFile(file.tmpPath, file.path); err != nil {
 			return errors.Join(err, rollback())
 		}
+		file.tmpPath = ""
 		file.committed = true
 	}
 	return nil

--- a/internal/cmd/auth_service_account_atomic_test.go
+++ b/internal/cmd/auth_service_account_atomic_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steipete/gogcli/internal/config"
@@ -15,11 +16,15 @@ type failingServiceAccountTempFile struct {
 }
 
 func (f *failingServiceAccountTempFile) Write(p []byte) (int, error) {
-	if f.operation == "write" {
+	switch f.operation {
+	case "write":
 		n, _ := f.File.Write(p[:len(p)/2])
 		return n, errors.New("injected write failure")
+	case "short_write":
+		return f.File.Write(p[:len(p)/2])
+	default:
+		return f.File.Write(p)
 	}
-	return f.File.Write(p)
 }
 
 func (f *failingServiceAccountTempFile) Chmod(mode os.FileMode) error {
@@ -207,8 +212,78 @@ func TestAuthKeep_SecondReplacementFailureRestoresPriorPairAndRemovesTemporaryFi
 	}
 }
 
+func TestAuthKeep_RollbackFailureIsReportedAndPreservesBackup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	const email = "user@example.com"
+	oldKeep := []byte(`{"type":"service_account","client_email":"old-keep@example.com"}`)
+	oldGeneric := []byte(`{"type":"service_account","client_email":"old-generic@example.com"}`)
+	newData := []byte(`{"type":"service_account","client_email":"new@example.com"}`)
+	keyPath := filepath.Join(t.TempDir(), "service-account.json")
+	if err := os.WriteFile(keyPath, newData, 0o600); err != nil {
+		t.Fatalf("write source key: %v", err)
+	}
+	if _, err := config.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	keepPath, err := config.KeepServiceAccountPath(email)
+	if err != nil {
+		t.Fatalf("KeepServiceAccountPath: %v", err)
+	}
+	genericPath, err := config.ServiceAccountPath(email)
+	if err != nil {
+		t.Fatalf("ServiceAccountPath: %v", err)
+	}
+	if writeErr := os.WriteFile(keepPath, oldKeep, 0o600); writeErr != nil {
+		t.Fatalf("write prior Keep key: %v", writeErr)
+	}
+	if writeErr := os.WriteFile(genericPath, oldGeneric, 0o600); writeErr != nil {
+		t.Fatalf("write prior generic key: %v", writeErr)
+	}
+
+	originalRename := renameServiceAccountFile
+	t.Cleanup(func() { renameServiceAccountFile = originalRename })
+	replacements := 0
+	renameServiceAccountFile = func(oldPath, newPath string) error {
+		if strings.Contains(oldPath, ".backup-") && newPath == keepPath {
+			return errors.New("injected rollback failure")
+		}
+		if !strings.Contains(oldPath, ".backup-") && oldPath != keepPath && oldPath != genericPath {
+			replacements++
+			if replacements == 2 {
+				return errors.New("injected second replacement failure")
+			}
+		}
+		return os.Rename(oldPath, newPath)
+	}
+
+	err = Execute([]string{"auth", "keep", email, "--key", keyPath})
+	if err == nil || !strings.Contains(err.Error(), "restore") || !strings.Contains(err.Error(), "injected rollback failure") {
+		t.Fatalf("Execute error = %v, want replacement and rollback failure", err)
+	}
+	if _, statErr := os.Stat(keepPath); statErr != nil {
+		t.Fatalf("final Keep credential missing after rollback failure: %v", statErr)
+	}
+	backups, globErr := filepath.Glob(filepath.Join(filepath.Dir(keepPath), "."+filepath.Base(keepPath)+".backup-*"))
+	if globErr != nil {
+		t.Fatalf("glob backups: %v", globErr)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("recoverable backup count = %d, want 1: %v", len(backups), backups)
+	}
+	gotBackup, readErr := os.ReadFile(backups[0])
+	if readErr != nil {
+		t.Fatalf("read recoverable backup: %v", readErr)
+	}
+	if string(gotBackup) != string(oldKeep) {
+		t.Fatalf("backup = %q, want prior Keep key %q", gotBackup, oldKeep)
+	}
+}
+
 func TestAuthServiceAccountSet_FailuresPreservePriorKeyAndRemoveTemporaryFiles(t *testing.T) {
-	for _, operation := range []string{"write", "close", "permission", "replacement"} {
+	for _, operation := range []string{"write", "short_write", "close", "permission", "replacement"} {
 		t.Run(operation, func(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("HOME", home)

--- a/internal/cmd/auth_service_account_atomic_test.go
+++ b/internal/cmd/auth_service_account_atomic_test.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"errors"
-	"io/fs"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,7 +145,82 @@ func TestAuthKeep_InstallsMatchingPrivateCredentialFiles(t *testing.T) {
 	}
 }
 
-func TestAuthKeep_SecondReplacementFailureRestoresPriorPairAndRemovesTemporaryFiles(t *testing.T) {
+func TestAuthKeep_StagingFailuresPreservePriorPairAndRemoveTemporaryFiles(t *testing.T) {
+	for _, operation := range []string{"write", "short_write", "close", "permission"} {
+		for _, failingTemp := range []int{2, 4} {
+			t.Run(operation+"/temp-"+fmt.Sprint(failingTemp), func(t *testing.T) {
+				home := t.TempDir()
+				t.Setenv("HOME", home)
+				t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+				const email = "user@example.com"
+				oldKeep := []byte(`{"type":"service_account","client_email":"old-keep@example.com"}`)
+				oldGeneric := []byte(`{"type":"service_account","client_email":"old-generic@example.com"}`)
+				newData := []byte(`{"type":"service_account","client_email":"new@example.com"}`)
+				keyPath := filepath.Join(t.TempDir(), "service-account.json")
+				if err := os.WriteFile(keyPath, newData, 0o600); err != nil {
+					t.Fatalf("write source key: %v", err)
+				}
+				if _, err := config.EnsureDir(); err != nil {
+					t.Fatalf("EnsureDir: %v", err)
+				}
+				keepPath, err := config.KeepServiceAccountPath(email)
+				if err != nil {
+					t.Fatalf("KeepServiceAccountPath: %v", err)
+				}
+				genericPath, err := config.ServiceAccountPath(email)
+				if err != nil {
+					t.Fatalf("ServiceAccountPath: %v", err)
+				}
+				for path, prior := range map[string][]byte{keepPath: oldKeep, genericPath: oldGeneric} {
+					if writeErr := os.WriteFile(path, prior, 0o600); writeErr != nil {
+						t.Fatalf("write prior key %q: %v", path, writeErr)
+					}
+				}
+
+				originalCreateTemp := createServiceAccountTempFile
+				t.Cleanup(func() { createServiceAccountTempFile = originalCreateTemp })
+				created := 0
+				createServiceAccountTempFile = func(dir, pattern string) (serviceAccountTempFile, error) {
+					file, createErr := os.CreateTemp(dir, pattern)
+					if createErr != nil {
+						return nil, createErr
+					}
+					created++
+					if created == failingTemp {
+						return &failingServiceAccountTempFile{File: file, operation: operation}, nil
+					}
+					return file, nil
+				}
+
+				err = Execute([]string{"auth", "keep", email, "--key", keyPath})
+				if err == nil {
+					t.Fatal("Execute succeeded, want injected staging failure")
+				}
+				for path, want := range map[string][]byte{keepPath: oldKeep, genericPath: oldGeneric} {
+					got, readErr := os.ReadFile(path)
+					if readErr != nil {
+						t.Fatalf("read prior key %q: %v", path, readErr)
+					}
+					if string(got) != string(want) {
+						t.Fatalf("prior key %q = %q, want %q", path, got, want)
+					}
+				}
+				entries, readErr := os.ReadDir(filepath.Dir(keepPath))
+				if readErr != nil {
+					t.Fatalf("read credential directory: %v", readErr)
+				}
+				for _, entry := range entries {
+					if entry.Name() != filepath.Base(keepPath) && entry.Name() != filepath.Base(genericPath) {
+						t.Fatalf("temporary file remains after failure: %s", entry.Name())
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestAuthKeep_SecondReplacementFailureRestoresPriorPairWhenRollbackRenamesFail(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
@@ -177,15 +252,24 @@ func TestAuthKeep_SecondReplacementFailureRestoresPriorPairAndRemovesTemporaryFi
 	}
 
 	originalRename := renameServiceAccountFile
-	t.Cleanup(func() { renameServiceAccountFile = originalRename })
+	originalFallbackRename := fallbackRenameServiceAccountFile
+	t.Cleanup(func() {
+		renameServiceAccountFile = originalRename
+		fallbackRenameServiceAccountFile = originalFallbackRename
+	})
 	replacement := 0
+	rollbackRenameFailed := false
+	fallbackRenameFailed := false
 	renameServiceAccountFile = func(oldPath, newPath string) error {
-		if strings.Contains(oldPath, ".backup-") {
-			if _, statErr := os.Stat(newPath); statErr == nil {
-				return fs.ErrExist
-			}
+		if strings.Contains(oldPath, ".backup-") && newPath == keepPath && !rollbackRenameFailed {
+			rollbackRenameFailed = true
+			return errors.New("injected initial rollback replacement failure")
 		}
-		if oldPath != keepPath && oldPath != genericPath && !strings.Contains(oldPath, ".backup-") {
+		if strings.Contains(oldPath, ".restore-") && newPath == keepPath && !fallbackRenameFailed {
+			fallbackRenameFailed = true
+			return errors.New("injected fallback rollback replacement failure")
+		}
+		if !strings.Contains(oldPath, ".backup-") && !strings.Contains(oldPath, ".restore-") {
 			replacement++
 			if replacement == 2 {
 				return errors.New("injected second replacement failure")
@@ -197,6 +281,12 @@ func TestAuthKeep_SecondReplacementFailureRestoresPriorPairAndRemovesTemporaryFi
 	err = Execute([]string{"auth", "keep", email, "--key", keyPath})
 	if err == nil {
 		t.Fatal("Execute succeeded, want injected replacement failure")
+	}
+	if !rollbackRenameFailed {
+		t.Fatal("rollback backup rename was not attempted")
+	}
+	if !fallbackRenameFailed {
+		t.Fatal("fallback rollback rename was not attempted")
 	}
 	for path, want := range map[string][]byte{keepPath: oldKeep, genericPath: oldGeneric} {
 		got, readErr := os.ReadFile(path)
@@ -218,7 +308,7 @@ func TestAuthKeep_SecondReplacementFailureRestoresPriorPairAndRemovesTemporaryFi
 	}
 }
 
-func TestAuthKeep_RollbackFailureIsReportedAndPreservesBackup(t *testing.T) {
+func TestAuthKeep_UnrecoverableRollbackPreservesPrivateBackup(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
@@ -242,7 +332,7 @@ func TestAuthKeep_RollbackFailureIsReportedAndPreservesBackup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ServiceAccountPath: %v", err)
 	}
-	if writeErr := os.WriteFile(keepPath, oldKeep, 0o644); writeErr != nil {
+	if writeErr := os.WriteFile(keepPath, oldKeep, 0o600); writeErr != nil {
 		t.Fatalf("write prior Keep key: %v", writeErr)
 	}
 	if writeErr := os.WriteFile(genericPath, oldGeneric, 0o600); writeErr != nil {
@@ -250,13 +340,19 @@ func TestAuthKeep_RollbackFailureIsReportedAndPreservesBackup(t *testing.T) {
 	}
 
 	originalRename := renameServiceAccountFile
-	t.Cleanup(func() { renameServiceAccountFile = originalRename })
+	originalFallbackRename := fallbackRenameServiceAccountFile
+	t.Cleanup(func() {
+		renameServiceAccountFile = originalRename
+		fallbackRenameServiceAccountFile = originalFallbackRename
+	})
 	replacements := 0
 	renameServiceAccountFile = func(oldPath, newPath string) error {
-		if strings.Contains(oldPath, ".backup-") && newPath == keepPath {
-			return errors.New("injected rollback failure")
-		}
-		if !strings.Contains(oldPath, ".backup-") && oldPath != keepPath && oldPath != genericPath {
+		switch {
+		case strings.Contains(oldPath, ".backup-") && newPath == keepPath:
+			return errors.New("injected backup rollback failure")
+		case strings.Contains(oldPath, ".restore-") && newPath == keepPath:
+			return errors.New("injected staged rollback failure")
+		case !strings.Contains(oldPath, ".backup-") && !strings.Contains(oldPath, ".restore-"):
 			replacements++
 			if replacements == 2 {
 				return errors.New("injected second replacement failure")
@@ -264,34 +360,102 @@ func TestAuthKeep_RollbackFailureIsReportedAndPreservesBackup(t *testing.T) {
 		}
 		return os.Rename(oldPath, newPath)
 	}
+	fallbackRenameServiceAccountFile = func(_, _ string) error {
+		return errors.New("injected platform rollback failure")
+	}
 
 	err = Execute([]string{"auth", "keep", email, "--key", keyPath})
-	if err == nil || !strings.Contains(err.Error(), "restore") || !strings.Contains(err.Error(), "injected rollback failure") {
-		t.Fatalf("Execute error = %v, want replacement and rollback failure", err)
+	if err == nil || !strings.Contains(err.Error(), "prior credential preserved at") {
+		t.Fatalf("Execute error = %v, want recovery path", err)
 	}
-	if _, statErr := os.Stat(keepPath); statErr != nil {
-		t.Fatalf("final Keep credential missing after rollback failure: %v", statErr)
+	gotKeep, readErr := os.ReadFile(keepPath)
+	if readErr != nil {
+		t.Fatalf("read current Keep key: %v", readErr)
+	}
+	if string(gotKeep) != string(newData) {
+		t.Fatalf("current Keep key = %q, want intact new key %q", gotKeep, newData)
+	}
+	gotGeneric, readErr := os.ReadFile(genericPath)
+	if readErr != nil {
+		t.Fatalf("read generic key: %v", readErr)
+	}
+	if string(gotGeneric) != string(oldGeneric) {
+		t.Fatalf("generic key = %q, want prior key %q", gotGeneric, oldGeneric)
 	}
 	backups, globErr := filepath.Glob(filepath.Join(filepath.Dir(keepPath), "."+filepath.Base(keepPath)+".backup-*"))
 	if globErr != nil {
 		t.Fatalf("glob backups: %v", globErr)
 	}
-	if len(backups) != 1 {
-		t.Fatalf("recoverable backup count = %d, want 1: %v", len(backups), backups)
+	if len(backups) != 1 || !strings.Contains(err.Error(), backups[0]) {
+		t.Fatalf("recoverable backups = %v, error = %v", backups, err)
 	}
 	gotBackup, readErr := os.ReadFile(backups[0])
 	if readErr != nil {
-		t.Fatalf("read recoverable backup: %v", readErr)
+		t.Fatalf("read backup: %v", readErr)
 	}
 	if string(gotBackup) != string(oldKeep) {
-		t.Fatalf("backup = %q, want prior Keep key %q", gotBackup, oldKeep)
+		t.Fatalf("backup = %q, want prior key %q", gotBackup, oldKeep)
 	}
 	backupInfo, statErr := os.Stat(backups[0])
 	if statErr != nil {
-		t.Fatalf("stat recoverable backup: %v", statErr)
+		t.Fatalf("stat backup: %v", statErr)
 	}
 	if gotMode := backupInfo.Mode().Perm(); gotMode != 0o600 {
 		t.Fatalf("backup mode = %04o, want 0600", gotMode)
+	}
+}
+
+func TestAuthServiceAccountSet_RejectsNonRegularDestination(t *testing.T) {
+	for _, kind := range []string{"symlink", "directory"} {
+		t.Run(kind, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+			const email = "user@example.com"
+			newData := []byte(`{"type":"service_account","client_email":"new@example.com"}`)
+			keyPath := filepath.Join(t.TempDir(), "service-account.json")
+			if err := os.WriteFile(keyPath, newData, 0o600); err != nil {
+				t.Fatalf("write source key: %v", err)
+			}
+			if _, err := config.EnsureDir(); err != nil {
+				t.Fatalf("EnsureDir: %v", err)
+			}
+			destPath, err := config.ServiceAccountPath(email)
+			if err != nil {
+				t.Fatalf("ServiceAccountPath: %v", err)
+			}
+
+			switch kind {
+			case "symlink":
+				target := filepath.Join(t.TempDir(), "target.json")
+				if writeErr := os.WriteFile(target, []byte("target"), 0o644); writeErr != nil {
+					t.Fatalf("write symlink target: %v", writeErr)
+				}
+				if symlinkErr := os.Symlink(target, destPath); symlinkErr != nil {
+					t.Fatalf("create symlink: %v", symlinkErr)
+				}
+			case "directory":
+				if mkdirErr := os.Mkdir(destPath, 0o755); mkdirErr != nil {
+					t.Fatalf("create destination directory: %v", mkdirErr)
+				}
+			}
+
+			err = Execute([]string{"auth", "service-account", "set", email, "--key", keyPath})
+			if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+				t.Fatalf("Execute error = %v, want non-regular destination error", err)
+			}
+			info, statErr := os.Lstat(destPath)
+			if statErr != nil {
+				t.Fatalf("lstat destination: %v", statErr)
+			}
+			if kind == "symlink" && info.Mode()&os.ModeSymlink == 0 {
+				t.Fatalf("destination mode = %v, want symlink", info.Mode())
+			}
+			if kind == "directory" && !info.IsDir() {
+				t.Fatalf("destination mode = %v, want directory", info.Mode())
+			}
+		})
 	}
 }
 
@@ -327,16 +491,28 @@ func TestAuthServiceAccountSet_FailuresPreservePriorKeyAndRemoveTemporaryFiles(t
 				renameServiceAccountFile = originalRename
 			})
 			if operation == "replacement" {
-				renameServiceAccountFile = func(_, _ string) error {
+				renameServiceAccountFile = func(_, newPath string) error {
+					got, readErr := os.ReadFile(newPath)
+					if readErr != nil {
+						t.Fatalf("read live key during replacement: %v", readErr)
+					}
+					if string(got) != string(oldData) {
+						t.Fatalf("live key during replacement = %q, want prior key %q", got, oldData)
+					}
 					return errors.New("injected replacement failure")
 				}
 			} else {
+				created := 0
 				createServiceAccountTempFile = func(dir, pattern string) (serviceAccountTempFile, error) {
 					file, createErr := os.CreateTemp(dir, pattern)
 					if createErr != nil {
 						return nil, createErr
 					}
-					return &failingServiceAccountTempFile{File: file, operation: operation}, nil
+					created++
+					if created == 2 {
+						return &failingServiceAccountTempFile{File: file, operation: operation}, nil
+					}
+					return file, nil
 				}
 			}
 
@@ -351,12 +527,14 @@ func TestAuthServiceAccountSet_FailuresPreservePriorKeyAndRemoveTemporaryFiles(t
 			if string(got) != string(oldData) {
 				t.Fatalf("prior key = %q, want %q", got, oldData)
 			}
-			temps, globErr := filepath.Glob(filepath.Join(filepath.Dir(destPath), "."+filepath.Base(destPath)+".tmp-*"))
-			if globErr != nil {
-				t.Fatalf("glob temporary files: %v", globErr)
-			}
-			if len(temps) != 0 {
-				t.Fatalf("temporary files remain after failure: %v", temps)
+			for _, pattern := range []string{"." + filepath.Base(destPath) + ".tmp-*", "." + filepath.Base(destPath) + ".backup-*"} {
+				temps, globErr := filepath.Glob(filepath.Join(filepath.Dir(destPath), pattern))
+				if globErr != nil {
+					t.Fatalf("glob temporary files: %v", globErr)
+				}
+				if len(temps) != 0 {
+					t.Fatalf("temporary files remain after failure: %v", temps)
+				}
 			}
 		})
 	}

--- a/internal/cmd/auth_service_account_atomic_test.go
+++ b/internal/cmd/auth_service_account_atomic_test.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/config"
+)
+
+type failingServiceAccountTempFile struct {
+	*os.File
+	operation string
+}
+
+func (f *failingServiceAccountTempFile) Write(p []byte) (int, error) {
+	if f.operation == "write" {
+		n, _ := f.File.Write(p[:len(p)/2])
+		return n, errors.New("injected write failure")
+	}
+	return f.File.Write(p)
+}
+
+func (f *failingServiceAccountTempFile) Chmod(mode os.FileMode) error {
+	if f.operation == "permission" {
+		return errors.New("injected permission failure")
+	}
+	return f.File.Chmod(mode)
+}
+
+func (f *failingServiceAccountTempFile) Close() error {
+	err := f.File.Close()
+	if f.operation == "close" {
+		return errors.New("injected close failure")
+	}
+	return err
+}
+
+func TestAuthServiceAccountSet_ReplacesPermissiveFilePrivately(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	const email = "user@example.com"
+	oldData := []byte(`{"type":"service_account","client_email":"old@example.com"}`)
+	newData := []byte(`{"type":"service_account","client_email":"new@example.com"}`)
+
+	keyPath := filepath.Join(t.TempDir(), "service-account.json")
+	if err := os.WriteFile(keyPath, newData, 0o600); err != nil {
+		t.Fatalf("write source key: %v", err)
+	}
+	if _, err := config.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	destPath, err := config.ServiceAccountPath(email)
+	if err != nil {
+		t.Fatalf("ServiceAccountPath: %v", err)
+	}
+	if writeErr := os.WriteFile(destPath, oldData, 0o644); writeErr != nil {
+		t.Fatalf("write prior key: %v", writeErr)
+	}
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if executeErr := Execute([]string{"auth", "service-account", "set", email, "--key", keyPath}); executeErr != nil {
+				t.Fatalf("Execute: %v", executeErr)
+			}
+		})
+	})
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("read installed key: %v", err)
+	}
+	if string(got) != string(newData) {
+		t.Fatalf("installed key = %q, want %q", got, newData)
+	}
+	info, err := os.Stat(destPath)
+	if err != nil {
+		t.Fatalf("stat installed key: %v", err)
+	}
+	if gotMode := info.Mode().Perm(); gotMode != 0o600 {
+		t.Fatalf("installed key mode = %04o, want 0600", gotMode)
+	}
+}
+
+func TestAuthKeep_InstallsMatchingPrivateCredentialFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	const email = "user@example.com"
+	newData := []byte(`{"type":"service_account","client_email":"new@example.com"}`)
+	keyPath := filepath.Join(t.TempDir(), "service-account.json")
+	if err := os.WriteFile(keyPath, newData, 0o600); err != nil {
+		t.Fatalf("write source key: %v", err)
+	}
+	if _, err := config.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	keepPath, err := config.KeepServiceAccountPath(email)
+	if err != nil {
+		t.Fatalf("KeepServiceAccountPath: %v", err)
+	}
+	genericPath, err := config.ServiceAccountPath(email)
+	if err != nil {
+		t.Fatalf("ServiceAccountPath: %v", err)
+	}
+	for _, path := range []string{keepPath, genericPath} {
+		if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+			t.Fatalf("write prior key %q: %v", path, err)
+		}
+	}
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"auth", "keep", email, "--key", keyPath}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	for _, path := range []string{keepPath, genericPath} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read installed key %q: %v", path, err)
+		}
+		if string(got) != string(newData) {
+			t.Fatalf("installed key %q = %q, want %q", path, got, newData)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat installed key %q: %v", path, err)
+		}
+		if gotMode := info.Mode().Perm(); gotMode != 0o600 {
+			t.Fatalf("installed key %q mode = %04o, want 0600", path, gotMode)
+		}
+	}
+}
+
+func TestAuthKeep_SecondReplacementFailureRestoresPriorPairAndRemovesTemporaryFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	const email = "user@example.com"
+	oldKeep := []byte(`{"type":"service_account","client_email":"old-keep@example.com"}`)
+	oldGeneric := []byte(`{"type":"service_account","client_email":"old-generic@example.com"}`)
+	newData := []byte(`{"type":"service_account","client_email":"new@example.com"}`)
+	keyPath := filepath.Join(t.TempDir(), "service-account.json")
+	if err := os.WriteFile(keyPath, newData, 0o600); err != nil {
+		t.Fatalf("write source key: %v", err)
+	}
+	if _, err := config.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	keepPath, err := config.KeepServiceAccountPath(email)
+	if err != nil {
+		t.Fatalf("KeepServiceAccountPath: %v", err)
+	}
+	genericPath, err := config.ServiceAccountPath(email)
+	if err != nil {
+		t.Fatalf("ServiceAccountPath: %v", err)
+	}
+	if writeErr := os.WriteFile(keepPath, oldKeep, 0o600); writeErr != nil {
+		t.Fatalf("write prior Keep key: %v", writeErr)
+	}
+	if writeErr := os.WriteFile(genericPath, oldGeneric, 0o600); writeErr != nil {
+		t.Fatalf("write prior generic key: %v", writeErr)
+	}
+
+	originalRename := renameServiceAccountFile
+	t.Cleanup(func() { renameServiceAccountFile = originalRename })
+	replacement := 0
+	renameServiceAccountFile = func(oldPath, newPath string) error {
+		if oldPath != keepPath && oldPath != genericPath {
+			replacement++
+			if replacement == 2 {
+				return errors.New("injected second replacement failure")
+			}
+		}
+		return os.Rename(oldPath, newPath)
+	}
+
+	err = Execute([]string{"auth", "keep", email, "--key", keyPath})
+	if err == nil {
+		t.Fatal("Execute succeeded, want injected replacement failure")
+	}
+	for path, want := range map[string][]byte{keepPath: oldKeep, genericPath: oldGeneric} {
+		got, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("read restored key %q: %v", path, readErr)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("restored key %q = %q, want %q", path, got, want)
+		}
+	}
+	entries, err := os.ReadDir(filepath.Dir(keepPath))
+	if err != nil {
+		t.Fatalf("read credential directory: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != filepath.Base(keepPath) && entry.Name() != filepath.Base(genericPath) {
+			t.Fatalf("temporary file remains after failure: %s", entry.Name())
+		}
+	}
+}
+
+func TestAuthServiceAccountSet_FailuresPreservePriorKeyAndRemoveTemporaryFiles(t *testing.T) {
+	for _, operation := range []string{"write", "close", "permission", "replacement"} {
+		t.Run(operation, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+			const email = "user@example.com"
+			oldData := []byte(`{"type":"service_account","client_email":"old@example.com"}`)
+			newData := []byte(`{"type":"service_account","client_email":"new@example.com"}`)
+			keyPath := filepath.Join(t.TempDir(), "service-account.json")
+			if err := os.WriteFile(keyPath, newData, 0o600); err != nil {
+				t.Fatalf("write source key: %v", err)
+			}
+			if _, err := config.EnsureDir(); err != nil {
+				t.Fatalf("EnsureDir: %v", err)
+			}
+			destPath, err := config.ServiceAccountPath(email)
+			if err != nil {
+				t.Fatalf("ServiceAccountPath: %v", err)
+			}
+			if writeErr := os.WriteFile(destPath, oldData, 0o600); writeErr != nil {
+				t.Fatalf("write prior key: %v", writeErr)
+			}
+
+			originalCreateTemp := createServiceAccountTempFile
+			originalRename := renameServiceAccountFile
+			t.Cleanup(func() {
+				createServiceAccountTempFile = originalCreateTemp
+				renameServiceAccountFile = originalRename
+			})
+			if operation == "replacement" {
+				renameServiceAccountFile = func(_, _ string) error {
+					return errors.New("injected replacement failure")
+				}
+			} else {
+				createServiceAccountTempFile = func(dir, pattern string) (serviceAccountTempFile, error) {
+					file, createErr := os.CreateTemp(dir, pattern)
+					if createErr != nil {
+						return nil, createErr
+					}
+					return &failingServiceAccountTempFile{File: file, operation: operation}, nil
+				}
+			}
+
+			err = Execute([]string{"auth", "service-account", "set", email, "--key", keyPath})
+			if err == nil {
+				t.Fatal("Execute succeeded, want injected failure")
+			}
+			got, readErr := os.ReadFile(destPath)
+			if readErr != nil {
+				t.Fatalf("read prior key: %v", readErr)
+			}
+			if string(got) != string(oldData) {
+				t.Fatalf("prior key = %q, want %q", got, oldData)
+			}
+			temps, globErr := filepath.Glob(filepath.Join(filepath.Dir(destPath), "."+filepath.Base(destPath)+".tmp-*"))
+			if globErr != nil {
+				t.Fatalf("glob temporary files: %v", globErr)
+			}
+			if len(temps) != 0 {
+				t.Fatalf("temporary files remain after failure: %v", temps)
+			}
+		})
+	}
+}

--- a/internal/cmd/auth_service_account_atomic_test.go
+++ b/internal/cmd/auth_service_account_atomic_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -179,7 +180,12 @@ func TestAuthKeep_SecondReplacementFailureRestoresPriorPairAndRemovesTemporaryFi
 	t.Cleanup(func() { renameServiceAccountFile = originalRename })
 	replacement := 0
 	renameServiceAccountFile = func(oldPath, newPath string) error {
-		if oldPath != keepPath && oldPath != genericPath {
+		if strings.Contains(oldPath, ".backup-") {
+			if _, statErr := os.Stat(newPath); statErr == nil {
+				return fs.ErrExist
+			}
+		}
+		if oldPath != keepPath && oldPath != genericPath && !strings.Contains(oldPath, ".backup-") {
 			replacement++
 			if replacement == 2 {
 				return errors.New("injected second replacement failure")
@@ -236,7 +242,7 @@ func TestAuthKeep_RollbackFailureIsReportedAndPreservesBackup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ServiceAccountPath: %v", err)
 	}
-	if writeErr := os.WriteFile(keepPath, oldKeep, 0o600); writeErr != nil {
+	if writeErr := os.WriteFile(keepPath, oldKeep, 0o644); writeErr != nil {
 		t.Fatalf("write prior Keep key: %v", writeErr)
 	}
 	if writeErr := os.WriteFile(genericPath, oldGeneric, 0o600); writeErr != nil {
@@ -279,6 +285,13 @@ func TestAuthKeep_RollbackFailureIsReportedAndPreservesBackup(t *testing.T) {
 	}
 	if string(gotBackup) != string(oldKeep) {
 		t.Fatalf("backup = %q, want prior Keep key %q", gotBackup, oldKeep)
+	}
+	backupInfo, statErr := os.Stat(backups[0])
+	if statErr != nil {
+		t.Fatalf("stat recoverable backup: %v", statErr)
+	}
+	if gotMode := backupInfo.Mode().Perm(); gotMode != 0o600 {
+		t.Fatalf("backup mode = %04o, want 0600", gotMode)
 	}
 }
 

--- a/internal/cmd/auth_service_account_replace.go
+++ b/internal/cmd/auth_service_account_replace.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package cmd
+
+import "os"
+
+func replaceServiceAccountFile(oldPath, newPath string) error {
+	return os.Rename(oldPath, newPath)
+}
+
+func secureServiceAccountFile(string) error {
+	return nil
+}

--- a/internal/cmd/auth_service_account_replace_windows.go
+++ b/internal/cmd/auth_service_account_replace_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package cmd
+
+import "golang.org/x/sys/windows"
+
+func replaceServiceAccountFile(oldPath, newPath string) error {
+	oldPathPtr, err := windows.UTF16PtrFromString(oldPath)
+	if err != nil {
+		return err
+	}
+	newPathPtr, err := windows.UTF16PtrFromString(newPath)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(oldPathPtr, newPathPtr, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}
+
+func secureServiceAccountFile(path string) error {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return err
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.GRANT_ACCESS,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+		},
+	}}, nil)
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	)
+}


### PR DESCRIPTION
Stages private credential files, atomically replaces generic and Keep destinations, restores prior copies on injected failures, enforces owner-only permissions including Windows ACLs, and adds focused failure-path coverage. Tested with focused auth tests, a Windows cross-compile, and PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci. Closes #62