### PR TITLE
fix(gmail): make thread detail valid TSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,26 @@ body and raw records; `VALUE` contains its value. Every row includes the
 message and thread IDs. Tabs, newlines, and carriage returns in free-form
 fields are replaced with spaces so each record occupies one physical TSV row.
 
+`gog gmail thread get <threadId> --plain` uses an eight-column TSV schema:
+
+```text
+RECORD_TYPE	THREAD_ID	MESSAGE_ID	NAME	VALUE	PATH	BYTES	CACHED
+```
+
+Record meanings:
+
+- `metadata`: `NAME` is `message_count` and `VALUE` is the count; `MESSAGE_ID` is empty.
+- `header`: `NAME` is `From`, `To`, `Subject`, or `Date`; `VALUE` is the header value.
+- `body`: `VALUE` is the selected body, using the same HTML cleanup and preview truncation as human output.
+- `attachment`: `NAME` is the filename, `VALUE` is the MIME type, `PATH` is the Gmail attachment ID, and `BYTES` is the declared attachment size.
+- `download`: `NAME` is the filename, `PATH` is the committed on-disk path, `BYTES` is the exact committed byte count, and `CACHED` is `true` or `false`.
+
+Every message-specific record includes both IDs. Free-form fields are kept to one
+physical row. Download `PATH` values use reversible URL path-segment percent
+encoding (decode with any URL percent-decoder), so tabs, newlines, and other path
+bytes remain lossless without creating extra TSV rows or columns. An empty thread
+emits only the header.
+
 Gmail watch (Pub/Sub push):
 - Create Pub/Sub topic + push subscription (OIDC preferred; shared token ok for dev).
 - Full flow + payload details: `docs/watch.md`.

--- a/internal/cmd/execute_gmail_thread_alias_test.go
+++ b/internal/cmd/execute_gmail_thread_alias_test.go
@@ -67,8 +67,14 @@ func TestExecute_GmailThreadAliases(t *testing.T) {
 				}
 			})
 		})
-		if !strings.Contains(out, "Thread contains 1 message(s)") {
-			t.Fatalf("unexpected output for %v: %q", args, out)
+		if !strings.Contains(out, "RECORD_TYPE\tTHREAD_ID\tMESSAGE_ID\tNAME\tVALUE\tPATH\tBYTES\tCACHED") {
+			t.Fatalf("missing plain header for %v: %q", args, out)
+		}
+		if !strings.Contains(out, "metadata\tt1\t\tmessage_count\t1\t\t\t") {
+			t.Fatalf("missing metadata row for %v: %q", args, out)
+		}
+		if !strings.Contains(out, "header\tt1\tm1\tSubject\tHello\t\t\t") {
+			t.Fatalf("missing subject header for %v: %q", args, out)
 		}
 	}
 }

--- a/internal/cmd/gmail_attachment.go
+++ b/internal/cmd/gmail_attachment.go
@@ -102,9 +102,13 @@ func downloadAttachmentToPath(
 		return "", false, 0, errors.New("missing outPath")
 	}
 
+	resolvedPath, err := resolveDownloadDestination(outPath)
+	if err != nil {
+		return "", false, 0, err
+	}
 	if expectedSize > 0 {
-		if st, err := os.Stat(outPath); err == nil && st.Size() == expectedSize {
-			return outPath, true, st.Size(), nil
+		if st, statErr := os.Stat(resolvedPath); statErr == nil && st.Size() == expectedSize {
+			return resolvedPath, true, st.Size(), nil
 		}
 	}
 
@@ -127,11 +131,11 @@ func downloadAttachmentToPath(
 	if mkdirErr := os.MkdirAll(filepath.Dir(outPath), 0o700); mkdirErr != nil {
 		return "", false, 0, mkdirErr
 	}
-	written, _, err := writeDownloadFile(outPath, 0o600, func(w io.Writer) (int64, error) {
+	written, committedPath, err := writeDownloadFile(outPath, 0o600, func(w io.Writer) (int64, error) {
 		return io.Copy(w, stdbytes.NewReader(data))
 	})
 	if err != nil {
 		return "", false, 0, err
 	}
-	return outPath, false, written, nil
+	return committedPath, false, written, nil
 }

--- a/internal/cmd/gmail_attachments.go
+++ b/internal/cmd/gmail_attachments.go
@@ -31,6 +31,8 @@ type attachmentDownloadOutput struct {
 	Path   string `json:"path,omitempty"`
 	Bytes  int64  `json:"-"`
 	Cached bool   `json:"cached,omitempty"`
+	// Bytes is the exact on-disk size after download/cache hit; omitted from JSON.
+	Bytes int64 `json:"-"`
 }
 
 type attachmentDownloadSummary struct {
@@ -170,6 +172,7 @@ func downloadAttachmentOutputs(ctx context.Context, svc *gmail.Service, messageI
 			Path:             outPath,
 			Bytes:            bytes,
 			Cached:           cached,
+			Bytes:            bytes,
 		})
 	}
 	return out, nil

--- a/internal/cmd/gmail_attachments.go
+++ b/internal/cmd/gmail_attachments.go
@@ -31,8 +31,6 @@ type attachmentDownloadOutput struct {
 	Path   string `json:"path,omitempty"`
 	Bytes  int64  `json:"-"`
 	Cached bool   `json:"cached,omitempty"`
-	// Bytes is the exact on-disk size after download/cache hit; omitted from JSON.
-	Bytes int64 `json:"-"`
 }
 
 type attachmentDownloadSummary struct {
@@ -172,7 +170,6 @@ func downloadAttachmentOutputs(ctx context.Context, svc *gmail.Service, messageI
 			Path:             outPath,
 			Bytes:            bytes,
 			Cached:           cached,
-			Bytes:            bytes,
 		})
 	}
 	return out, nil

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -27,6 +27,8 @@ import (
 )
 
 // HTML stripping patterns for cleaner text output.
+const gmailThreadRecordDownload = "download"
+
 var (
 	// Remove script blocks entirely (including content)
 	scriptPattern = regexp.MustCompile(`(?is)<script[^>]*>.*?</script>`)
@@ -247,7 +249,7 @@ func writeGmailThreadPlainTSV(
 			}
 			for _, a := range downloads {
 				writeTableRow(ctx, w, []string{
-					"download",
+					gmailThreadRecordDownload,
 					threadID,
 					msgID,
 					a.Filename,

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -118,6 +119,9 @@ func (c *GmailThreadGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"downloaded": downloadedFiles,
 		})
 	}
+	if outfmt.IsPlain(ctx) {
+		return writeGmailThreadPlainTSV(ctx, os.Stdout, threadID, thread, c.Full, c.Download, attachDir, svc)
+	}
 	if thread == nil || len(thread.Messages) == 0 {
 		u.Err().Println("Empty thread")
 		return nil
@@ -174,6 +178,87 @@ func (c *GmailThreadGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 	}
 
+	return nil
+}
+
+// writeGmailThreadPlainTSV emits framed plain TSV for thread detail.
+// Schema: RECORD_TYPE THREAD_ID MESSAGE_ID NAME VALUE PATH BYTES CACHED
+func writeGmailThreadPlainTSV(
+	ctx context.Context,
+	w io.Writer,
+	threadID string,
+	thread *gmail.Thread,
+	full bool,
+	download bool,
+	attachDir string,
+	svc *gmail.Service,
+) error {
+	writeTableRow(ctx, w, []string{"RECORD_TYPE", "THREAD_ID", "MESSAGE_ID", "NAME", "VALUE", "PATH", "BYTES", "CACHED"})
+	if thread == nil || len(thread.Messages) == 0 {
+		return nil
+	}
+
+	writeTableRow(ctx, w, []string{
+		"metadata", threadID, "", "message_count", strconv.Itoa(len(thread.Messages)), "", "", "",
+	})
+
+	for _, msg := range thread.Messages {
+		if msg == nil {
+			continue
+		}
+		msgID := msg.Id
+		for _, name := range []string{"From", "To", "Subject", "Date"} {
+			writeTableRow(ctx, w, []string{
+				"header", threadID, msgID, name, headerValue(msg.Payload, name), "", "", "",
+			})
+		}
+
+		body, isHTML := bestBodyForDisplay(msg.Payload)
+		if body != "" {
+			cleanBody := body
+			if isHTML {
+				cleanBody = stripHTMLTags(body)
+			}
+			runes := []rune(cleanBody)
+			if len(runes) > 500 && !full {
+				cleanBody = string(runes[:500]) + "... [truncated]"
+			}
+			writeTableRow(ctx, w, []string{"body", threadID, msgID, "", cleanBody, "", "", ""})
+		}
+
+		attachments := collectAttachments(msg.Payload)
+		for _, a := range attachments {
+			writeTableRow(ctx, w, []string{
+				"attachment",
+				threadID,
+				msgID,
+				a.Filename,
+				a.MimeType,
+				a.AttachmentID,
+				strconv.FormatInt(a.Size, 10),
+				"",
+			})
+		}
+
+		if download && len(attachments) > 0 {
+			downloads, err := downloadAttachmentOutputs(ctx, svc, msg.Id, attachments, attachDir)
+			if err != nil {
+				return err
+			}
+			for _, a := range downloads {
+				writeTableRow(ctx, w, []string{
+					"download",
+					threadID,
+					msgID,
+					a.Filename,
+					"",
+					a.Path,
+					strconv.FormatInt(a.Bytes, 10),
+					strconv.FormatBool(a.Cached),
+				})
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -195,11 +195,6 @@ func writeGmailThreadPlainTSV(
 	attachDir string,
 	svc *gmail.Service,
 ) error {
-	if download {
-		if err := validateGmailThreadPlainDownloadPaths(thread, attachDir); err != nil {
-			return err
-		}
-	}
 	writeTableRow(ctx, w, []string{"RECORD_TYPE", "THREAD_ID", "MESSAGE_ID", "NAME", "VALUE", "PATH", "BYTES", "CACHED"})
 	if thread == nil || len(thread.Messages) == 0 {
 		return nil
@@ -259,7 +254,7 @@ func writeGmailThreadPlainTSV(
 					msgID,
 					a.Filename,
 					"",
-					a.Path,
+					url.PathEscape(a.Path),
 					strconv.FormatInt(a.Bytes, 10),
 					strconv.FormatBool(a.Cached),
 				})
@@ -757,27 +752,6 @@ func attachmentDownloadPath(messageID string, a attachmentInfo, dir string) (str
 	}
 	filename := fmt.Sprintf("%s_%s_%s", messageID, shortID, safeFilename)
 	return filepath.Join(dir, filename), nil
-}
-
-func validateGmailThreadPlainDownloadPaths(thread *gmail.Thread, dir string) error {
-	if thread == nil {
-		return nil
-	}
-	for _, msg := range thread.Messages {
-		if msg == nil {
-			continue
-		}
-		for _, a := range collectAttachments(msg.Payload) {
-			path, err := attachmentDownloadPath(msg.Id, a, dir)
-			if err != nil {
-				return err
-			}
-			if sanitizePlainField(path) != path {
-				return fmt.Errorf("attachment download path contains a tab or newline: %q", path)
-			}
-		}
-	}
-	return nil
 }
 
 func downloadAttachment(ctx context.Context, svc *gmail.Service, messageID string, a attachmentInfo, dir string) (string, bool, int64, error) {

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -195,6 +195,11 @@ func writeGmailThreadPlainTSV(
 	attachDir string,
 	svc *gmail.Service,
 ) error {
+	if download {
+		if err := validateGmailThreadPlainDownloadPaths(thread, attachDir); err != nil {
+			return err
+		}
+	}
 	writeTableRow(ctx, w, []string{"RECORD_TYPE", "THREAD_ID", "MESSAGE_ID", "NAME", "VALUE", "PATH", "BYTES", "CACHED"})
 	if thread == nil || len(thread.Messages) == 0 {
 		return nil
@@ -255,7 +260,7 @@ func writeGmailThreadPlainTSV(
 					a.Filename,
 					"",
 					a.Path,
-					strconv.FormatInt(a.Size, 10),
+					strconv.FormatInt(a.Bytes, 10),
 					strconv.FormatBool(a.Cached),
 				})
 			}
@@ -734,9 +739,9 @@ func decodeBase64URL(s string) (string, error) {
 	return string(b), nil
 }
 
-func downloadAttachment(ctx context.Context, svc *gmail.Service, messageID string, a attachmentInfo, dir string) (string, bool, int64, error) {
+func attachmentDownloadPath(messageID string, a attachmentInfo, dir string) (string, error) {
 	if strings.TrimSpace(messageID) == "" || strings.TrimSpace(a.AttachmentID) == "" {
-		return "", false, 0, errors.New("missing messageID/attachmentID")
+		return "", errors.New("missing messageID/attachmentID")
 	}
 	if strings.TrimSpace(dir) == "" {
 		dir = "."
@@ -745,13 +750,41 @@ func downloadAttachment(ctx context.Context, svc *gmail.Service, messageID strin
 	if len(shortID) > 8 {
 		shortID = shortID[:8]
 	}
-	// Sanitize filename to prevent path traversal attacks
+	// Sanitize filename to prevent path traversal attacks.
 	safeFilename := filepath.Base(a.Filename)
 	if safeFilename == "" || safeFilename == "." || safeFilename == ".." {
 		safeFilename = "attachment"
 	}
 	filename := fmt.Sprintf("%s_%s_%s", messageID, shortID, safeFilename)
-	outPath := filepath.Join(dir, filename)
+	return filepath.Join(dir, filename), nil
+}
+
+func validateGmailThreadPlainDownloadPaths(thread *gmail.Thread, dir string) error {
+	if thread == nil {
+		return nil
+	}
+	for _, msg := range thread.Messages {
+		if msg == nil {
+			continue
+		}
+		for _, a := range collectAttachments(msg.Payload) {
+			path, err := attachmentDownloadPath(msg.Id, a, dir)
+			if err != nil {
+				return err
+			}
+			if sanitizePlainField(path) != path {
+				return fmt.Errorf("attachment download path contains a tab or newline: %q", path)
+			}
+		}
+	}
+	return nil
+}
+
+func downloadAttachment(ctx context.Context, svc *gmail.Service, messageID string, a attachmentInfo, dir string) (string, bool, int64, error) {
+	outPath, err := attachmentDownloadPath(messageID, a, dir)
+	if err != nil {
+		return "", false, 0, err
+	}
 	path, cached, byteCount, err := downloadAttachmentToPath(ctx, svc, messageID, a.AttachmentID, outPath, a.Size)
 	if err != nil {
 		return "", false, 0, err

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -255,7 +255,7 @@ func writeGmailThreadPlainTSV(
 					a.Filename,
 					"",
 					a.Path,
-					strconv.FormatInt(a.Bytes, 10),
+					strconv.FormatInt(a.Size, 10),
 					strconv.FormatBool(a.Cached),
 				})
 			}

--- a/internal/cmd/gmail_thread_plain_test.go
+++ b/internal/cmd/gmail_thread_plain_test.go
@@ -274,7 +274,7 @@ func TestGmailThreadGet_PlainTSV_RecordsAndSanitization(t *testing.T) {
 		t.Fatalf("attachment BYTES = %q, want %d", att[6], len(attachmentData))
 	}
 
-	downloads := byType["download"]
+	downloads := byType[gmailThreadRecordDownload]
 	if len(downloads) != 1 {
 		t.Fatalf("expected 1 download row, got %#v", downloads)
 	}
@@ -317,7 +317,7 @@ func TestGmailThreadGet_PlainTSV_RecordsAndSanitization(t *testing.T) {
 	var cachedDownload []string
 	for _, line := range cachedLines[1:] {
 		cols := strings.Split(line, "\t")
-		if cols[0] == "download" {
+		if cols[0] == gmailThreadRecordDownload {
 			cachedDownload = cols
 		}
 	}
@@ -405,8 +405,7 @@ func TestGmailThreadGet_PlainTSV_FullBodyAndJSONUnchanged(t *testing.T) {
 		})
 	})
 	var payload struct {
-		Thread     map[string]any   `json:"thread"`
-		Downloaded []map[string]any `json:"downloaded"`
+		Thread map[string]any `json:"thread"`
 	}
 	if err := json.Unmarshal([]byte(jsonOut), &payload); err != nil {
 		t.Fatalf("json decode: %v\nout=%q", err, jsonOut)
@@ -414,10 +413,6 @@ func TestGmailThreadGet_PlainTSV_FullBodyAndJSONUnchanged(t *testing.T) {
 	if payload.Thread == nil || payload.Thread["id"] != "t-full" {
 		t.Fatalf("unexpected json payload: %#v", payload)
 	}
-	if payload.Downloaded == nil {
-		// downloaded key present as empty slice is fine; missing is also ok for Go nil
-	}
-
 	humanOut := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
 			if err := Execute([]string{

--- a/internal/cmd/gmail_thread_plain_test.go
+++ b/internal/cmd/gmail_thread_plain_test.go
@@ -95,7 +95,7 @@ func TestGmailThreadGet_PlainTSV_RecordsAndSanitization(t *testing.T) {
 							},
 						},
 						{
-							"filename": "note\tfile.txt",
+							"filename": "note file.txt",
 							"mimeType": "text/plain",
 							"body": map[string]any{
 								"attachmentId": "att1",
@@ -285,10 +285,9 @@ func TestGmailThreadGet_PlainTSV_RecordsAndSanitization(t *testing.T) {
 	if dl[3] != "note file.txt" {
 		t.Fatalf("download NAME = %q", dl[3])
 	}
-	// On-disk path may embed delimiter-bearing filenames; TSV PATH is sanitized.
-	expectedPath := filepath.Join(outDir, "m1_att1_note\tfile.txt")
-	if dl[5] != sanitizePlainField(expectedPath) {
-		t.Fatalf("download PATH = %q, want sanitized %q", dl[5], sanitizePlainField(expectedPath))
+	expectedPath := filepath.Join(outDir, "m1_att1_note file.txt")
+	if dl[5] != expectedPath {
+		t.Fatalf("download PATH = %q, want exact path %q", dl[5], expectedPath)
 	}
 	st, err := os.Stat(expectedPath)
 	if err != nil {
@@ -332,6 +331,124 @@ func TestGmailThreadGet_PlainTSV_RecordsAndSanitization(t *testing.T) {
 	}
 	if cachedDownload[7] != "true" {
 		t.Fatalf("cached CACHED = %q, want true", cachedDownload[7])
+	}
+}
+
+func TestGmailThreadGet_PlainTSV_DownloadUsesExactBytes(t *testing.T) {
+	attachmentData := []byte("payload")
+	attachmentB64 := base64.RawURLEncoding.EncodeToString(attachmentData)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/users/me/threads/t-bytes"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "t-bytes",
+				"messages": []map[string]any{{
+					"id": "m-bytes",
+					"payload": map[string]any{
+						"parts": []map[string]any{{
+							"filename": "bytes.txt",
+							"mimeType": "text/plain",
+							"body":     map[string]any{"attachmentId": "att-bytes", "size": 1},
+						}},
+					},
+				}},
+			})
+		case strings.HasSuffix(r.URL.Path, "/users/me/messages/m-bytes/attachments/att-bytes"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": attachmentB64})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	setupGmailThreadPlainService(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com", "gmail", "thread", "get", "t-bytes",
+				"--download", "--out-dir", t.TempDir(),
+			}); err != nil {
+				t.Fatalf("Execute exact bytes: %v", err)
+			}
+		})
+	})
+	for _, line := range strings.Split(strings.TrimSuffix(out, "\n"), "\n")[1:] {
+		cols := strings.Split(line, "\t")
+		if cols[0] == gmailThreadRecordDownload {
+			if cols[6] != strconv.Itoa(len(attachmentData)) {
+				t.Fatalf("download BYTES = %q, want actual %d despite metadata size 1", cols[6], len(attachmentData))
+			}
+			return
+		}
+	}
+	t.Fatalf("missing download row: %q", out)
+}
+
+func TestGmailThreadGet_PlainTSV_RejectsUnsafeDownloadPath(t *testing.T) {
+	attachmentRequested := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/users/me/threads/t-unsafe"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "t-unsafe",
+				"messages": []map[string]any{{
+					"id": "m-unsafe",
+					"payload": map[string]any{
+						"parts": []map[string]any{{
+							"filename": "unsafe\tname.txt",
+							"mimeType": "text/plain",
+							"body":     map[string]any{"attachmentId": "att-unsafe", "size": 7},
+						}},
+					},
+				}},
+			})
+		case strings.Contains(r.URL.Path, "/attachments/"):
+			attachmentRequested = true
+			http.Error(w, "must not download", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	setupGmailThreadPlainService(t, srv)
+
+	listed := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com", "gmail", "thread", "get", "t-unsafe",
+			}); err != nil {
+				t.Fatalf("list unsafe attachment metadata: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(listed, "attachment\tt-unsafe\tm-unsafe\tunsafe name.txt\ttext/plain\tatt-unsafe\t7\t") {
+		t.Fatalf("unsafe attachment field was not sanitized: %q", listed)
+	}
+
+	outDir := t.TempDir()
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			err := Execute([]string{
+				"--plain", "--account", "a@b.com", "gmail", "thread", "get", "t-unsafe",
+				"--download", "--out-dir", outDir,
+			})
+			if err == nil || !strings.Contains(err.Error(), "tab or newline") {
+				t.Fatalf("unsafe path error = %v", err)
+			}
+		})
+	})
+	if out != "" {
+		t.Fatalf("unsafe download wrote partial stdout: %q", out)
+	}
+	if attachmentRequested {
+		t.Fatal("unsafe path attempted attachment transfer")
+	}
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatalf("read output dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("unsafe path created files: %#v", entries)
 	}
 }
 

--- a/internal/cmd/gmail_thread_plain_test.go
+++ b/internal/cmd/gmail_thread_plain_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -286,8 +287,8 @@ func TestGmailThreadGet_PlainTSV_RecordsAndSanitization(t *testing.T) {
 		t.Fatalf("download NAME = %q", dl[3])
 	}
 	expectedPath := filepath.Join(outDir, "m1_att1_note file.txt")
-	if dl[5] != expectedPath {
-		t.Fatalf("download PATH = %q, want exact path %q", dl[5], expectedPath)
+	if dl[5] != url.PathEscape(expectedPath) {
+		t.Fatalf("download PATH = %q, want encoded exact path %q", dl[5], url.PathEscape(expectedPath))
 	}
 	st, err := os.Stat(expectedPath)
 	if err != nil {
@@ -384,8 +385,9 @@ func TestGmailThreadGet_PlainTSV_DownloadUsesExactBytes(t *testing.T) {
 	t.Fatalf("missing download row: %q", out)
 }
 
-func TestGmailThreadGet_PlainTSV_RejectsUnsafeDownloadPath(t *testing.T) {
-	attachmentRequested := false
+func TestGmailThreadGet_PlainTSV_EncodesCommittedDownloadPath(t *testing.T) {
+	attachmentData := []byte("payload")
+	attachmentB64 := base64.RawURLEncoding.EncodeToString(attachmentData)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/users/me/threads/t-unsafe"):
@@ -397,14 +399,13 @@ func TestGmailThreadGet_PlainTSV_RejectsUnsafeDownloadPath(t *testing.T) {
 						"parts": []map[string]any{{
 							"filename": "unsafe\tname.txt",
 							"mimeType": "text/plain",
-							"body":     map[string]any{"attachmentId": "att-unsafe", "size": 7},
+							"body":     map[string]any{"attachmentId": "att-unsafe", "size": len(attachmentData)},
 						}},
 					},
 				}},
 			})
 		case strings.Contains(r.URL.Path, "/attachments/"):
-			attachmentRequested = true
-			http.Error(w, "must not download", http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": attachmentB64})
 		default:
 			http.NotFound(w, r)
 		}
@@ -412,44 +413,55 @@ func TestGmailThreadGet_PlainTSV_RejectsUnsafeDownloadPath(t *testing.T) {
 	defer srv.Close()
 	setupGmailThreadPlainService(t, srv)
 
-	listed := captureStdout(t, func() {
+	outDir := t.TempDir()
+	requestedPath := filepath.Join(outDir, "m-unsafe_att-unsa_unsafe\tname.txt")
+	committedPath := filepath.Join(outDir, "committed\nname.txt")
+	if err := os.Symlink(filepath.Base(committedPath), requestedPath); err != nil {
+		t.Fatalf("create destination symlink: %v", err)
+	}
+
+	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--plain", "--account", "a@b.com", "gmail", "thread", "get", "t-unsafe",
+				"--download", "--out-dir", outDir,
 			}); err != nil {
-				t.Fatalf("list unsafe attachment metadata: %v", err)
+				t.Fatalf("download delimiter-bearing path: %v", err)
 			}
 		})
 	})
-	if !strings.Contains(listed, "attachment\tt-unsafe\tm-unsafe\tunsafe name.txt\ttext/plain\tatt-unsafe\t7\t") {
-		t.Fatalf("unsafe attachment field was not sanitized: %q", listed)
+	if !strings.Contains(out, "attachment\tt-unsafe\tm-unsafe\tunsafe name.txt\ttext/plain\tatt-unsafe\t7\t") {
+		t.Fatalf("unsafe attachment field was not sanitized: %q", out)
 	}
 
-	outDir := t.TempDir()
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			err := Execute([]string{
-				"--plain", "--account", "a@b.com", "gmail", "thread", "get", "t-unsafe",
-				"--download", "--out-dir", outDir,
-			})
-			if err == nil || !strings.Contains(err.Error(), "tab or newline") {
-				t.Fatalf("unsafe path error = %v", err)
-			}
-		})
-	})
-	if out != "" {
-		t.Fatalf("unsafe download wrote partial stdout: %q", out)
+	for _, line := range strings.Split(strings.TrimSuffix(out, "\n"), "\n")[1:] {
+		cols := strings.Split(line, "\t")
+		if cols[0] != gmailThreadRecordDownload {
+			continue
+		}
+		decodedPath, err := url.PathUnescape(cols[5])
+		if err != nil {
+			t.Fatalf("decode PATH %q: %v", cols[5], err)
+		}
+		if decodedPath != committedPath {
+			t.Fatalf("decoded PATH = %q, want committed symlink target %q", decodedPath, committedPath)
+		}
+		if strings.ContainsAny(cols[5], "\t\r\n") {
+			t.Fatalf("encoded PATH contains a TSV delimiter: %q", cols[5])
+		}
+		if cols[6] != strconv.Itoa(len(attachmentData)) || cols[7] != "false" {
+			t.Fatalf("download receipt bytes/cached = %q/%q", cols[6], cols[7])
+		}
+		data, readErr := os.ReadFile(committedPath)
+		if readErr != nil {
+			t.Fatalf("read committed target: %v", readErr)
+		}
+		if string(data) != string(attachmentData) {
+			t.Fatalf("committed target data = %q", data)
+		}
+		return
 	}
-	if attachmentRequested {
-		t.Fatal("unsafe path attempted attachment transfer")
-	}
-	entries, err := os.ReadDir(outDir)
-	if err != nil {
-		t.Fatalf("read output dir: %v", err)
-	}
-	if len(entries) != 0 {
-		t.Fatalf("unsafe path created files: %#v", entries)
-	}
+	t.Fatalf("missing download row: %q", out)
 }
 
 func TestGmailThreadGet_PlainTSV_FullBodyAndJSONUnchanged(t *testing.T) {

--- a/internal/cmd/gmail_thread_plain_test.go
+++ b/internal/cmd/gmail_thread_plain_test.go
@@ -1,0 +1,444 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+)
+
+const gmailThreadPlainHeader = "RECORD_TYPE\tTHREAD_ID\tMESSAGE_ID\tNAME\tVALUE\tPATH\tBYTES\tCACHED"
+
+func setupGmailThreadPlainService(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+}
+
+func TestGmailThreadGet_PlainTSV_EmptyThreadHeaderOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/users/me/threads/empty") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "empty",
+				"messages": []map[string]any{},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	setupGmailThreadPlainService(t, srv)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "gmail", "thread", "get", "empty"}); err != nil {
+				t.Fatalf("Execute empty thread plain: %v", err)
+			}
+		})
+	})
+	if got, want := out, gmailThreadPlainHeader+"\n"; got != want {
+		t.Fatalf("empty plain output = %q, want %q", got, want)
+	}
+}
+
+func TestGmailThreadGet_PlainTSV_RecordsAndSanitization(t *testing.T) {
+	bodyText := "line1\nline2\twith\ttabs\rand more"
+	unsafeFrom := "Alice\tSmith <alice\n@example.com>"
+	unsafeSubject := "Hello\r\nWorld"
+	longBodyRunes := make([]rune, 520)
+	for i := range longBodyRunes {
+		longBodyRunes[i] = 'あ'
+	}
+	longBody := string(longBodyRunes)
+	attachmentData := []byte("payload")
+	attachmentB64 := base64.RawURLEncoding.EncodeToString(attachmentData)
+
+	threadResp := map[string]any{
+		"id": "t1",
+		"messages": []map[string]any{
+			{
+				"id": "m1",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "From", "value": unsafeFrom},
+						{"name": "To", "value": "bob@example.com"},
+						{"name": "Subject", "value": unsafeSubject},
+						{"name": "Date", "value": "Mon, 1 Jan 2025 00:00:00 +0000"},
+					},
+					"mimeType": "multipart/mixed",
+					"parts": []map[string]any{
+						{
+							"mimeType": "text/plain",
+							"body": map[string]any{
+								"data": base64.RawURLEncoding.EncodeToString([]byte(bodyText)),
+							},
+						},
+						{
+							"filename": "note\tfile.txt",
+							"mimeType": "text/plain",
+							"body": map[string]any{
+								"attachmentId": "att1",
+								"size":         int64(len(attachmentData)),
+							},
+						},
+					},
+				},
+			},
+			{
+				"id": "m2",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "From", "value": "carol@example.com"},
+						{"name": "To", "value": "dave@example.com"},
+						{"name": "Subject", "value": "Reply"},
+						{"name": "Date", "value": "Tue, 2 Jan 2025 00:00:00 +0000"},
+					},
+					"mimeType": "text/plain",
+					"body": map[string]any{
+						"data": base64.RawURLEncoding.EncodeToString([]byte(longBody)),
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		switch {
+		case r.Method == http.MethodGet && path == "/users/me/threads/t1":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(threadResp)
+			return
+		case r.Method == http.MethodGet && path == "/users/me/messages/m1/attachments/att1":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": attachmentB64})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+	setupGmailThreadPlainService(t, srv)
+
+	outDir := t.TempDir()
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"gmail", "thread", "get", "t1",
+				"--download", "--out-dir", outDir,
+			}); err != nil {
+				t.Fatalf("Execute thread get plain: %v", err)
+			}
+		})
+	})
+
+	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	if len(lines) == 0 || lines[0] != gmailThreadPlainHeader {
+		t.Fatalf("missing exact header row; first line = %q\nout=%q", firstLine(out), out)
+	}
+	for i, line := range lines {
+		if strings.Count(line, "\t") != 7 {
+			t.Fatalf("line %d has %d tabs (want 7): %q", i, strings.Count(line, "\t"), line)
+		}
+		if strings.ContainsAny(line, "\r") {
+			t.Fatalf("line %d contains CR: %q", i, line)
+		}
+		// Free-form fields must not inject physical rows.
+		if i > 0 && strings.Contains(line, "\n") {
+			t.Fatalf("line %d is multi-line: %q", i, line)
+		}
+	}
+
+	byType := map[string][][]string{}
+	for _, line := range lines[1:] {
+		cols := strings.Split(line, "\t")
+		if len(cols) != 8 {
+			t.Fatalf("expected 8 columns, got %d: %q", len(cols), line)
+		}
+		if cols[1] != "t1" {
+			t.Fatalf("expected THREAD_ID t1 on every row, got %q in %q", cols[1], line)
+		}
+		byType[cols[0]] = append(byType[cols[0]], cols)
+	}
+
+	if len(byType["metadata"]) != 1 {
+		t.Fatalf("expected 1 metadata row, got %#v", byType["metadata"])
+	}
+	meta := byType["metadata"][0]
+	if meta[2] != "" || meta[3] != "message_count" || meta[4] != "2" {
+		t.Fatalf("unexpected metadata row: %#v", meta)
+	}
+
+	headers := byType["header"]
+	if len(headers) != 8 {
+		t.Fatalf("expected 8 header rows (4 per message), got %d: %#v", len(headers), headers)
+	}
+	foundUnsafeFrom := false
+	foundUnsafeSubject := false
+	for _, h := range headers {
+		if h[2] == "" {
+			t.Fatalf("header row missing MESSAGE_ID: %#v", h)
+		}
+		if h[2] == "m1" && h[3] == "From" {
+			foundUnsafeFrom = true
+			if h[4] != "Alice Smith <alice @example.com>" {
+				t.Fatalf("From not sanitized: %q", h[4])
+			}
+		}
+		if h[2] == "m1" && h[3] == "Subject" {
+			foundUnsafeSubject = true
+			if h[4] != "Hello World" {
+				t.Fatalf("Subject not sanitized: %q", h[4])
+			}
+		}
+	}
+	if !foundUnsafeFrom || !foundUnsafeSubject {
+		t.Fatalf("missing sanitized header rows: %#v", headers)
+	}
+
+	bodies := byType["body"]
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 body rows, got %#v", bodies)
+	}
+	var bodyM1, bodyM2 []string
+	for _, b := range bodies {
+		if b[2] == "" {
+			t.Fatalf("body row missing MESSAGE_ID: %#v", b)
+		}
+		switch b[2] {
+		case "m1":
+			bodyM1 = b
+		case "m2":
+			bodyM2 = b
+		}
+	}
+	if bodyM1 == nil || bodyM2 == nil {
+		t.Fatalf("missing body rows for m1/m2: %#v", bodies)
+	}
+	if bodyM1[4] != "line1 line2 with tabs and more" {
+		t.Fatalf("body m1 not sanitized: %q", bodyM1[4])
+	}
+	// Default truncation at 500 runes with marker; full mode is covered separately.
+	if utf8.RuneCountInString(bodyM2[4]) <= 500 {
+		t.Fatalf("expected truncated body for m2 to include marker, got %q", bodyM2[4])
+	}
+	if !strings.HasSuffix(bodyM2[4], "... [truncated]") {
+		t.Fatalf("expected truncation marker on m2 body, got %q", bodyM2[4])
+	}
+	truncatedRunes := []rune(bodyM2[4])
+	if string(truncatedRunes[:500]) != string(longBodyRunes[:500]) {
+		t.Fatalf("truncated body prefix mismatch")
+	}
+
+	atts := byType["attachment"]
+	if len(atts) != 1 {
+		t.Fatalf("expected 1 attachment row, got %#v", atts)
+	}
+	att := atts[0]
+	if att[2] != "m1" {
+		t.Fatalf("attachment MESSAGE_ID = %q, want m1", att[2])
+	}
+	if att[3] != "note file.txt" {
+		t.Fatalf("attachment NAME not sanitized: %q", att[3])
+	}
+	if att[4] != "text/plain" {
+		t.Fatalf("attachment VALUE(mime) = %q", att[4])
+	}
+	if att[5] != "att1" {
+		t.Fatalf("attachment PATH(attachmentId) = %q", att[5])
+	}
+	if att[6] != strconv.FormatInt(int64(len(attachmentData)), 10) {
+		t.Fatalf("attachment BYTES = %q, want %d", att[6], len(attachmentData))
+	}
+
+	downloads := byType["download"]
+	if len(downloads) != 1 {
+		t.Fatalf("expected 1 download row, got %#v", downloads)
+	}
+	dl := downloads[0]
+	if dl[2] != "m1" {
+		t.Fatalf("download MESSAGE_ID = %q, want m1", dl[2])
+	}
+	if dl[3] != "note file.txt" {
+		t.Fatalf("download NAME = %q", dl[3])
+	}
+	// On-disk path may embed delimiter-bearing filenames; TSV PATH is sanitized.
+	expectedPath := filepath.Join(outDir, "m1_att1_note\tfile.txt")
+	if dl[5] != sanitizePlainField(expectedPath) {
+		t.Fatalf("download PATH = %q, want sanitized %q", dl[5], sanitizePlainField(expectedPath))
+	}
+	st, err := os.Stat(expectedPath)
+	if err != nil {
+		t.Fatalf("stat download path: %v", err)
+	}
+	if dl[6] != strconv.FormatInt(st.Size(), 10) || dl[6] != strconv.Itoa(len(attachmentData)) {
+		t.Fatalf("download BYTES = %q, want exact %d", dl[6], len(attachmentData))
+	}
+	if dl[7] != "false" {
+		t.Fatalf("download CACHED = %q, want false", dl[7])
+	}
+
+	// Second download hits cache; CACHED must flip true with same exact bytes/path.
+	cachedOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"gmail", "thread", "get", "t1",
+				"--download", "--out-dir", outDir,
+			}); err != nil {
+				t.Fatalf("Execute cached plain: %v", err)
+			}
+		})
+	})
+	cachedLines := strings.Split(strings.TrimSuffix(cachedOut, "\n"), "\n")
+	var cachedDownload []string
+	for _, line := range cachedLines[1:] {
+		cols := strings.Split(line, "\t")
+		if cols[0] == "download" {
+			cachedDownload = cols
+		}
+	}
+	if cachedDownload == nil {
+		t.Fatalf("missing download row on cache pass: %q", cachedOut)
+	}
+	if cachedDownload[5] != dl[5] {
+		t.Fatalf("cached path %q != first path %q", cachedDownload[5], dl[5])
+	}
+	if cachedDownload[6] != dl[6] {
+		t.Fatalf("cached BYTES %q != first BYTES %q", cachedDownload[6], dl[6])
+	}
+	if cachedDownload[7] != "true" {
+		t.Fatalf("cached CACHED = %q, want true", cachedDownload[7])
+	}
+}
+
+func TestGmailThreadGet_PlainTSV_FullBodyAndJSONUnchanged(t *testing.T) {
+	longBodyRunes := make([]rune, 520)
+	for i := range longBodyRunes {
+		longBodyRunes[i] = 'x'
+	}
+	longBody := string(longBodyRunes)
+	threadResp := map[string]any{
+		"id": "t-full",
+		"messages": []map[string]any{
+			{
+				"id": "m-full",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "From", "value": "a@example.com"},
+						{"name": "To", "value": "b@example.com"},
+						{"name": "Subject", "value": "Full"},
+						{"name": "Date", "value": "Mon, 1 Jan 2025 00:00:00 +0000"},
+					},
+					"mimeType": "text/plain",
+					"body": map[string]any{
+						"data": base64.RawURLEncoding.EncodeToString([]byte(longBody)),
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/users/me/threads/t-full") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(threadResp)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	setupGmailThreadPlainService(t, srv)
+
+	fullOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"gmail", "thread", "get", "t-full", "--full",
+			}); err != nil {
+				t.Fatalf("Execute full plain: %v", err)
+			}
+		})
+	})
+	var fullBody string
+	for _, line := range strings.Split(strings.TrimSuffix(fullOut, "\n"), "\n")[1:] {
+		cols := strings.Split(line, "\t")
+		if cols[0] == "body" {
+			fullBody = cols[4]
+		}
+	}
+	if fullBody != longBody {
+		t.Fatalf("--full body length=%d want %d (truncated? %v)", len(fullBody), len(longBody), strings.Contains(fullBody, "[truncated]"))
+	}
+
+	jsonOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--account", "a@b.com",
+				"gmail", "thread", "get", "t-full",
+			}); err != nil {
+				t.Fatalf("Execute json: %v", err)
+			}
+		})
+	})
+	var payload struct {
+		Thread     map[string]any   `json:"thread"`
+		Downloaded []map[string]any `json:"downloaded"`
+	}
+	if err := json.Unmarshal([]byte(jsonOut), &payload); err != nil {
+		t.Fatalf("json decode: %v\nout=%q", err, jsonOut)
+	}
+	if payload.Thread == nil || payload.Thread["id"] != "t-full" {
+		t.Fatalf("unexpected json payload: %#v", payload)
+	}
+	if payload.Downloaded == nil {
+		// downloaded key present as empty slice is fine; missing is also ok for Go nil
+	}
+
+	humanOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--account", "a@b.com",
+				"gmail", "thread", "get", "t-full",
+			}); err != nil {
+				t.Fatalf("Execute human: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(humanOut, "Thread contains 1 message(s)") {
+		t.Fatalf("human output regresssed: %q", humanOut)
+	}
+	if !strings.Contains(humanOut, "... [truncated]") {
+		t.Fatalf("human default still truncates; got %q", humanOut)
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/cmd/gmail_thread_run_test.go
+++ b/internal/cmd/gmail_thread_run_test.go
@@ -206,15 +206,29 @@ func TestGmailThreadGetAndAttachments_JSON(t *testing.T) {
 		t.Fatalf("unexpected download path: %s", path)
 	}
 
-	plainOut := captureStdout(t, func() {
+	humanOut := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
 			if err := Execute([]string{"--account", "a@b.com", "gmail", "thread", "get", "t1"}); err != nil {
+				t.Fatalf("Execute thread get human: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(humanOut, "Thread contains") {
+		t.Fatalf("unexpected human output: %q", humanOut)
+	}
+
+	plainOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "gmail", "thread", "get", "t1"}); err != nil {
 				t.Fatalf("Execute thread get plain: %v", err)
 			}
 		})
 	})
-	if !strings.Contains(plainOut, "Thread contains") {
+	if !strings.HasPrefix(plainOut, "RECORD_TYPE\tTHREAD_ID\tMESSAGE_ID\tNAME\tVALUE\tPATH\tBYTES\tCACHED\n") {
 		t.Fatalf("unexpected plain output: %q", plainOut)
+	}
+	if !strings.Contains(plainOut, "metadata\tt1\t\tmessage_count\t1\t\t\t") {
+		t.Fatalf("missing plain metadata row: %q", plainOut)
 	}
 
 	emptyErr := captureStderr(t, func() {
@@ -224,6 +238,17 @@ func TestGmailThreadGetAndAttachments_JSON(t *testing.T) {
 	})
 	if !strings.Contains(emptyErr, "Empty thread") {
 		t.Fatalf("unexpected empty thread stderr: %q", emptyErr)
+	}
+
+	emptyPlain := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "gmail", "thread", "get", "empty"}); err != nil {
+				t.Fatalf("Execute empty thread plain: %v", err)
+			}
+		})
+	})
+	if emptyPlain != "RECORD_TYPE\tTHREAD_ID\tMESSAGE_ID\tNAME\tVALUE\tPATH\tBYTES\tCACHED\n" {
+		t.Fatalf("unexpected empty plain output: %q", emptyPlain)
 	}
 
 	noAttsOut := captureStdout(t, func() {


### PR DESCRIPTION
Emits Gmail thread detail plain output as a stable eight-column TSV with explicit thread/message association and sanitized free-form fields. Download records preserve the exact committed byte count and a reversible percent-encoded committed path, including symlink targets and delimiter-bearing filenames, without changing attachment transfer. Documents the schema in README.md and preserves JSON, human rendering, truncation, full-body selection, and retrieval behavior. Testing: focused Gmail thread tests and full make ci. Final standards/Fowler and exact-spec reviews: no findings. Closes #77