### PR TITLE
fix(sheets): make metadata plain output stable TSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,8 @@ gog sheets format <spreadsheetId> 'Sheet1!A1:B2' --format-json '{"textFormat":{"
 gog sheets create "My New Spreadsheet" --sheets "Sheet1,Sheet2"
 ```
 
+`gog sheets metadata <spreadsheetId> --plain` emits headerless TSV with columns `SPREADSHEET_ID`, `SPREADSHEET_TITLE`, `LOCALE`, `TIMEZONE`, `URL`, `SHEET_ID`, `SHEET_TITLE`, `ROWS`, and `COLUMNS`, in that order. It emits one row per sheet; a spreadsheet with no sheets emits one row with the four sheet fields empty.
+
 ### People
 
 ```bash

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -436,18 +436,6 @@ func (c *SheetsMetadataCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 func writeSheetsMetadataPlain(ctx context.Context, resp *sheets.Spreadsheet) error {
-	writeTableRow(ctx, os.Stdout, []string{
-		"SPREADSHEET_ID",
-		"SPREADSHEET_TITLE",
-		"LOCALE",
-		"TIMEZONE",
-		"URL",
-		"SHEET_ID",
-		"SHEET_TITLE",
-		"ROWS",
-		"COLUMNS",
-	})
-
 	title := ""
 	locale := ""
 	timeZone := ""

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -408,6 +408,10 @@ func (c *SheetsMetadataCmd) Run(ctx context.Context, flags *RootFlags) error {
 		})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		return writeSheetsMetadataPlain(ctx, resp)
+	}
+
 	u.Out().Printf("ID\t%s", resp.SpreadsheetId)
 	u.Out().Printf("Title\t%s", resp.Properties.Title)
 	u.Out().Printf("Locale\t%s", resp.Properties.Locale)
@@ -428,6 +432,72 @@ func (c *SheetsMetadataCmd) Run(ctx context.Context, flags *RootFlags) error {
 		)
 	}
 	_ = tw.Flush()
+	return nil
+}
+
+func writeSheetsMetadataPlain(ctx context.Context, resp *sheets.Spreadsheet) error {
+	writeTableRow(ctx, os.Stdout, []string{
+		"SPREADSHEET_ID",
+		"SPREADSHEET_TITLE",
+		"LOCALE",
+		"TIMEZONE",
+		"URL",
+		"SHEET_ID",
+		"SHEET_TITLE",
+		"ROWS",
+		"COLUMNS",
+	})
+
+	title := ""
+	locale := ""
+	timeZone := ""
+	if resp.Properties != nil {
+		title = resp.Properties.Title
+		locale = resp.Properties.Locale
+		timeZone = resp.Properties.TimeZone
+	}
+
+	if len(resp.Sheets) == 0 {
+		writeTableRow(ctx, os.Stdout, []string{
+			resp.SpreadsheetId,
+			title,
+			locale,
+			timeZone,
+			resp.SpreadsheetUrl,
+			"",
+			"",
+			"",
+			"",
+		})
+		return nil
+	}
+
+	for _, sheet := range resp.Sheets {
+		sheetID := ""
+		sheetTitle := ""
+		rows := ""
+		cols := ""
+		if sheet != nil && sheet.Properties != nil {
+			props := sheet.Properties
+			sheetID = fmt.Sprintf("%d", props.SheetId)
+			sheetTitle = props.Title
+			if props.GridProperties != nil {
+				rows = fmt.Sprintf("%d", props.GridProperties.RowCount)
+				cols = fmt.Sprintf("%d", props.GridProperties.ColumnCount)
+			}
+		}
+		writeTableRow(ctx, os.Stdout, []string{
+			resp.SpreadsheetId,
+			title,
+			locale,
+			timeZone,
+			resp.SpreadsheetUrl,
+			sheetID,
+			sheetTitle,
+			rows,
+			cols,
+		})
+	}
 	return nil
 }
 

--- a/internal/cmd/sheets_metadata_test.go
+++ b/internal/cmd/sheets_metadata_test.go
@@ -17,10 +17,6 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
-const (
-	sheetsMetadataPlainHeader = "SPREADSHEET_ID\tSPREADSHEET_TITLE\tLOCALE\tTIMEZONE\tURL\tSHEET_ID\tSHEET_TITLE\tROWS\tCOLUMNS"
-)
-
 func TestSheetsMetadataCmd_TextAndJSON(t *testing.T) {
 	origNew := newSheetsService
 	t.Cleanup(func() { newSheetsService = origNew })
@@ -152,7 +148,6 @@ func TestExecute_SheetsMetadata_PlainTSV(t *testing.T) {
 		})
 	})
 	wantPlain := strings.Join([]string{
-		sheetsMetadataPlainHeader,
 		"id1\tBudget Q1 2026\ten_US\tAmerica/Chicago\thttps://docs.google.com/spreadsheets/d/id1\t1\tIncome Main\t10\t5",
 		"id1\tBudget Q1 2026\ten_US\tAmerica/Chicago\thttps://docs.google.com/spreadsheets/d/id1\t2\tExpenses Ops\t20\t8",
 		"",
@@ -160,8 +155,8 @@ func TestExecute_SheetsMetadata_PlainTSV(t *testing.T) {
 	if plain != wantPlain {
 		t.Fatalf("plain output =\n%q\nwant\n%q", plain, wantPlain)
 	}
-	if strings.Contains(plain, "Sheets:") || strings.Contains(plain, "ID\tid1") {
-		t.Fatalf("plain output mixed human headings: %q", plain)
+	if strings.Contains(plain, "Sheets:") || strings.Contains(plain, "ID\tid1") || strings.HasPrefix(plain, "SPREADSHEET_ID\t") {
+		t.Fatalf("plain output included headings or key/value prelude: %q", plain)
 	}
 
 	jsonOut := captureStdout(t, func() {
@@ -201,9 +196,6 @@ func TestExecute_SheetsMetadata_PlainTSV(t *testing.T) {
 	})
 	if !strings.Contains(human, "ID\tid1") || !strings.Contains(human, "Sheets:") {
 		t.Fatalf("human output lost metadata layout: %q", human)
-	}
-	if strings.Contains(human, sheetsMetadataPlainHeader) {
-		t.Fatalf("human output used plain header: %q", human)
 	}
 }
 
@@ -248,7 +240,6 @@ func TestExecute_SheetsMetadata_PlainTSV_NoSheets(t *testing.T) {
 		})
 	})
 	wantPlain := strings.Join([]string{
-		sheetsMetadataPlainHeader,
 		"empty1\tEmpty\ten_GB\tUTC\thttps://docs.google.com/spreadsheets/d/empty1\t\t\t\t",
 		"",
 	}, "\n")

--- a/internal/cmd/sheets_metadata_test.go
+++ b/internal/cmd/sheets_metadata_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
+const (
+	sheetsMetadataPlainHeader = "SPREADSHEET_ID\tSPREADSHEET_TITLE\tLOCALE\tTIMEZONE\tURL\tSHEET_ID\tSHEET_TITLE\tROWS\tCOLUMNS"
+)
+
 func TestSheetsMetadataCmd_TextAndJSON(t *testing.T) {
 	origNew := newSheetsService
 	t.Cleanup(func() { newSheetsService = origNew })
@@ -95,5 +99,160 @@ func TestSheetsMetadataCmd_TextAndJSON(t *testing.T) {
 	}
 	if parsed.SpreadsheetID != "id1" || parsed.Title != "Budget" || len(parsed.Sheets) != 1 {
 		t.Fatalf("unexpected json: %#v", parsed)
+	}
+}
+
+func TestExecute_SheetsMetadata_PlainTSV(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+
+	const (
+		spreadsheetTitle = "Budget\tQ1\n2026"
+		sheetTitle1      = "Income\tMain"
+		sheetTitle2      = "Expenses\r\nOps"
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/v4/spreadsheets/id1") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId":  "id1",
+				"spreadsheetUrl": "https://docs.google.com/spreadsheets/d/id1",
+				"properties": map[string]any{
+					"title":    spreadsheetTitle,
+					"locale":   "en_US",
+					"timeZone": "America/Chicago",
+				},
+				"sheets": []map[string]any{
+					{"properties": map[string]any{"sheetId": 1, "title": sheetTitle1, "gridProperties": map[string]any{"rowCount": 10, "columnCount": 5}}},
+					{"properties": map[string]any{"sheetId": 2, "title": sheetTitle2, "gridProperties": map[string]any{"rowCount": 20, "columnCount": 8}}},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	plain := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "sheets", "metadata", "id1"}); err != nil {
+				t.Fatalf("Execute plain: %v", err)
+			}
+		})
+	})
+	wantPlain := strings.Join([]string{
+		sheetsMetadataPlainHeader,
+		"id1\tBudget Q1 2026\ten_US\tAmerica/Chicago\thttps://docs.google.com/spreadsheets/d/id1\t1\tIncome Main\t10\t5",
+		"id1\tBudget Q1 2026\ten_US\tAmerica/Chicago\thttps://docs.google.com/spreadsheets/d/id1\t2\tExpenses Ops\t20\t8",
+		"",
+	}, "\n")
+	if plain != wantPlain {
+		t.Fatalf("plain output =\n%q\nwant\n%q", plain, wantPlain)
+	}
+	if strings.Contains(plain, "Sheets:") || strings.Contains(plain, "ID\tid1") {
+		t.Fatalf("plain output mixed human headings: %q", plain)
+	}
+
+	jsonOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "sheets", "metadata", "id1"}); err != nil {
+				t.Fatalf("Execute json: %v", err)
+			}
+		})
+	})
+	var parsed struct {
+		SpreadsheetID string `json:"spreadsheetId"`
+		Title         string `json:"title"`
+		Locale        string `json:"locale"`
+		TimeZone      string `json:"timeZone"`
+		Sheets        []struct {
+			Properties struct {
+				Title string `json:"title"`
+			} `json:"properties"`
+		} `json:"sheets"`
+	}
+	if err := json.Unmarshal([]byte(jsonOut), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, jsonOut)
+	}
+	if parsed.SpreadsheetID != "id1" || parsed.Title != spreadsheetTitle || parsed.Locale != "en_US" || parsed.TimeZone != "America/Chicago" {
+		t.Fatalf("unexpected json identity: %#v", parsed)
+	}
+	if len(parsed.Sheets) != 2 || parsed.Sheets[0].Properties.Title != sheetTitle1 || parsed.Sheets[1].Properties.Title != sheetTitle2 {
+		t.Fatalf("JSON must preserve unsanitized sheet titles: %#v", parsed.Sheets)
+	}
+
+	human := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--account", "a@b.com", "sheets", "metadata", "id1"}); err != nil {
+				t.Fatalf("Execute human: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(human, "ID\tid1") || !strings.Contains(human, "Sheets:") {
+		t.Fatalf("human output lost metadata layout: %q", human)
+	}
+	if strings.Contains(human, sheetsMetadataPlainHeader) {
+		t.Fatalf("human output used plain header: %q", human)
+	}
+}
+
+func TestExecute_SheetsMetadata_PlainTSV_NoSheets(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/v4/spreadsheets/empty1") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId":  "empty1",
+				"spreadsheetUrl": "https://docs.google.com/spreadsheets/d/empty1",
+				"properties": map[string]any{
+					"title":    "Empty",
+					"locale":   "en_GB",
+					"timeZone": "UTC",
+				},
+				"sheets": []map[string]any{},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	plain := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "sheets", "metadata", "empty1"}); err != nil {
+				t.Fatalf("Execute plain: %v", err)
+			}
+		})
+	})
+	wantPlain := strings.Join([]string{
+		sheetsMetadataPlainHeader,
+		"empty1\tEmpty\ten_GB\tUTC\thttps://docs.google.com/spreadsheets/d/empty1\t\t\t\t",
+		"",
+	}, "\n")
+	if plain != wantPlain {
+		t.Fatalf("plain empty-sheets output =\n%q\nwant\n%q", plain, wantPlain)
 	}
 }


### PR DESCRIPTION
## Summary
- emit one literal TSV data row per sheet for `sheets metadata --plain`
- attach spreadsheet identity and properties to every tab row
- preserve spreadsheet metadata when no sheets are returned
- sanitize free-form titles while leaving human and JSON output unchanged
- omit headings, blank lines, aligned padding, and key/value preludes

## Testing
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" go test ./internal/cmd -run 'Test(SheetsMetadataCmd_TextAndJSON|Execute_SheetsMetadata_PlainTSV)'`
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci`

## Review
- Standards/Fowler: no hard violations; optional localized duplication noted and intentionally left explicit
- Exact spec: removed an initially transplanted schema header and added regression coverage for header-free output

Closes #84