### PR TITLE
fix(sheets): make batch reads valid TSV

### DIFF
--- a/internal/cmd/sheets_batch.go
+++ b/internal/cmd/sheets_batch.go
@@ -18,6 +18,36 @@ type SheetsBatchGetCmd struct {
 	Ranges        []string `arg:"" name:"ranges" help:"Ranges to read (e.g., Sheet1!A1:D10)"`
 }
 
+func writeSheetsValueRangesPlain(ctx context.Context, valueRanges []*sheets.ValueRange) {
+	if len(valueRanges) == 0 {
+		return
+	}
+	writeTableRow(ctx, os.Stdout, []string{"range", "row", "column", "value"})
+	for _, valueRange := range valueRanges {
+		if valueRange == nil {
+			continue
+		}
+		for majorIndex, majorValues := range valueRange.Values {
+			for minorIndex, cell := range majorValues {
+				row, column := majorIndex+1, minorIndex+1
+				if strings.EqualFold(valueRange.MajorDimension, "COLUMNS") {
+					row, column = minorIndex+1, majorIndex+1
+				}
+				value := ""
+				if cell != nil {
+					value = fmt.Sprintf("%v", cell)
+				}
+				writeTableRow(ctx, os.Stdout, []string{
+					valueRange.Range,
+					fmt.Sprintf("%d", row),
+					fmt.Sprintf("%d", column),
+					value,
+				})
+			}
+		}
+	}
+}
+
 func (c *SheetsBatchGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	account, err := requireAccount(flags)
 	if err != nil {
@@ -51,6 +81,10 @@ func (c *SheetsBatchGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"spreadsheetId": resp.SpreadsheetId,
 			"valueRanges":   resp.ValueRanges,
 		})
+	}
+	if outfmt.IsPlain(ctx) {
+		writeSheetsValueRangesPlain(ctx, resp.ValueRanges)
+		return nil
 	}
 
 	u := ui.FromContext(ctx)

--- a/internal/cmd/sheets_batch.go
+++ b/internal/cmd/sheets_batch.go
@@ -19,19 +19,16 @@ type SheetsBatchGetCmd struct {
 }
 
 func writeSheetsValueRangesPlain(ctx context.Context, valueRanges []*sheets.ValueRange) {
-	if len(valueRanges) == 0 {
-		return
-	}
-	writeTableRow(ctx, os.Stdout, []string{"range", "row", "column", "value"})
+	writeTableRow(ctx, os.Stdout, []string{"RANGE", "ROW_INDEX", "COLUMN_INDEX", "VALUE"})
 	for _, valueRange := range valueRanges {
 		if valueRange == nil {
 			continue
 		}
 		for majorIndex, majorValues := range valueRange.Values {
 			for minorIndex, cell := range majorValues {
-				row, column := majorIndex+1, minorIndex+1
+				row, column := majorIndex, minorIndex
 				if strings.EqualFold(valueRange.MajorDimension, "COLUMNS") {
-					row, column = minorIndex+1, majorIndex+1
+					row, column = minorIndex, majorIndex
 				}
 				value := ""
 				if cell != nil {

--- a/internal/cmd/sheets_gaps.go
+++ b/internal/cmd/sheets_gaps.go
@@ -460,6 +460,16 @@ func (c *SheetsValuesBatchGetByFilterCmd) Run(ctx context.Context, flags *RootFl
 		u.Err().Println("No data found")
 		return nil
 	}
+	if outfmt.IsPlain(ctx) {
+		valueRanges := make([]*sheets.ValueRange, 0, len(resp.ValueRanges))
+		for _, matchedValueRange := range resp.ValueRanges {
+			if matchedValueRange != nil && matchedValueRange.ValueRange != nil {
+				valueRanges = append(valueRanges, matchedValueRange.ValueRange)
+			}
+		}
+		writeSheetsValueRangesPlain(ctx, valueRanges)
+		return nil
+	}
 
 	for i, mvr := range resp.ValueRanges {
 		u.Out().Printf("Range %d:", i+1)

--- a/internal/cmd/sheets_gaps.go
+++ b/internal/cmd/sheets_gaps.go
@@ -456,10 +456,6 @@ func (c *SheetsValuesBatchGetByFilterCmd) Run(ctx context.Context, flags *RootFl
 		})
 	}
 
-	if len(resp.ValueRanges) == 0 {
-		u.Err().Println("No data found")
-		return nil
-	}
 	if outfmt.IsPlain(ctx) {
 		valueRanges := make([]*sheets.ValueRange, 0, len(resp.ValueRanges))
 		for _, matchedValueRange := range resp.ValueRanges {
@@ -468,6 +464,10 @@ func (c *SheetsValuesBatchGetByFilterCmd) Run(ctx context.Context, flags *RootFl
 			}
 		}
 		writeSheetsValueRangesPlain(ctx, valueRanges)
+		return nil
+	}
+	if len(resp.ValueRanges) == 0 {
+		u.Err().Println("No data found")
 		return nil
 	}
 

--- a/internal/cmd/sheets_tsv_test.go
+++ b/internal/cmd/sheets_tsv_test.go
@@ -14,20 +14,21 @@ import (
 
 const (
 	sheetsSafeTSV      = "tab value\tline feed\tcarriage return\tcrlf value\n"
-	sheetsBatchSafeTSV = "range\trow\tcolumn\tvalue\n" +
-		"Sheet1!A1:D1\t1\t1\ttab value\n" +
-		"Sheet1!A1:D1\t1\t2\tline feed\n" +
-		"Sheet1!A1:D1\t1\t3\tcarriage return\n" +
-		"Sheet1!A1:D1\t1\t4\tcrlf value\n" +
-		"Sheet2!B2:D4\t1\t1\tsecond\n" +
-		"Sheet2!B2:D4\t1\t2\t\n" +
-		"Sheet2!B2:D4\t1\t3\tthird\n" +
-		"Sheet2!B2:D4\t3\t1\tlast\n"
-	sheetsColumnMajorSafeTSV = "range\trow\tcolumn\tvalue\n" +
-		"Sheet3!A1:B2\t1\t1\ta\n" +
-		"Sheet3!A1:B2\t2\t1\tb\n" +
-		"Sheet3!A1:B2\t1\t2\tc\n" +
-		"Sheet3!A1:B2\t2\t2\td\n"
+	sheetsBatchHeader  = "RANGE\tROW_INDEX\tCOLUMN_INDEX\tVALUE\n"
+	sheetsBatchSafeTSV = sheetsBatchHeader +
+		"Sheet1!A1:D1\t0\t0\ttab value\n" +
+		"Sheet1!A1:D1\t0\t1\tline feed\n" +
+		"Sheet1!A1:D1\t0\t2\tcarriage return\n" +
+		"Sheet1!A1:D1\t0\t3\tcrlf value\n" +
+		"Sheet2!B2:D4\t0\t0\tsecond\n" +
+		"Sheet2!B2:D4\t0\t1\t\n" +
+		"Sheet2!B2:D4\t0\t2\tthird\n" +
+		"Sheet2!B2:D4\t2\t0\tlast\n"
+	sheetsColumnMajorSafeTSV = sheetsBatchHeader +
+		"Sheet3!A1:B2\t0\t0\ta\n" +
+		"Sheet3!A1:B2\t1\t0\tb\n" +
+		"Sheet3!A1:B2\t0\t1\tc\n" +
+		"Sheet3!A1:B2\t1\t1\td\n"
 )
 
 func TestSheetsValueReads_PlainTSVPreservesRows(t *testing.T) {
@@ -148,6 +149,55 @@ func TestSheetsValueReads_PlainTSVPreservesRows(t *testing.T) {
 			})
 			if out != tt.want {
 				t.Fatalf("plain output = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestSheetsBatchValueReads_PlainEmptyResultsPrintHeaderOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{"valueRanges": []any{}}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	original := newSheetsService
+	t.Cleanup(func() { newSheetsService = original })
+	service, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) {
+		return service, nil
+	}
+
+	commands := [][]string{
+		{"sheets", "batch-get", "s1", "Sheet1!A1"},
+		{"sheets", "batch-get-by-filter", "s1", "--filters-json", `[{"a1Range":"Sheet1!A1"}]`},
+	}
+	for _, command := range commands {
+		name := command[1]
+		t.Run(name, func(t *testing.T) {
+			var stderr string
+			stdout := captureStdout(t, func() {
+				stderr = captureStderr(t, func() {
+					args := append([]string{"--plain", "--account", "a@b.com"}, command...)
+					if err := Execute(args); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+			if stdout != sheetsBatchHeader {
+				t.Fatalf("plain output = %q, want %q", stdout, sheetsBatchHeader)
+			}
+			if stderr != "" {
+				t.Fatalf("plain stderr = %q, want empty", stderr)
 			}
 		})
 	}

--- a/internal/cmd/sheets_tsv_test.go
+++ b/internal/cmd/sheets_tsv_test.go
@@ -12,10 +12,40 @@ import (
 	"google.golang.org/api/sheets/v4"
 )
 
-const sheetsSafeTSV = "tab value\tline feed\tcarriage return\tcrlf value\n"
+const (
+	sheetsSafeTSV      = "tab value\tline feed\tcarriage return\tcrlf value\n"
+	sheetsBatchSafeTSV = "range\trow\tcolumn\tvalue\n" +
+		"Sheet1!A1:D1\t1\t1\ttab value\n" +
+		"Sheet1!A1:D1\t1\t2\tline feed\n" +
+		"Sheet1!A1:D1\t1\t3\tcarriage return\n" +
+		"Sheet1!A1:D1\t1\t4\tcrlf value\n" +
+		"Sheet2!B2:D4\t1\t1\tsecond\n" +
+		"Sheet2!B2:D4\t1\t2\t\n" +
+		"Sheet2!B2:D4\t1\t3\tthird\n" +
+		"Sheet2!B2:D4\t3\t1\tlast\n"
+	sheetsColumnMajorSafeTSV = "range\trow\tcolumn\tvalue\n" +
+		"Sheet3!A1:B2\t1\t1\ta\n" +
+		"Sheet3!A1:B2\t2\t1\tb\n" +
+		"Sheet3!A1:B2\t1\t2\tc\n" +
+		"Sheet3!A1:B2\t2\t2\td\n"
+)
 
 func TestSheetsValueReads_PlainTSVPreservesRows(t *testing.T) {
 	values := [][]any{{"tab\tvalue", "line\nfeed", "carriage\rreturn", "crlf\r\nvalue"}}
+	valueRanges := []map[string]any{
+		{
+			"range":  "Sheet1!A1:D1",
+			"values": values,
+		},
+		{
+			"range": "Sheet2!B2:D4",
+			"values": [][]any{
+				{"second", nil, "third"},
+				{},
+				{"last"},
+			},
+		},
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -24,20 +54,31 @@ func TestSheetsValueReads_PlainTSVPreservesRows(t *testing.T) {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/values:batchGet"):
 			response = map[string]any{
 				"spreadsheetId": "s1",
-				"valueRanges": []map[string]any{{
-					"range":  "Sheet1!A1:D1",
-					"values": values,
-				}},
+				"valueRanges":   valueRanges,
 			}
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/values:batchGetByDataFilter"):
-			response = map[string]any{
-				"valueRanges": []map[string]any{{
-					"valueRange": map[string]any{
-						"range":  "Sheet1!A1:D1",
-						"values": values,
-					},
-				}},
+			var request struct {
+				MajorDimension string `json:"majorDimension"`
 			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode request: %v", err)
+				return
+			}
+			if request.MajorDimension == "COLUMNS" {
+				response = map[string]any{"valueRanges": []map[string]any{{
+					"valueRange": map[string]any{
+						"range":          "Sheet3!A1:B2",
+						"majorDimension": "COLUMNS",
+						"values":         [][]any{{"a", "b"}, {"c", "d"}},
+					},
+				}}}
+				break
+			}
+			matchedValueRanges := make([]map[string]any, len(valueRanges))
+			for i, valueRange := range valueRanges {
+				matchedValueRanges[i] = map[string]any{"valueRange": valueRange}
+			}
+			response = map[string]any{"valueRanges": matchedValueRanges}
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/values/"):
 			response = map[string]any{
 				"range":  "Sheet1!A1:D1",
@@ -71,18 +112,27 @@ func TestSheetsValueReads_PlainTSVPreservesRows(t *testing.T) {
 	tests := []struct {
 		name    string
 		command []string
+		want    string
 	}{
 		{
 			name:    "single range",
 			command: []string{"sheets", "get", "s1", "Sheet1!A1:D1"},
+			want:    sheetsSafeTSV,
 		},
 		{
 			name:    "batch ranges",
-			command: []string{"sheets", "batch-get", "s1", "Sheet1!A1:D1"},
+			command: []string{"sheets", "batch-get", "s1", "Sheet1!A1:D1", "Sheet2!B2:D4"},
+			want:    sheetsBatchSafeTSV,
 		},
 		{
 			name:    "filter ranges",
-			command: []string{"sheets", "batch-get-by-filter", "s1", "--filters-json", `[{"a1Range":"Sheet1!A1:D1"}]`},
+			command: []string{"sheets", "batch-get-by-filter", "s1", "--filters-json", `[{"a1Range":"Sheet1!A1:D1"},{"a1Range":"Sheet2!B2:D4"}]`},
+			want:    sheetsBatchSafeTSV,
+		},
+		{
+			name:    "column-major filter range",
+			command: []string{"sheets", "batch-get-by-filter", "s1", "--filters-json", `[{"a1Range":"Sheet3!A1:B2"}]`, "--major-dimension", "COLUMNS"},
+			want:    sheetsColumnMajorSafeTSV,
 		},
 	}
 
@@ -96,8 +146,8 @@ func TestSheetsValueReads_PlainTSVPreservesRows(t *testing.T) {
 					}
 				})
 			})
-			if !strings.HasSuffix(out, sheetsSafeTSV) {
-				t.Fatalf("plain output = %q, want sanitized row suffix %q", out, sheetsSafeTSV)
+			if out != tt.want {
+				t.Fatalf("plain output = %q, want %q", out, tt.want)
 			}
 		})
 	}

--- a/internal/cmd/sheets_tsv_test.go
+++ b/internal/cmd/sheets_tsv_test.go
@@ -31,6 +31,23 @@ const (
 		"Sheet3!A1:B2\t1\t1\td\n"
 )
 
+func installSheetsTestService(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	original := newSheetsService
+	t.Cleanup(func() { newSheetsService = original })
+	service, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) {
+		return service, nil
+	}
+}
+
 func TestSheetsValueReads_PlainTSVPreservesRows(t *testing.T) {
 	values := [][]any{{"tab\tvalue", "line\nfeed", "carriage\rreturn", "crlf\r\nvalue"}}
 	valueRanges := []map[string]any{
@@ -96,19 +113,7 @@ func TestSheetsValueReads_PlainTSVPreservesRows(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	original := newSheetsService
-	t.Cleanup(func() { newSheetsService = original })
-	service, err := sheets.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newSheetsService = func(context.Context, string) (*sheets.Service, error) {
-		return service, nil
-	}
+	installSheetsTestService(t, srv)
 
 	tests := []struct {
 		name    string
@@ -163,19 +168,7 @@ func TestSheetsBatchValueReads_PlainEmptyResultsPrintHeaderOnly(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	original := newSheetsService
-	t.Cleanup(func() { newSheetsService = original })
-	service, err := sheets.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newSheetsService = func(context.Context, string) (*sheets.Service, error) {
-		return service, nil
-	}
+	installSheetsTestService(t, srv)
 
 	commands := [][]string{
 		{"sheets", "batch-get", "s1", "Sheet1!A1"},


### PR DESCRIPTION
Summary: emit one positional TSV stream for Sheets batch and filter-batch reads in plain mode; preserve zero-based row and column positions, range identity, sparse values, and escaped field boundaries; emit the exact header-only schema for empty results while leaving JSON and default output unchanged. Testing: focused Sheets tests and PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci. Closes #83. Generated with Claude Code: https://claude.com/claude-code