### PR TITLE
fix(sheets): emit stable plain TSV receipts for structural mutations

### DIFF
--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -483,6 +483,10 @@ func (c *SheetsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"spreadsheetUrl": resp.SpreadsheetUrl,
 		})
 	}
+	if outfmt.IsPlain(ctx) {
+		writeSheetsStructuralPlain(ctx, "create", resp.SpreadsheetId, "", resp.Properties.Title, "", "ok")
+		return nil
+	}
 
 	u.Out().Printf("Created spreadsheet: %s", resp.Properties.Title)
 	u.Out().Printf("ID: %s", resp.SpreadsheetId)

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -484,7 +484,7 @@ func (c *SheetsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		writeSheetsStructuralPlain(ctx, "create", resp.SpreadsheetId, "", resp.Properties.Title, "", "ok")
+		writeSheetsStructuralPlain(ctx, "create", resp.SpreadsheetId, "", resp.Properties.Title, "")
 		return nil
 	}
 

--- a/internal/cmd/sheets_format.go
+++ b/internal/cmd/sheets_format.go
@@ -104,7 +104,7 @@ func (c *SheetsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if gridRange != nil {
 			sheetID = fmt.Sprintf("%d", gridRange.SheetId)
 		}
-		writeSheetsStructuralPlain(ctx, "format", spreadsheetID, sheetID, "", rangeSpec, "ok")
+		writeSheetsStructuralPlain(ctx, "format", spreadsheetID, sheetID, "", rangeSpec)
 		return nil
 	}
 

--- a/internal/cmd/sheets_format.go
+++ b/internal/cmd/sheets_format.go
@@ -99,6 +99,14 @@ func (c *SheetsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"fields": formatFields,
 		})
 	}
+	if outfmt.IsPlain(ctx) {
+		sheetID := ""
+		if gridRange != nil {
+			sheetID = fmt.Sprintf("%d", gridRange.SheetId)
+		}
+		writeSheetsStructuralPlain(ctx, "format", spreadsheetID, sheetID, "", rangeSpec, "ok")
+		return nil
+	}
 
 	u.Out().Printf("Formatted %s", rangeSpec)
 	return nil

--- a/internal/cmd/sheets_gaps.go
+++ b/internal/cmd/sheets_gaps.go
@@ -274,6 +274,10 @@ func (c *SheetsCopyToCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"sheetType": resp.SheetType,
 		})
 	}
+	if outfmt.IsPlain(ctx) {
+		writeSheetsStructuralPlain(ctx, "copy-to", destID, fmt.Sprintf("%d", resp.SheetId), resp.Title, "", "ok")
+		return nil
+	}
 
 	u.Out().Printf("Sheet ID\t%d", resp.SheetId)
 	u.Out().Printf("Title\t%s", resp.Title)

--- a/internal/cmd/sheets_gaps.go
+++ b/internal/cmd/sheets_gaps.go
@@ -275,7 +275,7 @@ func (c *SheetsCopyToCmd) Run(ctx context.Context, flags *RootFlags) error {
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		writeSheetsStructuralPlain(ctx, "copy-to", destID, fmt.Sprintf("%d", resp.SheetId), resp.Title, "", "ok")
+		writeSheetsStructuralPlain(ctx, "copy-to", destID, fmt.Sprintf("%d", resp.SheetId), resp.Title, "")
 		return nil
 	}
 

--- a/internal/cmd/sheets_structural_plain.go
+++ b/internal/cmd/sheets_structural_plain.go
@@ -7,9 +7,9 @@ import (
 
 // writeSheetsStructuralPlain emits one TSV receipt row for Sheets structural mutations.
 // Header: ACTION SPREADSHEET_ID SHEET_ID TITLE RANGE STATUS
-func writeSheetsStructuralPlain(ctx context.Context, action, spreadsheetID, sheetID, title, rangeSpec, status string) {
+func writeSheetsStructuralPlain(ctx context.Context, action, spreadsheetID, sheetID, title, rangeSpec string) {
 	w, flush := tableWriter(ctx)
 	defer flush()
 	fmt.Fprintln(w, "ACTION\tSPREADSHEET_ID\tSHEET_ID\tTITLE\tRANGE\tSTATUS")
-	writeTableRow(ctx, w, []string{action, spreadsheetID, sheetID, title, rangeSpec, status})
+	writeTableRow(ctx, w, []string{action, spreadsheetID, sheetID, title, rangeSpec, "ok"})
 }

--- a/internal/cmd/sheets_structural_plain.go
+++ b/internal/cmd/sheets_structural_plain.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+)
+
+// writeSheetsStructuralPlain emits one TSV receipt row for Sheets structural mutations.
+// Header: ACTION SPREADSHEET_ID SHEET_ID TITLE RANGE STATUS
+func writeSheetsStructuralPlain(ctx context.Context, action, spreadsheetID, sheetID, title, rangeSpec, status string) {
+	w, flush := tableWriter(ctx)
+	defer flush()
+	fmt.Fprintln(w, "ACTION\tSPREADSHEET_ID\tSHEET_ID\tTITLE\tRANGE\tSTATUS")
+	writeTableRow(ctx, w, []string{action, spreadsheetID, sheetID, title, rangeSpec, status})
+}

--- a/internal/cmd/sheets_structural_plain.go
+++ b/internal/cmd/sheets_structural_plain.go
@@ -1,15 +1,13 @@
 package cmd
 
-import (
-	"context"
-	"fmt"
-)
+import "context"
 
 // writeSheetsStructuralPlain emits one TSV receipt row for Sheets structural mutations.
-// Header: ACTION SPREADSHEET_ID SHEET_ID TITLE RANGE STATUS
+// Header: ACTION SPREADSHEET_ID SHEET_ID TITLE RANGE STATUS.
+// Actions are the lowercase machine values create, format, copy-to, add, update, and delete.
 func writeSheetsStructuralPlain(ctx context.Context, action, spreadsheetID, sheetID, title, rangeSpec string) {
-	w, flush := tableWriter(ctx)
-	defer flush()
-	fmt.Fprintln(w, "ACTION\tSPREADSHEET_ID\tSHEET_ID\tTITLE\tRANGE\tSTATUS")
-	writeTableRow(ctx, w, []string{action, spreadsheetID, sheetID, title, rangeSpec, "ok"})
+	writePlainReceipt(ctx,
+		[]string{"ACTION", "SPREADSHEET_ID", "SHEET_ID", "TITLE", "RANGE", "STATUS"},
+		[]string{action, spreadsheetID, sheetID, title, rangeSpec, "ok"},
+	)
 }

--- a/internal/cmd/sheets_structural_plain_test.go
+++ b/internal/cmd/sheets_structural_plain_test.go
@@ -153,7 +153,7 @@ func TestSheetsStructuralMutations_PlainReceipts(t *testing.T) {
 		{
 			name: "sheet delete",
 			args: []string{
-				"--plain", "--account", "a@b.com",
+				"--plain", "--force", "--account", "a@b.com",
 				"sheets", "sheet", "delete", "ss-tabs",
 				"--sheet-id", "55",
 			},

--- a/internal/cmd/sheets_structural_plain_test.go
+++ b/internal/cmd/sheets_structural_plain_test.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+)
+
+const sheetsStructuralPlainHeader = "ACTION\tSPREADSHEET_ID\tSHEET_ID\tTITLE\tRANGE\tSTATUS\n"
+
+func TestSheetsStructuralMutations_PlainReceipts(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(path, "/v4/spreadsheets"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId":  "ss-create",
+				"spreadsheetUrl": "http://example.com/ss-create",
+				"properties":     map[string]any{"title": "Budget 2026"},
+			})
+			return
+
+		case r.Method == http.MethodGet && strings.Contains(path, "/v4/spreadsheets/ss-format"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId": "ss-format",
+				"sheets": []map[string]any{
+					{"properties": map[string]any{"sheetId": 42, "title": "Sheet1"}},
+				},
+			})
+			return
+
+		case r.Method == http.MethodPost && strings.Contains(path, "/v4/spreadsheets/ss-format:batchUpdate"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"spreadsheetId": "ss-format", "replies": []any{map[string]any{}}})
+			return
+
+		case r.Method == http.MethodPost && strings.Contains(path, "/sheets/7:copyTo"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sheetId": 99,
+				"title":   "Copied Tab",
+				"index":   1,
+			})
+			return
+
+		case r.Method == http.MethodPost && strings.Contains(path, "/v4/spreadsheets/ss-tabs:batchUpdate"):
+			var req sheets.BatchUpdateSpreadsheetRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode batchUpdate: %v", err)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			if len(req.Requests) != 1 {
+				t.Errorf("expected 1 request, got %d", len(req.Requests))
+			}
+			switch {
+			case req.Requests[0].AddSheet != nil:
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"spreadsheetId": "ss-tabs",
+					"replies": []map[string]any{{
+						"addSheet": map[string]any{
+							"properties": map[string]any{
+								"sheetId": 123,
+								"title":   req.Requests[0].AddSheet.Properties.Title,
+							},
+						},
+					}},
+				})
+			case req.Requests[0].DeleteSheet != nil:
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"spreadsheetId": "ss-tabs",
+					"replies":       []map[string]any{{}},
+				})
+			case req.Requests[0].UpdateSheetProperties != nil:
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"spreadsheetId": "ss-tabs",
+					"replies":       []map[string]any{{}},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+			return
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "create",
+			args: []string{"--plain", "--account", "a@b.com", "sheets", "create", "Budget 2026"},
+			want: sheetsStructuralPlainHeader + "create\tss-create\t\tBudget 2026\t\tok\n",
+		},
+		{
+			name: "format",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "format", "ss-format", "Sheet1!B2:C3",
+				"--format-json", `{"textFormat":{"bold":true}}`,
+				"--format-fields", "textFormat.bold",
+			},
+			want: sheetsStructuralPlainHeader + "format\tss-format\t42\t\tSheet1!B2:C3\tok\n",
+		},
+		{
+			name: "copy-to",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "copy-to", "ss-source", "7",
+				"--destination-spreadsheet-id", "ss-dest",
+			},
+			want: sheetsStructuralPlainHeader + "copy-to\tss-dest\t99\tCopied Tab\t\tok\n",
+		},
+		{
+			name: "sheet add",
+			args: []string{"--plain", "--account", "a@b.com", "sheets", "sheet", "add", "ss-tabs", "--title", "NewTab"},
+			want: sheetsStructuralPlainHeader + "add\tss-tabs\t123\tNewTab\t\tok\n",
+		},
+		{
+			name: "sheet update",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "sheet", "update", "ss-tabs",
+				"--sheet-id", "55",
+				"--title", "Renamed",
+			},
+			want: sheetsStructuralPlainHeader + "update\tss-tabs\t55\tRenamed\t\tok\n",
+		},
+		{
+			name: "sheet delete",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "sheet", "delete", "ss-tabs",
+				"--sheet-id", "55",
+			},
+			want: sheetsStructuralPlainHeader + "delete\tss-tabs\t55\t\t\tok\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				_ = captureStderr(t, func() {
+					if err := Execute(tt.args); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+			if out != tt.want {
+				t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", tt.want, out)
+			}
+			if strings.Contains(out, "Created ") ||
+				strings.Contains(out, "Formatted ") ||
+				strings.Contains(out, "Added sheet") ||
+				strings.Contains(out, "Updated sheet") ||
+				strings.Contains(out, "Deleted sheet") {
+				t.Fatalf("plain stdout contains prose: %q", out)
+			}
+		})
+	}
+}

--- a/internal/cmd/sheets_tabs.go
+++ b/internal/cmd/sheets_tabs.go
@@ -75,6 +75,15 @@ func (c *SheetsSheetAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 		return outfmt.WriteJSON(os.Stdout, out)
 	}
+	if outfmt.IsPlain(ctx) {
+		sheetID, title := "", ""
+		if addedProps != nil {
+			sheetID = fmt.Sprintf("%d", addedProps.SheetId)
+			title = addedProps.Title
+		}
+		writeSheetsStructuralPlain(ctx, "add", resp.SpreadsheetId, sheetID, title, "", "ok")
+		return nil
+	}
 
 	u := ui.FromContext(ctx)
 	if addedProps != nil {
@@ -126,6 +135,10 @@ func (c *SheetsSheetDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 			"spreadsheetId":  resp.SpreadsheetId,
 			"deletedSheetId": c.SheetID,
 		})
+	}
+	if outfmt.IsPlain(ctx) {
+		writeSheetsStructuralPlain(ctx, "delete", resp.SpreadsheetId, fmt.Sprintf("%d", c.SheetID), "", "", "ok")
+		return nil
 	}
 
 	u := ui.FromContext(ctx)
@@ -204,6 +217,10 @@ func (c *SheetsSheetUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 			"sheetId":       c.SheetID,
 			"updatedFields": fields,
 		})
+	}
+	if outfmt.IsPlain(ctx) {
+		writeSheetsStructuralPlain(ctx, "update", resp.SpreadsheetId, fmt.Sprintf("%d", c.SheetID), strings.TrimSpace(c.Title), "", "ok")
+		return nil
 	}
 
 	u := ui.FromContext(ctx)

--- a/internal/cmd/sheets_tabs.go
+++ b/internal/cmd/sheets_tabs.go
@@ -81,7 +81,7 @@ func (c *SheetsSheetAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 			sheetID = fmt.Sprintf("%d", addedProps.SheetId)
 			title = addedProps.Title
 		}
-		writeSheetsStructuralPlain(ctx, "add", resp.SpreadsheetId, sheetID, title, "", "ok")
+		writeSheetsStructuralPlain(ctx, "add", resp.SpreadsheetId, sheetID, title, "")
 		return nil
 	}
 
@@ -137,7 +137,7 @@ func (c *SheetsSheetDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		writeSheetsStructuralPlain(ctx, "delete", resp.SpreadsheetId, fmt.Sprintf("%d", c.SheetID), "", "", "ok")
+		writeSheetsStructuralPlain(ctx, "delete", resp.SpreadsheetId, fmt.Sprintf("%d", c.SheetID), "", "")
 		return nil
 	}
 
@@ -219,7 +219,7 @@ func (c *SheetsSheetUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		writeSheetsStructuralPlain(ctx, "update", resp.SpreadsheetId, fmt.Sprintf("%d", c.SheetID), strings.TrimSpace(c.Title), "", "ok")
+		writeSheetsStructuralPlain(ctx, "update", resp.SpreadsheetId, fmt.Sprintf("%d", c.SheetID), strings.TrimSpace(c.Title), "")
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- emit a fixed ACTION/SPREADSHEET_ID/SHEET_ID/TITLE/RANGE/STATUS TSV receipt for Sheets create, format, copy-to, and sheet-tab add/update/delete under --plain
- preserve JSON, human output, mutation behavior, and deletion confirmation policy
- cover every structural mutation with focused receipt tests

## Testing
- PATH="$HOME/.local/go-sdk/go/bin:$PATH" go test ./internal/cmd -run 'TestSheetsStructuralMutations_PlainReceipts' -count=1
- PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci

Closes #85

Issue #86 depends on this PR merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)