### PR TITLE
fix(people): emit stable plain mutation receipts

### DIFF
--- a/internal/cmd/people_batch.go
+++ b/internal/cmd/people_batch.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 
 	"google.golang.org/api/people/v1"
@@ -98,6 +100,16 @@ func (c *ContactsBatchCreateCmd) Run(ctx context.Context, flags *RootFlags) erro
 			"createdContacts": resp.CreatedPeople,
 			"count":           len(resp.CreatedPeople),
 		})
+	}
+
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		writeTableRow(ctx, w, []string{"REQUEST_KEY", "RESOURCE", "NAME", "EMAIL", "STATUS", "ERROR"})
+		for i, r := range resp.CreatedPeople {
+			writePeopleBatchPlainRow(ctx, w, strconv.Itoa(i), r)
+		}
+		return nil
 	}
 
 	if len(resp.CreatedPeople) == 0 {
@@ -242,6 +254,22 @@ func (c *ContactsBatchUpdateCmd) Run(ctx context.Context, flags *RootFlags) erro
 		})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		writeTableRow(ctx, w, []string{"REQUEST_KEY", "RESOURCE", "NAME", "EMAIL", "STATUS", "ERROR"})
+		keys := make([]string, 0, len(resp.UpdateResult))
+		for key := range resp.UpdateResult {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			result := resp.UpdateResult[key]
+			writePeopleBatchPlainRow(ctx, w, key, &result)
+		}
+		return nil
+	}
+
 	u.Out().Printf("Updated %d contact(s)", len(contactsMap))
 	return nil
 }
@@ -329,6 +357,28 @@ func (c *ContactsBatchGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		)
 	}
 	return nil
+}
+
+func writePeopleBatchPlainRow(ctx context.Context, w io.Writer, requestKey string, r *people.PersonResponse) {
+	resource := ""
+	name := ""
+	email := ""
+	status := "OK"
+	errMsg := ""
+
+	if r != nil {
+		if r.Person != nil {
+			resource = r.Person.ResourceName
+			name = primaryName(r.Person)
+			email = primaryEmail(r.Person)
+		}
+		if r.Status != nil && r.Status.Code != 0 {
+			status = "ERROR"
+			errMsg = r.Status.Message
+		}
+	}
+
+	writeTableRow(ctx, w, []string{requestKey, resource, name, email, status, errMsg})
 }
 
 // readContactsJSON reads JSON input from either raw string or file path.

--- a/internal/cmd/people_batch.go
+++ b/internal/cmd/people_batch.go
@@ -106,8 +106,12 @@ func (c *ContactsBatchCreateCmd) Run(ctx context.Context, flags *RootFlags) erro
 		w, flush := tableWriter(ctx)
 		defer flush()
 		writeTableRow(ctx, w, []string{"REQUEST_KEY", "RESOURCE", "NAME", "EMAIL", "STATUS", "ERROR"})
-		for i, r := range resp.CreatedPeople {
-			writePeopleBatchPlainRow(ctx, w, strconv.Itoa(i), r)
+		for i, contact := range contactsToCreate {
+			var result *people.PersonResponse
+			if i < len(resp.CreatedPeople) {
+				result = resp.CreatedPeople[i]
+			}
+			writePeopleBatchPlainRow(ctx, w, strconv.Itoa(i), result, contact.ContactPerson, "")
 		}
 		return nil
 	}
@@ -258,14 +262,19 @@ func (c *ContactsBatchUpdateCmd) Run(ctx context.Context, flags *RootFlags) erro
 		w, flush := tableWriter(ctx)
 		defer flush()
 		writeTableRow(ctx, w, []string{"REQUEST_KEY", "RESOURCE", "NAME", "EMAIL", "STATUS", "ERROR"})
-		keys := make([]string, 0, len(resp.UpdateResult))
-		for key := range resp.UpdateResult {
+		keys := make([]string, 0, len(contactsMap))
+		for key := range contactsMap {
 			keys = append(keys, key)
 		}
 		sort.Strings(keys)
 		for _, key := range keys {
-			result := resp.UpdateResult[key]
-			writePeopleBatchPlainRow(ctx, w, key, &result)
+			contact := contactsMap[key]
+			result, ok := resp.UpdateResult[key]
+			if ok {
+				writePeopleBatchPlainRow(ctx, w, key, &result, &contact, key)
+				continue
+			}
+			writePeopleBatchPlainRow(ctx, w, key, nil, &contact, key)
 		}
 		return nil
 	}
@@ -359,18 +368,28 @@ func (c *ContactsBatchGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	return nil
 }
 
-func writePeopleBatchPlainRow(ctx context.Context, w io.Writer, requestKey string, r *people.PersonResponse) {
+func writePeopleBatchPlainRow(ctx context.Context, w io.Writer, requestKey string, r *people.PersonResponse, fallbackPerson *people.Person, fallbackResource string) {
 	resource := ""
 	name := ""
 	email := ""
 	status := "OK"
 	errMsg := ""
 
-	if r != nil {
+	if r == nil {
+		resource = fallbackResource
+		name = primaryName(fallbackPerson)
+		email = primaryEmail(fallbackPerson)
+	} else {
 		if r.Person != nil {
-			resource = r.Person.ResourceName
-			name = primaryName(r.Person)
-			email = primaryEmail(r.Person)
+			if r.Person.ResourceName != "" {
+				resource = r.Person.ResourceName
+			}
+			if responseName := primaryName(r.Person); responseName != "" {
+				name = responseName
+			}
+			if responseEmail := primaryEmail(r.Person); responseEmail != "" {
+				email = responseEmail
+			}
 		}
 		if r.Status != nil && r.Status.Code != 0 {
 			status = "ERROR"

--- a/internal/cmd/people_batch_test.go
+++ b/internal/cmd/people_batch_test.go
@@ -648,7 +648,8 @@ func TestContactsBatchUpdate_PlainEmptyResponseStillEmitsRequestRow(t *testing.T
 		}
 	})
 
-	want := "REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\npeople/1\tpeople/1\tA\t\tOK\t\n"
+	resource := "people/1"
+	want := "REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\n" + resource + "\t" + resource + "\tA\t\tOK\t\n"
 	if out != want {
 		t.Fatalf("plain update output with empty response = %q, want %q", out, want)
 	}

--- a/internal/cmd/people_batch_test.go
+++ b/internal/cmd/people_batch_test.go
@@ -466,9 +466,6 @@ func TestContactsBatchGet(t *testing.T) {
 }
 
 func TestContactsBatchCreate_PlainTSV(t *testing.T) {
-	origNew := newPeopleContactsService
-	t.Cleanup(func() { newPeopleContactsService = origNew })
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/people:batchCreateContacts" {
 			http.NotFound(w, r)
@@ -497,17 +494,7 @@ func TestContactsBatchCreate_PlainTSV(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
-	t.Cleanup(srv.Close)
-
-	svc, err := people.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+	usePeopleContactsTestServer(t, srv)
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
@@ -532,24 +519,11 @@ func TestContactsBatchCreate_PlainTSV(t *testing.T) {
 }
 
 func TestContactsBatchCreate_PlainEmptyEmitsHeaderOnly(t *testing.T) {
-	origNew := newPeopleContactsService
-	t.Cleanup(func() { newPeopleContactsService = origNew })
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(&people.BatchCreateContactsResponse{CreatedPeople: []*people.PersonResponse{}})
 	}))
-	t.Cleanup(srv.Close)
-
-	svc, err := people.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+	usePeopleContactsTestServer(t, srv)
 
 	out := captureStdout(t, func() {
 		stderr := captureStderr(t, func() {
@@ -573,9 +547,6 @@ func TestContactsBatchCreate_PlainEmptyEmitsHeaderOnly(t *testing.T) {
 }
 
 func TestContactsBatchCreate_HumanStillPrintsCount(t *testing.T) {
-	origNew := newPeopleContactsService
-	t.Cleanup(func() { newPeopleContactsService = origNew })
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := &people.BatchCreateContactsResponse{
 			CreatedPeople: []*people.PersonResponse{
@@ -585,17 +556,7 @@ func TestContactsBatchCreate_HumanStillPrintsCount(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
-	t.Cleanup(srv.Close)
-
-	svc, err := people.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+	usePeopleContactsTestServer(t, srv)
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
@@ -617,9 +578,6 @@ func TestContactsBatchCreate_HumanStillPrintsCount(t *testing.T) {
 }
 
 func TestContactsBatchUpdate_PlainTSV(t *testing.T) {
-	origNew := newPeopleContactsService
-	t.Cleanup(func() { newPeopleContactsService = origNew })
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/people:batchUpdateContacts" {
 			http.NotFound(w, r)
@@ -644,17 +602,7 @@ func TestContactsBatchUpdate_PlainTSV(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
-	t.Cleanup(srv.Close)
-
-	svc, err := people.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+	usePeopleContactsTestServer(t, srv)
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
@@ -679,24 +627,11 @@ func TestContactsBatchUpdate_PlainTSV(t *testing.T) {
 }
 
 func TestContactsBatchUpdate_PlainEmptyEmitsHeaderOnly(t *testing.T) {
-	origNew := newPeopleContactsService
-	t.Cleanup(func() { newPeopleContactsService = origNew })
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(&people.BatchUpdateContactsResponse{UpdateResult: map[string]people.PersonResponse{}})
 	}))
-	t.Cleanup(srv.Close)
-
-	svc, err := people.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+	usePeopleContactsTestServer(t, srv)
 
 	out := captureStdout(t, func() {
 		stderr := captureStderr(t, func() {
@@ -720,9 +655,6 @@ func TestContactsBatchUpdate_PlainEmptyEmitsHeaderOnly(t *testing.T) {
 }
 
 func TestContactsBatchUpdate_HumanStillPrintsCount(t *testing.T) {
-	origNew := newPeopleContactsService
-	t.Cleanup(func() { newPeopleContactsService = origNew })
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := &people.BatchUpdateContactsResponse{
 			UpdateResult: map[string]people.PersonResponse{
@@ -732,17 +664,7 @@ func TestContactsBatchUpdate_HumanStillPrintsCount(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
-	t.Cleanup(srv.Close)
-
-	svc, err := people.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+	usePeopleContactsTestServer(t, srv)
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
@@ -758,4 +680,24 @@ func TestContactsBatchUpdate_HumanStillPrintsCount(t *testing.T) {
 	if out != "Updated 1 contact(s)\n" {
 		t.Fatalf("human update output = %q, want count prose", out)
 	}
+}
+
+func usePeopleContactsTestServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+
+	origNew := newPeopleContactsService
+	t.Cleanup(func() {
+		newPeopleContactsService = origNew
+		srv.Close()
+	})
+
+	svc, err := people.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
 }

--- a/internal/cmd/people_batch_test.go
+++ b/internal/cmd/people_batch_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"google.golang.org/api/option"
@@ -461,5 +462,299 @@ func TestContactsBatchGet(t *testing.T) {
 				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestContactsBatchCreate_PlainTSV(t *testing.T) {
+	origNew := newPeopleContactsService
+	t.Cleanup(func() { newPeopleContactsService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/people:batchCreateContacts" {
+			http.NotFound(w, r)
+			return
+		}
+		resp := &people.BatchCreateContactsResponse{
+			CreatedPeople: []*people.PersonResponse{
+				{
+					Person: &people.Person{
+						ResourceName:   "people/1",
+						Names:          []*people.Name{{DisplayName: "John\tDoe\nNorth"}},
+						EmailAddresses: []*people.EmailAddress{{Value: "john@example.com"}},
+					},
+				},
+				{
+					Status: &people.Status{Code: 3, Message: "invalid\targument\r\nline"},
+				},
+				{
+					Person: &people.Person{
+						ResourceName: "people/3",
+						Names:        []*people.Name{{DisplayName: "Only Name"}},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := people.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if execErr := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"contacts", "batch", "create",
+				"--contacts-json", `[{"names":[{"givenName":"John"}]},{"names":[{"givenName":"Bad"}]},{"names":[{"givenName":"Only"}]}]`,
+			}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+	})
+
+	want := "" +
+		"REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\n" +
+		"0\tpeople/1\tJohn Doe North\tjohn@example.com\tOK\t\n" +
+		"1\t\t\t\tERROR\tinvalid argument line\n" +
+		"2\tpeople/3\tOnly Name\t\tOK\t\n"
+	if out != want {
+		t.Fatalf("plain batch create output = %q, want %q", out, want)
+	}
+}
+
+func TestContactsBatchCreate_PlainEmptyEmitsHeaderOnly(t *testing.T) {
+	origNew := newPeopleContactsService
+	t.Cleanup(func() { newPeopleContactsService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&people.BatchCreateContactsResponse{CreatedPeople: []*people.PersonResponse{}})
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := people.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		stderr := captureStderr(t, func() {
+			if execErr := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"contacts", "batch", "create",
+				"--contacts-json", `[{"names":[{"givenName":"X"}]}]`,
+			}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+		if stderr != "" {
+			t.Fatalf("unexpected stderr under --plain: %q", stderr)
+		}
+	})
+
+	want := "REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\n"
+	if out != want {
+		t.Fatalf("plain empty create output = %q, want %q", out, want)
+	}
+}
+
+func TestContactsBatchCreate_HumanStillPrintsCount(t *testing.T) {
+	origNew := newPeopleContactsService
+	t.Cleanup(func() { newPeopleContactsService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := &people.BatchCreateContactsResponse{
+			CreatedPeople: []*people.PersonResponse{
+				{Person: &people.Person{ResourceName: "people/1", Names: []*people.Name{{DisplayName: "A"}}, EmailAddresses: []*people.EmailAddress{{Value: "a@b.com"}}}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := people.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if execErr := Execute([]string{
+				"--account", "a@b.com",
+				"contacts", "batch", "create",
+				"--contacts-json", `[{"names":[{"givenName":"A"}]}]`,
+			}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+	})
+	if !strings.Contains(out, "Created 1 contact(s)") {
+		t.Fatalf("human create output missing count prose: %q", out)
+	}
+	if strings.Contains(out, "REQUEST_KEY") {
+		t.Fatalf("human create output unexpectedly used plain schema: %q", out)
+	}
+}
+
+func TestContactsBatchUpdate_PlainTSV(t *testing.T) {
+	origNew := newPeopleContactsService
+	t.Cleanup(func() { newPeopleContactsService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/people:batchUpdateContacts" {
+			http.NotFound(w, r)
+			return
+		}
+		resp := &people.BatchUpdateContactsResponse{
+			UpdateResult: map[string]people.PersonResponse{
+				"people/2": {
+					RequestedResourceName: "people/2",
+					Person: &people.Person{
+						ResourceName:   "people/2",
+						Names:          []*people.Name{{DisplayName: "Jane\nSmith"}},
+						EmailAddresses: []*people.EmailAddress{{Value: "jane@example.com"}},
+					},
+				},
+				"people/1": {
+					RequestedResourceName: "people/1",
+					Status:                &people.Status{Code: 5, Message: "not found"},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := people.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if execErr := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"contacts", "batch", "update",
+				"--contacts-json", `{"people/1":{"names":[{"givenName":"A"}]},"people/2":{"names":[{"givenName":"B"}]}}`,
+			}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+	})
+
+	want := "" +
+		"REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\n" +
+		"people/1\t\t\t\tERROR\tnot found\n" +
+		"people/2\tpeople/2\tJane Smith\tjane@example.com\tOK\t\n"
+	if out != want {
+		t.Fatalf("plain batch update output = %q, want %q", out, want)
+	}
+}
+
+func TestContactsBatchUpdate_PlainEmptyEmitsHeaderOnly(t *testing.T) {
+	origNew := newPeopleContactsService
+	t.Cleanup(func() { newPeopleContactsService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&people.BatchUpdateContactsResponse{UpdateResult: map[string]people.PersonResponse{}})
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := people.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		stderr := captureStderr(t, func() {
+			if execErr := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"contacts", "batch", "update",
+				"--contacts-json", `{"people/1":{"names":[{"givenName":"A"}]}}`,
+			}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+		if stderr != "" {
+			t.Fatalf("unexpected stderr under --plain: %q", stderr)
+		}
+	})
+
+	want := "REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\n"
+	if out != want {
+		t.Fatalf("plain empty update output = %q, want %q", out, want)
+	}
+}
+
+func TestContactsBatchUpdate_HumanStillPrintsCount(t *testing.T) {
+	origNew := newPeopleContactsService
+	t.Cleanup(func() { newPeopleContactsService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := &people.BatchUpdateContactsResponse{
+			UpdateResult: map[string]people.PersonResponse{
+				"people/1": {Person: &people.Person{ResourceName: "people/1"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := people.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if execErr := Execute([]string{
+				"--account", "a@b.com",
+				"contacts", "batch", "update",
+				"--contacts-json", `{"people/1":{"names":[{"givenName":"A"}]}}`,
+			}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+	})
+	if out != "Updated 1 contact(s)\n" {
+		t.Fatalf("human update output = %q, want count prose", out)
 	}
 }

--- a/internal/cmd/people_batch_test.go
+++ b/internal/cmd/people_batch_test.go
@@ -668,10 +668,11 @@ func TestContactsBatchUpdate_PlainTSV(t *testing.T) {
 		})
 	})
 
+	resource := "people/2"
 	want := "" +
 		"REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\n" +
 		"people/1\t\t\t\tERROR\tnot found\n" +
-		"people/2\tpeople/2\tJane Smith\tjane@example.com\tOK\t\n"
+		resource + "\t" + resource + "\tJane Smith\tjane@example.com\tOK\t\n"
 	if out != want {
 		t.Fatalf("plain batch update output = %q, want %q", out, want)
 	}

--- a/internal/cmd/people_batch_test.go
+++ b/internal/cmd/people_batch_test.go
@@ -518,7 +518,7 @@ func TestContactsBatchCreate_PlainTSV(t *testing.T) {
 	}
 }
 
-func TestContactsBatchCreate_PlainEmptyEmitsHeaderOnly(t *testing.T) {
+func TestContactsBatchCreate_PlainEmptyResponseStillEmitsRequestRow(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(&people.BatchCreateContactsResponse{CreatedPeople: []*people.PersonResponse{}})
@@ -540,9 +540,9 @@ func TestContactsBatchCreate_PlainEmptyEmitsHeaderOnly(t *testing.T) {
 		}
 	})
 
-	want := "REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\n"
+	want := "REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\n0\t\tX\t\tOK\t\n"
 	if out != want {
-		t.Fatalf("plain empty create output = %q, want %q", out, want)
+		t.Fatalf("plain create output with empty response = %q, want %q", out, want)
 	}
 }
 
@@ -626,7 +626,7 @@ func TestContactsBatchUpdate_PlainTSV(t *testing.T) {
 	}
 }
 
-func TestContactsBatchUpdate_PlainEmptyEmitsHeaderOnly(t *testing.T) {
+func TestContactsBatchUpdate_PlainEmptyResponseStillEmitsRequestRow(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(&people.BatchUpdateContactsResponse{UpdateResult: map[string]people.PersonResponse{}})
@@ -648,9 +648,9 @@ func TestContactsBatchUpdate_PlainEmptyEmitsHeaderOnly(t *testing.T) {
 		}
 	})
 
-	want := "REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\n"
+	want := "REQUEST_KEY\tRESOURCE\tNAME\tEMAIL\tSTATUS\tERROR\npeople/1\tpeople/1\tA\t\tOK\t\n"
 	if out != want {
-		t.Fatalf("plain empty update output = %q, want %q", out, want)
+		t.Fatalf("plain update output with empty response = %q, want %q", out, want)
 	}
 }
 

--- a/internal/cmd/people_photo.go
+++ b/internal/cmd/people_photo.go
@@ -57,6 +57,14 @@ func (c *ContactsPhotoDeleteCmd) Run(ctx context.Context, flags *RootFlags) erro
 		return err
 	}
 
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		writeTableRow(ctx, w, []string{"RESOURCE", "STATUS"})
+		writeTableRow(ctx, w, []string{resourceName, "OK"})
+		return nil
+	}
+
 	return writeDeleteResult(ctx, u, fmt.Sprintf("photo for contact %s", resourceName))
 }
 

--- a/internal/cmd/people_photo.go
+++ b/internal/cmd/people_photo.go
@@ -129,6 +129,14 @@ func (c *ContactsPhotoUpdateCmd) Run(ctx context.Context, flags *RootFlags) erro
 		})
 	}
 
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		writeTableRow(ctx, w, []string{"RESOURCE", "STATUS"})
+		writeTableRow(ctx, w, []string{resourceName, "OK"})
+		return nil
+	}
+
 	u.Out().Printf("Updated photo for %s", resourceName)
 	return nil
 }

--- a/internal/cmd/people_photo.go
+++ b/internal/cmd/people_photo.go
@@ -130,10 +130,14 @@ func (c *ContactsPhotoUpdateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsPlain(ctx) {
+		responseResourceName := resourceName
+		if resp.Person != nil && resp.Person.ResourceName != "" {
+			responseResourceName = resp.Person.ResourceName
+		}
 		w, flush := tableWriter(ctx)
 		defer flush()
 		writeTableRow(ctx, w, []string{"RESOURCE", "STATUS"})
-		writeTableRow(ctx, w, []string{resourceName, "OK"})
+		writeTableRow(ctx, w, []string{responseResourceName, "OK"})
 		return nil
 	}
 

--- a/internal/cmd/people_photo_test.go
+++ b/internal/cmd/people_photo_test.go
@@ -302,6 +302,40 @@ func createTempImageFile(t *testing.T, data []byte) string {
 	return tmpFile.Name()
 }
 
+func TestContactsPhotoDelete_PlainTSV(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/people/123:deleteContactPhoto" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{}"))
+	}))
+	usePeopleContactsTestServer(t, srv)
+
+	out := captureStdout(t, func() {
+		stderr := captureStderr(t, func() {
+			if execErr := Execute([]string{
+				"--plain", "--force", "--account", "a@b.com",
+				"contacts", "photo", "delete", "123",
+			}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+		if stderr != "" {
+			t.Fatalf("unexpected stderr under --plain: %q", stderr)
+		}
+	})
+
+	want := "RESOURCE\tSTATUS\npeople/123\tOK\n"
+	if out != want {
+		t.Fatalf("plain photo delete output = %q, want %q", out, want)
+	}
+}
+
 func TestContactsPhotoUpdate_PlainTSV(t *testing.T) {
 	testImageData := []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01")
 	tmpFile := createTempImageFile(t, testImageData)

--- a/internal/cmd/people_photo_test.go
+++ b/internal/cmd/people_photo_test.go
@@ -315,7 +315,7 @@ func TestContactsPhotoUpdate_PlainTSV(t *testing.T) {
 			return
 		}
 		resp := &people.UpdateContactPhotoResponse{
-			Person: &people.Person{ResourceName: "people/123"},
+			Person: &people.Person{ResourceName: "people/returned"},
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
@@ -347,7 +347,7 @@ func TestContactsPhotoUpdate_PlainTSV(t *testing.T) {
 		}
 	})
 
-	want := "RESOURCE\tSTATUS\npeople/123\tOK\n"
+	want := "RESOURCE\tSTATUS\npeople/returned\tOK\n"
 	if out != want {
 		t.Fatalf("plain photo update output = %q, want %q", out, want)
 	}

--- a/internal/cmd/people_photo_test.go
+++ b/internal/cmd/people_photo_test.go
@@ -398,4 +398,3 @@ func TestContactsPhotoUpdate_HumanStillPrintsProse(t *testing.T) {
 		t.Fatalf("human photo update unexpectedly used plain schema: %q", out)
 	}
 }
-

--- a/internal/cmd/people_photo_test.go
+++ b/internal/cmd/people_photo_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"google.golang.org/api/option"
@@ -300,3 +301,101 @@ func createTempImageFile(t *testing.T, data []byte) string {
 	})
 	return tmpFile.Name()
 }
+
+func TestContactsPhotoUpdate_PlainTSV(t *testing.T) {
+	origNew := newPeopleContactsService
+	t.Cleanup(func() { newPeopleContactsService = origNew })
+
+	testImageData := []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01")
+	tmpFile := createTempImageFile(t, testImageData)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/people/123:updateContactPhoto" {
+			http.NotFound(w, r)
+			return
+		}
+		resp := &people.UpdateContactPhotoResponse{
+			Person: &people.Person{ResourceName: "people/123"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := people.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		stderr := captureStderr(t, func() {
+			if execErr := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"contacts", "photo", "update", "123",
+				"--file", tmpFile,
+			}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+		if stderr != "" {
+			t.Fatalf("unexpected stderr under --plain: %q", stderr)
+		}
+	})
+
+	want := "RESOURCE\tSTATUS\npeople/123\tOK\n"
+	if out != want {
+		t.Fatalf("plain photo update output = %q, want %q", out, want)
+	}
+}
+
+func TestContactsPhotoUpdate_HumanStillPrintsProse(t *testing.T) {
+	origNew := newPeopleContactsService
+	t.Cleanup(func() { newPeopleContactsService = origNew })
+
+	testImageData := []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01")
+	tmpFile := createTempImageFile(t, testImageData)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := &people.UpdateContactPhotoResponse{
+			Person: &people.Person{ResourceName: "people/123"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := people.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if execErr := Execute([]string{
+				"--account", "a@b.com",
+				"contacts", "photo", "update", "people/123",
+				"--file", tmpFile,
+			}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+	})
+	want := "Updated photo for people/123\n"
+	if out != want {
+		t.Fatalf("human photo update output = %q, want %q", out, want)
+	}
+	if strings.Contains(out, "RESOURCE\tSTATUS") {
+		t.Fatalf("human photo update unexpectedly used plain schema: %q", out)
+	}
+}
+

--- a/internal/cmd/people_photo_test.go
+++ b/internal/cmd/people_photo_test.go
@@ -303,9 +303,6 @@ func createTempImageFile(t *testing.T, data []byte) string {
 }
 
 func TestContactsPhotoUpdate_PlainTSV(t *testing.T) {
-	origNew := newPeopleContactsService
-	t.Cleanup(func() { newPeopleContactsService = origNew })
-
 	testImageData := []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01")
 	tmpFile := createTempImageFile(t, testImageData)
 
@@ -320,17 +317,7 @@ func TestContactsPhotoUpdate_PlainTSV(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
-	t.Cleanup(srv.Close)
-
-	svc, err := people.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+	usePeopleContactsTestServer(t, srv)
 
 	out := captureStdout(t, func() {
 		stderr := captureStderr(t, func() {
@@ -354,9 +341,6 @@ func TestContactsPhotoUpdate_PlainTSV(t *testing.T) {
 }
 
 func TestContactsPhotoUpdate_HumanStillPrintsProse(t *testing.T) {
-	origNew := newPeopleContactsService
-	t.Cleanup(func() { newPeopleContactsService = origNew })
-
 	testImageData := []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01")
 	tmpFile := createTempImageFile(t, testImageData)
 
@@ -367,17 +351,7 @@ func TestContactsPhotoUpdate_HumanStillPrintsProse(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
-	t.Cleanup(srv.Close)
-
-	svc, err := people.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newPeopleContactsService = func(context.Context, string) (*people.Service, error) { return svc, nil }
+	usePeopleContactsTestServer(t, srv)
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {


### PR DESCRIPTION
## Summary
- emit deterministic TSV receipts for People batch create and update operations
- preserve one correlated row per request when response details are omitted
- emit stable photo update and delete receipts, preferring returned resource names

## Testing
- focused People mutation receipt tests
- full make ci with required Go SDK PATH

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)