### PR TITLE
fix(gmail): redact watch webhook tokens from status

### DIFF
--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -336,51 +336,50 @@ func (c *GmailWatchServeCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 }
 
 func writeWatchState(ctx context.Context, state gmailWatchState) error {
+	view := watchStatusView(state)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"watch": state})
+		return outfmt.WriteJSON(os.Stdout, map[string]any{"watch": view})
 	}
 	u := ui.FromContext(ctx)
-	u.Out().Printf("account\t%s", state.Account)
-	u.Out().Printf("topic\t%s", state.Topic)
-	if len(state.Labels) > 0 {
-		u.Out().Printf("labels\t%s", strings.Join(state.Labels, ","))
+	u.Out().Printf("account\t%s", view.Account)
+	u.Out().Printf("topic\t%s", view.Topic)
+	if len(view.Labels) > 0 {
+		u.Out().Printf("labels\t%s", strings.Join(view.Labels, ","))
 	}
-	u.Out().Printf("history_id\t%s", state.HistoryID)
-	if state.ExpirationMs > 0 {
-		u.Out().Printf("expiration\t%s", formatUnixMillis(state.ExpirationMs))
+	u.Out().Printf("history_id\t%s", view.HistoryID)
+	if view.ExpirationMs > 0 {
+		u.Out().Printf("expiration\t%s", formatUnixMillis(view.ExpirationMs))
 	}
-	if state.ProviderExpirationMs > 0 {
-		u.Out().Printf("provider_expiration\t%s", formatUnixMillis(state.ProviderExpirationMs))
+	if view.ProviderExpirationMs > 0 {
+		u.Out().Printf("provider_expiration\t%s", formatUnixMillis(view.ProviderExpirationMs))
 	}
-	if state.RenewAfterMs > 0 {
-		u.Out().Printf("renew_after\t%s", formatUnixMillis(state.RenewAfterMs))
+	if view.RenewAfterMs > 0 {
+		u.Out().Printf("renew_after\t%s", formatUnixMillis(view.RenewAfterMs))
 	}
-	if state.UpdatedAtMs > 0 {
-		u.Out().Printf("updated_at\t%s", formatUnixMillis(state.UpdatedAtMs))
+	if view.UpdatedAtMs > 0 {
+		u.Out().Printf("updated_at\t%s", formatUnixMillis(view.UpdatedAtMs))
 	}
-	if state.Hook != nil {
-		u.Out().Printf("hook_url\t%s", state.Hook.URL)
-		if state.Hook.IncludeBody {
+	if view.Hook != nil {
+		u.Out().Printf("hook_url\t%s", view.Hook.URL)
+		if view.Hook.IncludeBody {
 			u.Out().Printf("hook_include_body\ttrue")
 		}
-		if state.Hook.MaxBytes > 0 {
-			u.Out().Printf("hook_max_bytes\t%d", state.Hook.MaxBytes)
-		}
-		if state.Hook.Token != "" {
-			u.Out().Printf("hook_token\t%s", state.Hook.Token)
+		if view.Hook.MaxBytes > 0 {
+			u.Out().Printf("hook_max_bytes\t%d", view.Hook.MaxBytes)
 		}
 	}
-	if state.LastDeliveryStatus != "" {
-		u.Out().Printf("last_delivery_status\t%s", state.LastDeliveryStatus)
+	u.Out().Printf("hook_token_configured\t%t", view.HookTokenConfigured)
+	if view.LastDeliveryStatus != "" {
+		u.Out().Printf("last_delivery_status\t%s", view.LastDeliveryStatus)
 	}
-	if state.LastDeliveryAtMs > 0 {
-		u.Out().Printf("last_delivery_at\t%s", formatUnixMillis(state.LastDeliveryAtMs))
+	if view.LastDeliveryAtMs > 0 {
+		u.Out().Printf("last_delivery_at\t%s", formatUnixMillis(view.LastDeliveryAtMs))
 	}
-	if state.LastDeliveryStatusNote != "" {
-		u.Out().Printf("last_delivery_note\t%s", state.LastDeliveryStatusNote)
+	if view.LastDeliveryStatusNote != "" {
+		u.Out().Printf("last_delivery_note\t%s", view.LastDeliveryStatusNote)
 	}
-	if state.LastPushMessageID != "" {
-		u.Out().Printf("last_push_message_id\t%s", state.LastPushMessageID)
+	if view.LastPushMessageID != "" {
+		u.Out().Printf("last_push_message_id\t%s", view.LastPushMessageID)
 	}
 	return nil
 }

--- a/internal/cmd/gmail_watch_cmds_more_test.go
+++ b/internal/cmd/gmail_watch_cmds_more_test.go
@@ -58,6 +58,7 @@ func TestGmailWatchRenewAndStop_JSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store: %v", err)
 	}
+	const sentinelToken = "sentinel-hook-token-issue-88-secret"
 	_ = store.Update(func(s *gmailWatchState) error {
 		*s = gmailWatchState{
 			Account:      "a@b.com",
@@ -66,13 +67,17 @@ func TestGmailWatchRenewAndStop_JSON(t *testing.T) {
 			HistoryID:    "100",
 			RenewAfterMs: time.Now().Add(10 * time.Minute).UnixMilli(),
 			ExpirationMs: time.Now().Add(20 * time.Minute).UnixMilli(),
+			Hook: &gmailWatchHook{
+				URL:   "http://example.com/hook",
+				Token: sentinelToken,
+			},
 		}
 		return nil
 	})
 
 	flags := &RootFlags{Account: "a@b.com", Force: true}
 
-	_ = captureStdout(t, func() {
+	out := captureStdout(t, func() {
 		u, uiErr := ui.New(ui.Options{Stdout: os.Stdout, Stderr: os.Stderr, Color: "never"})
 		if uiErr != nil {
 			t.Fatalf("ui.New: %v", uiErr)
@@ -88,6 +93,27 @@ func TestGmailWatchRenewAndStop_JSON(t *testing.T) {
 			t.Fatalf("stop: %v", err)
 		}
 	})
+	if strings.Contains(out, sentinelToken) {
+		t.Fatalf("renew/stop json output leaked hook token: %q", out)
+	}
+	var renewParsed struct {
+		Watch struct {
+			Hook *struct {
+				Token string `json:"token"`
+			} `json:"hook"`
+			HookTokenConfigured bool `json:"hookTokenConfigured"`
+		} `json:"watch"`
+	}
+	// renew emits one JSON object before stop text; parse first object only.
+	if decodeErr := json.NewDecoder(strings.NewReader(out)).Decode(&renewParsed); decodeErr != nil {
+		t.Fatalf("renew json parse: %v (out=%q)", decodeErr, out)
+	}
+	if renewParsed.Watch.Hook != nil && renewParsed.Watch.Hook.Token != "" {
+		t.Fatalf("renew json must omit token value")
+	}
+	if !renewParsed.Watch.HookTokenConfigured {
+		t.Fatalf("expected hookTokenConfigured true after renew")
+	}
 
 	if _, statErr := os.Stat(store.path); !os.IsNotExist(statErr) {
 		t.Fatalf("expected watch state removed, err=%v", statErr)
@@ -105,12 +131,16 @@ func TestGmailWatchStatusAndStop_Text(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store: %v", err)
 	}
+	const sentinelToken = "sentinel-hook-token-issue-88-secret"
 	_ = store.Update(func(s *gmailWatchState) error {
 		*s = gmailWatchState{
 			Account:   "a@b.com",
 			Topic:     "projects/p/topics/t",
 			HistoryID: "100",
-			Hook:      &gmailWatchHook{URL: "http://example.com/hook"},
+			Hook: &gmailWatchHook{
+				URL:   "http://example.com/hook",
+				Token: sentinelToken,
+			},
 		}
 		return nil
 	})
@@ -152,5 +182,11 @@ func TestGmailWatchStatusAndStop_Text(t *testing.T) {
 	})
 	if !strings.Contains(out, "account") || !strings.Contains(out, "stopped") {
 		t.Fatalf("unexpected output: %q", out)
+	}
+	if !strings.Contains(out, "hook_token_configured\ttrue") {
+		t.Fatalf("expected configured flag in status text, got: %q", out)
+	}
+	if strings.Contains(out, sentinelToken) || strings.Contains(out, "hook_token\t") {
+		t.Fatalf("status text leaked hook token: %q", out)
 	}
 }

--- a/internal/cmd/gmail_watch_helpers_test.go
+++ b/internal/cmd/gmail_watch_helpers_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestWriteWatchState_TextAndJSON(t *testing.T) {
+	const sentinelToken = "sentinel-hook-token-issue-88-secret"
 	state := gmailWatchState{
 		Account:              "a@b.com",
 		Topic:                "projects/p/topics/t",
@@ -27,7 +28,7 @@ func TestWriteWatchState_TextAndJSON(t *testing.T) {
 			URL:         "http://example.com/hook",
 			IncludeBody: true,
 			MaxBytes:    12,
-			Token:       "tok",
+			Token:       sentinelToken,
 		},
 		LastDeliveryStatus:     "ok",
 		LastDeliveryAtMs:       5,
@@ -50,6 +51,29 @@ func TestWriteWatchState_TextAndJSON(t *testing.T) {
 	if !strings.Contains(textOut, "hook_url\thttp://example.com/hook") {
 		t.Fatalf("expected hook output")
 	}
+	if !strings.Contains(textOut, "hook_token_configured\ttrue") {
+		t.Fatalf("expected configured flag in text output, got: %q", textOut)
+	}
+	if strings.Contains(textOut, sentinelToken) || strings.Contains(textOut, "hook_token\t") {
+		t.Fatalf("text status leaked hook token: %q", textOut)
+	}
+
+	// Absent token reports configured=false without inventing a secret field.
+	noTokenState := state
+	noTokenState.Hook = &gmailWatchHook{URL: "http://example.com/hook"}
+	textAbsent := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		if err := writeWatchState(ctx, noTokenState); err != nil {
+			t.Fatalf("writeWatchState absent token: %v", err)
+		}
+	})
+	if !strings.Contains(textAbsent, "hook_token_configured\tfalse") {
+		t.Fatalf("expected configured=false for empty token, got: %q", textAbsent)
+	}
 
 	jsonOut := captureStdout(t, func() {
 		u, uiErr := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
@@ -62,14 +86,71 @@ func TestWriteWatchState_TextAndJSON(t *testing.T) {
 			t.Fatalf("writeWatchState json: %v", err)
 		}
 	})
+	if strings.Contains(jsonOut, sentinelToken) {
+		t.Fatalf("json status leaked hook token: %q", jsonOut)
+	}
 	var parsed struct {
-		Watch gmailWatchState `json:"watch"`
+		Watch struct {
+			Hook *struct {
+				URL         string `json:"url"`
+				Token       string `json:"token"`
+				IncludeBody bool   `json:"includeBody"`
+				MaxBytes    int    `json:"maxBytes"`
+			} `json:"hook"`
+			HookTokenConfigured bool `json:"hookTokenConfigured"`
+		} `json:"watch"`
 	}
 	if err := json.Unmarshal([]byte(jsonOut), &parsed); err != nil {
 		t.Fatalf("json parse: %v", err)
 	}
 	if parsed.Watch.Hook == nil || parsed.Watch.Hook.URL == "" {
 		t.Fatalf("expected hook in json")
+	}
+	if parsed.Watch.Hook.Token != "" {
+		t.Fatalf("json hook must omit token value, got: %#v", parsed.Watch.Hook)
+	}
+	if !parsed.Watch.HookTokenConfigured {
+		t.Fatalf("expected hookTokenConfigured true")
+	}
+
+	jsonAbsent := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+		if err := writeWatchState(ctx, noTokenState); err != nil {
+			t.Fatalf("writeWatchState json absent: %v", err)
+		}
+	})
+	var parsedAbsent struct {
+		Watch struct {
+			HookTokenConfigured bool `json:"hookTokenConfigured"`
+		} `json:"watch"`
+	}
+	if err := json.Unmarshal([]byte(jsonAbsent), &parsedAbsent); err != nil {
+		t.Fatalf("json absent parse: %v", err)
+	}
+	if parsedAbsent.Watch.HookTokenConfigured {
+		t.Fatalf("expected hookTokenConfigured false when token absent")
+	}
+
+	// No hook at all still reports configured=false in every mode.
+	noHook := state
+	noHook.Hook = nil
+	textNoHook := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		if err := writeWatchState(ctx, noHook); err != nil {
+			t.Fatalf("writeWatchState no hook: %v", err)
+		}
+	})
+	if !strings.Contains(textNoHook, "hook_token_configured\tfalse") {
+		t.Fatalf("expected configured=false when hook missing, got: %q", textNoHook)
 	}
 }
 

--- a/internal/cmd/gmail_watch_test.go
+++ b/internal/cmd/gmail_watch_test.go
@@ -69,6 +69,7 @@ func TestGmailWatchStartCmd_JSON(t *testing.T) {
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	flags := &RootFlags{Account: "a@b.com"}
+	const sentinelToken = "sentinel-hook-token-issue-88-secret"
 	out := captureStdout(t, func() {
 		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
 		if uiErr != nil {
@@ -82,7 +83,7 @@ func TestGmailWatchStartCmd_JSON(t *testing.T) {
 			"--label", "INBOX",
 			"--label", "Custom",
 			"--hook-url", "http://127.0.0.1:1/hooks",
-			"--hook-token", "tok",
+			"--hook-token", sentinelToken,
 			"--include-body",
 			"--max-bytes", "5",
 		}, ctx, flags); execErr != nil {
@@ -96,9 +97,21 @@ func TestGmailWatchStartCmd_JSON(t *testing.T) {
 	if len(watchReq.LabelIds) != 2 || watchReq.LabelIds[0] != "INBOX" || watchReq.LabelIds[1] != "Label_1" {
 		t.Fatalf("unexpected labels: %#v", watchReq.LabelIds)
 	}
+	if strings.Contains(out, sentinelToken) {
+		t.Fatalf("start json output leaked hook token: %q", out)
+	}
 
 	var parsed struct {
-		Watch gmailWatchState `json:"watch"`
+		Watch struct {
+			HistoryID string `json:"historyId"`
+			Hook      *struct {
+				URL         string `json:"url"`
+				Token       string `json:"token"`
+				IncludeBody bool   `json:"includeBody"`
+				MaxBytes    int    `json:"maxBytes"`
+			} `json:"hook"`
+			HookTokenConfigured bool `json:"hookTokenConfigured"`
+		} `json:"watch"`
 	}
 	if parseErr := json.Unmarshal([]byte(out), &parsed); parseErr != nil {
 		t.Fatalf("json parse: %v", parseErr)
@@ -112,13 +125,23 @@ func TestGmailWatchStartCmd_JSON(t *testing.T) {
 	if parsed.Watch.Hook.MaxBytes != 5 {
 		t.Fatalf("unexpected max bytes: %#v", parsed.Watch.Hook)
 	}
+	if parsed.Watch.Hook.Token != "" {
+		t.Fatalf("json hook must omit token value, got: %#v", parsed.Watch.Hook)
+	}
+	if !parsed.Watch.HookTokenConfigured {
+		t.Fatalf("expected hookTokenConfigured true")
+	}
 
 	store, err := loadGmailWatchStore("a@b.com")
 	if err != nil {
 		t.Fatalf("load store: %v", err)
 	}
-	if store.Get().HistoryID != "123" {
-		t.Fatalf("store missing history: %#v", store.Get())
+	stored := store.Get()
+	if stored.HistoryID != "123" {
+		t.Fatalf("store missing history: %#v", stored)
+	}
+	if stored.Hook == nil || stored.Hook.Token != sentinelToken {
+		t.Fatalf("store must retain real hook token, got: %#v", stored.Hook)
 	}
 }
 

--- a/internal/cmd/gmail_watch_types.go
+++ b/internal/cmd/gmail_watch_types.go
@@ -124,3 +124,56 @@ type gmailHookPayload struct {
 	HistoryID string             `json:"historyId"`
 	Messages  []gmailHookMessage `json:"messages"`
 }
+
+// gmailWatchStatusHook is the public hook view for status output.
+// It intentionally omits the bearer token.
+type gmailWatchStatusHook struct {
+	URL         string `json:"url"`
+	IncludeBody bool   `json:"includeBody,omitempty"`
+	MaxBytes    int    `json:"maxBytes,omitempty"`
+}
+
+// gmailWatchStatusView is the redacted public representation of watch state.
+// Persistence continues to use gmailWatchState, which retains the real hook token.
+type gmailWatchStatusView struct {
+	Account                string                `json:"account"`
+	Topic                  string                `json:"topic"`
+	Labels                 []string              `json:"labels,omitempty"`
+	HistoryID              string                `json:"historyId"`
+	ExpirationMs           int64                 `json:"expirationMs,omitempty"`
+	ProviderExpirationMs   int64                 `json:"providerExpirationMs,omitempty"`
+	RenewAfterMs           int64                 `json:"renewAfterMs,omitempty"`
+	UpdatedAtMs            int64                 `json:"updatedAtMs,omitempty"`
+	Hook                   *gmailWatchStatusHook `json:"hook,omitempty"`
+	HookTokenConfigured    bool                  `json:"hookTokenConfigured"`
+	LastDeliveryStatus     string                `json:"lastDeliveryStatus,omitempty"`
+	LastDeliveryAtMs       int64                 `json:"lastDeliveryAtMs,omitempty"`
+	LastDeliveryStatusNote string                `json:"lastDeliveryStatusNote,omitempty"`
+	LastPushMessageID      string                `json:"lastPushMessageId,omitempty"`
+}
+
+func watchStatusView(state gmailWatchState) gmailWatchStatusView {
+	view := gmailWatchStatusView{
+		Account:                state.Account,
+		Topic:                  state.Topic,
+		Labels:                 state.Labels,
+		HistoryID:              state.HistoryID,
+		ExpirationMs:           state.ExpirationMs,
+		ProviderExpirationMs:   state.ProviderExpirationMs,
+		RenewAfterMs:           state.RenewAfterMs,
+		UpdatedAtMs:            state.UpdatedAtMs,
+		LastDeliveryStatus:     state.LastDeliveryStatus,
+		LastDeliveryAtMs:       state.LastDeliveryAtMs,
+		LastDeliveryStatusNote: state.LastDeliveryStatusNote,
+		LastPushMessageID:      state.LastPushMessageID,
+	}
+	if state.Hook != nil {
+		view.Hook = &gmailWatchStatusHook{
+			URL:         state.Hook.URL,
+			IncludeBody: state.Hook.IncludeBody,
+			MaxBytes:    state.Hook.MaxBytes,
+		}
+		view.HookTokenConfigured = state.Hook.Token != ""
+	}
+	return view
+}


### PR DESCRIPTION
## Summary
- render Gmail watch status through a redacted public view
- report only whether outbound hook authentication is configured
- cover text/plain and JSON start, renew, and status output with sentinel secrets
- preserve the stored bearer token for outbound webhook delivery

## Testing
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" go test ./internal/cmd -run 'Test(GmailWatch|WriteWatchState|HookFromFlags)'`
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci`
- standards/Fowler review: no confirmed findings
- exact-spec review: no confirmed findings

Closes #88