### PR TITLE
fix(tracking): write tracking config atomically

### DIFF
--- a/internal/tracking/config.go
+++ b/internal/tracking/config.go
@@ -16,6 +16,17 @@ var errMissingAccount = errors.New("missing account")
 
 const trackingConfigVersion = 1
 
+// Filesystem hooks allow tests to inject write/sync/close/rename failures.
+var (
+	createTrackingConfigTemp = os.CreateTemp
+	writeTrackingConfigFile  = func(f *os.File, data []byte) (int, error) { return f.Write(data) }
+	syncTrackingConfigFile   = func(f *os.File) error { return f.Sync() }
+	closeTrackingConfigFile  = func(f *os.File) error { return f.Close() }
+	renameTrackingConfigFile = os.Rename
+	removeTrackingConfigFile = os.Remove
+	chmodTrackingConfigFile  = os.Chmod
+)
+
 // Config holds tracking configuration for a single account.
 type Config struct {
 	Enabled          bool   `json:"enabled"`
@@ -163,9 +174,60 @@ func SaveConfig(account string, cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("marshal tracking config: %w", err)
 	}
+	data = append(data, '\n')
 
-	if writeErr := os.WriteFile(path, data, 0o600); writeErr != nil {
+	if writeErr := writeConfigAtomic(path, data); writeErr != nil {
+		return writeErr
+	}
+
+	return nil
+}
+
+func writeConfigAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+
+	tmp, err := createTrackingConfigTemp(dir, "tracking-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp tracking config: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	// Ensure owner-only permissions even if umask is loose.
+	if chmodErr := chmodTrackingConfigFile(tmpName, 0o600); chmodErr != nil {
+		_ = closeTrackingConfigFile(tmp)
+		_ = removeTrackingConfigFile(tmpName)
+		return fmt.Errorf("chmod temp tracking config: %w", chmodErr)
+	}
+
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = removeTrackingConfigFile(tmpName)
+		}
+	}()
+
+	if _, writeErr := writeTrackingConfigFile(tmp, data); writeErr != nil {
+		_ = closeTrackingConfigFile(tmp)
 		return fmt.Errorf("write tracking config: %w", writeErr)
+	}
+
+	if syncErr := syncTrackingConfigFile(tmp); syncErr != nil {
+		_ = closeTrackingConfigFile(tmp)
+		return fmt.Errorf("sync tracking config: %w", syncErr)
+	}
+
+	if closeErr := closeTrackingConfigFile(tmp); closeErr != nil {
+		return fmt.Errorf("close tracking config: %w", closeErr)
+	}
+
+	if renameErr := renameTrackingConfigFile(tmpName, path); renameErr != nil {
+		return fmt.Errorf("commit tracking config: %w", renameErr)
+	}
+	cleanup = false
+
+	// Re-assert final permissions in case an existing destination was more permissive.
+	if chmodErr := chmodTrackingConfigFile(path, 0o600); chmodErr != nil {
+		return fmt.Errorf("chmod tracking config: %w", chmodErr)
 	}
 
 	return nil

--- a/internal/tracking/config.go
+++ b/internal/tracking/config.go
@@ -16,15 +16,15 @@ var errMissingAccount = errors.New("missing account")
 
 const trackingConfigVersion = 1
 
-// Filesystem hooks allow tests to inject write/sync/close/rename failures.
+// Filesystem hooks allow tests to inject write/sync/close/replace failures.
 var (
-	createTrackingConfigTemp = os.CreateTemp
-	writeTrackingConfigFile  = func(f *os.File, data []byte) (int, error) { return f.Write(data) }
-	syncTrackingConfigFile   = func(f *os.File) error { return f.Sync() }
-	closeTrackingConfigFile  = func(f *os.File) error { return f.Close() }
-	renameTrackingConfigFile = os.Rename
-	removeTrackingConfigFile = os.Remove
-	chmodTrackingConfigFile  = os.Chmod
+	createTrackingConfigTemp  = os.CreateTemp
+	writeTrackingConfigFile   = func(f *os.File, data []byte) (int, error) { return f.Write(data) }
+	syncTrackingConfigFile    = func(f *os.File) error { return f.Sync() }
+	closeTrackingConfigFile   = func(f *os.File) error { return f.Close() }
+	replaceTrackingConfigFile = replaceTrackingConfig
+	removeTrackingConfigFile  = os.Remove
+	chmodTrackingConfigFile   = os.Chmod
 )
 
 // Config holds tracking configuration for a single account.
@@ -220,8 +220,8 @@ func writeConfigAtomic(path string, data []byte) error {
 		return fmt.Errorf("close tracking config: %w", closeErr)
 	}
 
-	if renameErr := renameTrackingConfigFile(tmpName, path); renameErr != nil {
-		return fmt.Errorf("commit tracking config: %w", renameErr)
+	if replaceErr := replaceTrackingConfigFile(tmpName, path); replaceErr != nil {
+		return fmt.Errorf("commit tracking config: %w", replaceErr)
 	}
 	cleanup = false
 

--- a/internal/tracking/config.go
+++ b/internal/tracking/config.go
@@ -174,6 +174,7 @@ func SaveConfig(account string, cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("marshal tracking config: %w", err)
 	}
+
 	data = append(data, '\n')
 
 	if writeErr := writeConfigAtomic(path, data); writeErr != nil {
@@ -196,10 +197,12 @@ func writeConfigAtomic(path string, data []byte) error {
 	if chmodErr := chmodTrackingConfigFile(tmpName, 0o600); chmodErr != nil {
 		_ = closeTrackingConfigFile(tmp)
 		_ = removeTrackingConfigFile(tmpName)
+
 		return fmt.Errorf("chmod temp tracking config: %w", chmodErr)
 	}
 
 	cleanup := true
+
 	defer func() {
 		if cleanup {
 			_ = removeTrackingConfigFile(tmpName)
@@ -224,11 +227,6 @@ func writeConfigAtomic(path string, data []byte) error {
 		return fmt.Errorf("commit tracking config: %w", replaceErr)
 	}
 	cleanup = false
-
-	// Re-assert final permissions in case an existing destination was more permissive.
-	if chmodErr := chmodTrackingConfigFile(path, 0o600); chmodErr != nil {
-		return fmt.Errorf("chmod tracking config: %w", chmodErr)
-	}
 
 	return nil
 }

--- a/internal/tracking/config_atomic_test.go
+++ b/internal/tracking/config_atomic_test.go
@@ -3,7 +3,6 @@ package tracking
 import (
 	"encoding/json"
 	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,17 +55,12 @@ func TestSaveConfigRetainsAccountsAndOwnerOnlyPerms(t *testing.T) {
 		t.Fatalf("missing account b: %#v", fileCfg.Accounts)
 	}
 
-	temps, err := filepath.Glob(path + "*")
+	temps, err := filepath.Glob(filepath.Join(filepath.Dir(path), "tracking-*.tmp"))
 	if err != nil {
 		t.Fatalf("Glob: %v", err)
 	}
-	for _, temp := range temps {
-		if temp == path {
-			continue
-		}
-		if strings.Contains(filepath.Base(temp), "tmp") || strings.HasPrefix(filepath.Base(temp), ".") {
-			t.Fatalf("temporary artifact left behind: %s", temp)
-		}
+	if len(temps) != 0 {
+		t.Fatalf("temporary artifacts left behind: %v", temps)
 	}
 }
 
@@ -127,14 +121,14 @@ func TestSaveConfigFailurePreservesPriorBytesAndCleansTemp(t *testing.T) {
 			},
 		},
 		{
-			name: "rename",
+			name: "replace",
 			setup: func(t *testing.T) {
 				t.Helper()
-				original := renameTrackingConfigFile
-				renameTrackingConfigFile = func(string, string) error {
-					return errors.New("injected rename failure")
+				original := replaceTrackingConfigFile
+				replaceTrackingConfigFile = func(string, string) error {
+					return errors.New("injected replace failure")
 				}
-				t.Cleanup(func() { renameTrackingConfigFile = original })
+				t.Cleanup(func() { replaceTrackingConfigFile = original })
 			},
 		},
 	}
@@ -179,22 +173,17 @@ func TestSaveConfigFailurePreservesPriorBytesAndCleansTemp(t *testing.T) {
 func TestSaveConfigTempUsesOwnerOnlyPermissions(t *testing.T) {
 	setupTrackingConfigEnv(t)
 
-	var sawTempPerm fs.FileMode
-	originalCreate := createTrackingConfigTemp
-	createTrackingConfigTemp = func(dir, pattern string) (*os.File, error) {
-		f, err := originalCreate(dir, pattern)
+	var sawTempPerm os.FileMode
+	originalWrite := writeTrackingConfigFile
+	writeTrackingConfigFile = func(f *os.File, data []byte) (int, error) {
+		info, err := f.Stat()
 		if err != nil {
-			return nil, err
-		}
-		info, statErr := f.Stat()
-		if statErr != nil {
-			_ = f.Close()
-			return nil, statErr
+			return 0, err
 		}
 		sawTempPerm = info.Mode().Perm()
-		return f, nil
+		return originalWrite(f, data)
 	}
-	t.Cleanup(func() { createTrackingConfigTemp = originalCreate })
+	t.Cleanup(func() { writeTrackingConfigFile = originalWrite })
 
 	if err := SaveConfig("a@example.com", &Config{
 		Enabled:   true,

--- a/internal/tracking/config_atomic_test.go
+++ b/internal/tracking/config_atomic_test.go
@@ -3,10 +3,18 @@ package tracking
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+)
+
+var (
+	errInjectedWriteFailure   = errors.New("injected write failure")
+	errInjectedSyncFailure    = errors.New("injected sync failure")
+	errInjectedCloseFailure   = errors.New("injected close failure")
+	errInjectedReplaceFailure = errors.New("injected replace failure")
 )
 
 func TestSaveConfigRetainsAccountsAndOwnerOnlyPerms(t *testing.T) {
@@ -35,6 +43,7 @@ func TestSaveConfigRetainsAccountsAndOwnerOnlyPerms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stat: %v", err)
 	}
+
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("final permissions = %04o, want 0600", info.Mode().Perm())
 	}
@@ -45,12 +54,14 @@ func TestSaveConfigRetainsAccountsAndOwnerOnlyPerms(t *testing.T) {
 	}
 
 	var fileCfg fileConfig
-	if err := json.Unmarshal(data, &fileCfg); err != nil {
-		t.Fatalf("parse tracking config: %v\n%s", err, data)
+	if unmarshalErr := json.Unmarshal(data, &fileCfg); unmarshalErr != nil {
+		t.Fatalf("parse tracking config: %v\n%s", unmarshalErr, data)
 	}
+
 	if fileCfg.Accounts["a@example.com"] == nil || fileCfg.Accounts["a@example.com"].WorkerURL != "https://a.example" {
 		t.Fatalf("missing prior account a: %#v", fileCfg.Accounts)
 	}
+
 	if fileCfg.Accounts["b@example.com"] == nil || fileCfg.Accounts["b@example.com"].WorkerURL != "https://b.example" {
 		t.Fatalf("missing account b: %#v", fileCfg.Accounts)
 	}
@@ -59,6 +70,7 @@ func TestSaveConfigRetainsAccountsAndOwnerOnlyPerms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Glob: %v", err)
 	}
+
 	if len(temps) != 0 {
 		t.Fatalf("temporary artifacts left behind: %v", temps)
 	}
@@ -78,6 +90,7 @@ func TestSaveConfigFailurePreservesPriorBytesAndCleansTemp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConfigPath: %v", err)
 	}
+
 	prior, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read prior: %v", err)
@@ -93,8 +106,9 @@ func TestSaveConfigFailurePreservesPriorBytesAndCleansTemp(t *testing.T) {
 				t.Helper()
 				original := writeTrackingConfigFile
 				writeTrackingConfigFile = func(f *os.File, data []byte) (int, error) {
-					return 0, errors.New("injected write failure")
+					return 0, errInjectedWriteFailure
 				}
+
 				t.Cleanup(func() { writeTrackingConfigFile = original })
 			},
 		},
@@ -104,8 +118,9 @@ func TestSaveConfigFailurePreservesPriorBytesAndCleansTemp(t *testing.T) {
 				t.Helper()
 				original := syncTrackingConfigFile
 				syncTrackingConfigFile = func(*os.File) error {
-					return errors.New("injected sync failure")
+					return errInjectedSyncFailure
 				}
+
 				t.Cleanup(func() { syncTrackingConfigFile = original })
 			},
 		},
@@ -115,8 +130,9 @@ func TestSaveConfigFailurePreservesPriorBytesAndCleansTemp(t *testing.T) {
 				t.Helper()
 				original := closeTrackingConfigFile
 				closeTrackingConfigFile = func(*os.File) error {
-					return errors.New("injected close failure")
+					return errInjectedCloseFailure
 				}
+
 				t.Cleanup(func() { closeTrackingConfigFile = original })
 			},
 		},
@@ -126,8 +142,9 @@ func TestSaveConfigFailurePreservesPriorBytesAndCleansTemp(t *testing.T) {
 				t.Helper()
 				original := replaceTrackingConfigFile
 				replaceTrackingConfigFile = func(string, string) error {
-					return errors.New("injected replace failure")
+					return errInjectedReplaceFailure
 				}
+
 				t.Cleanup(func() { replaceTrackingConfigFile = original })
 			},
 		},
@@ -149,6 +166,7 @@ func TestSaveConfigFailurePreservesPriorBytesAndCleansTemp(t *testing.T) {
 			if readErr != nil {
 				t.Fatalf("read after failure: %v", readErr)
 			}
+
 			if string(got) != string(prior) {
 				t.Fatalf("prior config changed on %s failure\nprior:\n%s\ngot:\n%s", tc.name, prior, got)
 			}
@@ -157,11 +175,13 @@ func TestSaveConfigFailurePreservesPriorBytesAndCleansTemp(t *testing.T) {
 			if listErr != nil {
 				t.Fatalf("ReadDir: %v", listErr)
 			}
+
 			for _, entry := range entries {
 				name := entry.Name()
 				if name == filepath.Base(path) {
 					continue
 				}
+
 				if strings.Contains(name, "tmp") || strings.HasPrefix(name, "tracking.json.") {
 					t.Fatalf("temporary artifact left after %s failure: %s", tc.name, name)
 				}
@@ -178,11 +198,13 @@ func TestSaveConfigTempUsesOwnerOnlyPermissions(t *testing.T) {
 	writeTrackingConfigFile = func(f *os.File, data []byte) (int, error) {
 		info, err := f.Stat()
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("stat temp tracking config: %w", err)
 		}
 		sawTempPerm = info.Mode().Perm()
+
 		return originalWrite(f, data)
 	}
+
 	t.Cleanup(func() { writeTrackingConfigFile = originalWrite })
 
 	if err := SaveConfig("a@example.com", &Config{
@@ -191,6 +213,7 @@ func TestSaveConfigTempUsesOwnerOnlyPermissions(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SaveConfig: %v", err)
 	}
+
 	if sawTempPerm != 0o600 {
 		t.Fatalf("temp permissions = %04o, want 0600", sawTempPerm)
 	}

--- a/internal/tracking/config_atomic_test.go
+++ b/internal/tracking/config_atomic_test.go
@@ -1,0 +1,208 @@
+package tracking
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSaveConfigRetainsAccountsAndOwnerOnlyPerms(t *testing.T) {
+	setupTrackingConfigEnv(t)
+
+	if err := SaveConfig("a@example.com", &Config{
+		Enabled:   true,
+		WorkerURL: "https://a.example",
+	}); err != nil {
+		t.Fatalf("SaveConfig a: %v", err)
+	}
+
+	if err := SaveConfig("b@example.com", &Config{
+		Enabled:   true,
+		WorkerURL: "https://b.example",
+	}); err != nil {
+		t.Fatalf("SaveConfig b: %v", err)
+	}
+
+	path, err := ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("final permissions = %04o, want 0600", info.Mode().Perm())
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var fileCfg fileConfig
+	if err := json.Unmarshal(data, &fileCfg); err != nil {
+		t.Fatalf("parse tracking config: %v\n%s", err, data)
+	}
+	if fileCfg.Accounts["a@example.com"] == nil || fileCfg.Accounts["a@example.com"].WorkerURL != "https://a.example" {
+		t.Fatalf("missing prior account a: %#v", fileCfg.Accounts)
+	}
+	if fileCfg.Accounts["b@example.com"] == nil || fileCfg.Accounts["b@example.com"].WorkerURL != "https://b.example" {
+		t.Fatalf("missing account b: %#v", fileCfg.Accounts)
+	}
+
+	temps, err := filepath.Glob(path + "*")
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	for _, temp := range temps {
+		if temp == path {
+			continue
+		}
+		if strings.Contains(filepath.Base(temp), "tmp") || strings.HasPrefix(filepath.Base(temp), ".") {
+			t.Fatalf("temporary artifact left behind: %s", temp)
+		}
+	}
+}
+
+func TestSaveConfigFailurePreservesPriorBytesAndCleansTemp(t *testing.T) {
+	setupTrackingConfigEnv(t)
+
+	if err := SaveConfig("a@example.com", &Config{
+		Enabled:   true,
+		WorkerURL: "https://original.example",
+	}); err != nil {
+		t.Fatalf("seed SaveConfig: %v", err)
+	}
+
+	path, err := ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	prior, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read prior: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		setup func(t *testing.T)
+	}{
+		{
+			name: "write",
+			setup: func(t *testing.T) {
+				t.Helper()
+				original := writeTrackingConfigFile
+				writeTrackingConfigFile = func(f *os.File, data []byte) (int, error) {
+					return 0, errors.New("injected write failure")
+				}
+				t.Cleanup(func() { writeTrackingConfigFile = original })
+			},
+		},
+		{
+			name: "sync",
+			setup: func(t *testing.T) {
+				t.Helper()
+				original := syncTrackingConfigFile
+				syncTrackingConfigFile = func(*os.File) error {
+					return errors.New("injected sync failure")
+				}
+				t.Cleanup(func() { syncTrackingConfigFile = original })
+			},
+		},
+		{
+			name: "close",
+			setup: func(t *testing.T) {
+				t.Helper()
+				original := closeTrackingConfigFile
+				closeTrackingConfigFile = func(*os.File) error {
+					return errors.New("injected close failure")
+				}
+				t.Cleanup(func() { closeTrackingConfigFile = original })
+			},
+		},
+		{
+			name: "rename",
+			setup: func(t *testing.T) {
+				t.Helper()
+				original := renameTrackingConfigFile
+				renameTrackingConfigFile = func(string, string) error {
+					return errors.New("injected rename failure")
+				}
+				t.Cleanup(func() { renameTrackingConfigFile = original })
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup(t)
+
+			err := SaveConfig("b@example.com", &Config{
+				Enabled:   true,
+				WorkerURL: "https://new.example",
+			})
+			if err == nil {
+				t.Fatal("expected SaveConfig to fail")
+			}
+
+			got, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatalf("read after failure: %v", readErr)
+			}
+			if string(got) != string(prior) {
+				t.Fatalf("prior config changed on %s failure\nprior:\n%s\ngot:\n%s", tc.name, prior, got)
+			}
+
+			entries, listErr := os.ReadDir(filepath.Dir(path))
+			if listErr != nil {
+				t.Fatalf("ReadDir: %v", listErr)
+			}
+			for _, entry := range entries {
+				name := entry.Name()
+				if name == filepath.Base(path) {
+					continue
+				}
+				if strings.Contains(name, "tmp") || strings.HasPrefix(name, "tracking.json.") {
+					t.Fatalf("temporary artifact left after %s failure: %s", tc.name, name)
+				}
+			}
+		})
+	}
+}
+
+func TestSaveConfigTempUsesOwnerOnlyPermissions(t *testing.T) {
+	setupTrackingConfigEnv(t)
+
+	var sawTempPerm fs.FileMode
+	originalCreate := createTrackingConfigTemp
+	createTrackingConfigTemp = func(dir, pattern string) (*os.File, error) {
+		f, err := originalCreate(dir, pattern)
+		if err != nil {
+			return nil, err
+		}
+		info, statErr := f.Stat()
+		if statErr != nil {
+			_ = f.Close()
+			return nil, statErr
+		}
+		sawTempPerm = info.Mode().Perm()
+		return f, nil
+	}
+	t.Cleanup(func() { createTrackingConfigTemp = originalCreate })
+
+	if err := SaveConfig("a@example.com", &Config{
+		Enabled:   true,
+		WorkerURL: "https://example.com",
+	}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+	if sawTempPerm != 0o600 {
+		t.Fatalf("temp permissions = %04o, want 0600", sawTempPerm)
+	}
+}

--- a/internal/tracking/config_replace_unix.go
+++ b/internal/tracking/config_replace_unix.go
@@ -2,8 +2,15 @@
 
 package tracking
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 func replaceTrackingConfig(source, destination string) error {
-	return os.Rename(source, destination)
+	if err := os.Rename(source, destination); err != nil {
+		return fmt.Errorf("rename tracking config: %w", err)
+	}
+
+	return nil
 }

--- a/internal/tracking/config_replace_unix.go
+++ b/internal/tracking/config_replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package tracking
+
+import "os"
+
+func replaceTrackingConfig(source, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/internal/tracking/config_replace_windows.go
+++ b/internal/tracking/config_replace_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package tracking
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const replaceTrackingConfigWriteThrough = 0x1
+
+var replaceTrackingConfigW = windows.NewLazySystemDLL("kernel32.dll").NewProc("ReplaceFileW")
+
+func replaceTrackingConfig(source, destination string) error {
+	sourcePath, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	destinationPath, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(destination); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		return windows.MoveFileEx(sourcePath, destinationPath, windows.MOVEFILE_WRITE_THROUGH)
+	}
+	result, _, callErr := replaceTrackingConfigW.Call(
+		uintptr(unsafe.Pointer(destinationPath)),
+		uintptr(unsafe.Pointer(sourcePath)),
+		0,
+		replaceTrackingConfigWriteThrough,
+		0,
+		0,
+	)
+	if result != 0 {
+		return nil
+	}
+	if callErr != windows.ERROR_SUCCESS {
+		return callErr
+	}
+	return windows.ERROR_GEN_FAILURE
+}


### PR DESCRIPTION
## Summary
- stage the complete multi-account tracking configuration in a private same-directory temporary file
- sync and close it before an atomic platform-specific replacement
- preserve prior bytes and remove temporary artifacts on injected write, sync, close, or replacement failures
- retain owner-only permissions and existing account data

## Testing
- `/tmp/gogcli-go-1.26.5/bin/go test ./internal/tracking`
- `PATH=/tmp/gogcli-go-1.26.5/bin:$PATH make ci`

## Review
- Standards/Fowler: no hard repository violations; confirmed post-commit error path fixed before publishing
- Exact spec: no remaining findings

Closes #87
