### PR TITLE
fix(sheets): emit stable plain value mutation receipts

### DIFF
--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -229,7 +229,7 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		writeSheetsValueMutationPlainSingle(ctx, "update", spreadsheetID, resp.UpdatedRange, resp.UpdatedRows, resp.UpdatedColumns, resp.UpdatedCells, 0)
+		writeSheetsValueMutationPlainSingle(ctx, "update", sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId), resp.UpdatedRange, resp.UpdatedRows, resp.UpdatedColumns, resp.UpdatedCells)
 		return nil
 	}
 
@@ -327,21 +327,17 @@ func (c *SheetsAppendCmd) Run(ctx context.Context, flags *RootFlags) error {
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		spreadsheetIDOut := spreadsheetID
-		if resp.Updates != nil && strings.TrimSpace(resp.Updates.SpreadsheetId) != "" {
-			spreadsheetIDOut = resp.Updates.SpreadsheetId
-		} else if strings.TrimSpace(resp.SpreadsheetId) != "" {
-			spreadsheetIDOut = resp.SpreadsheetId
-		}
+		spreadsheetIDOut := sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId)
 		var updatedRange string
 		var updatedRows, updatedColumns, updatedCells int64
 		if resp.Updates != nil {
+			spreadsheetIDOut = sheetsMutationSpreadsheetID(spreadsheetIDOut, resp.Updates.SpreadsheetId)
 			updatedRange = resp.Updates.UpdatedRange
 			updatedRows = resp.Updates.UpdatedRows
 			updatedColumns = resp.Updates.UpdatedColumns
 			updatedCells = resp.Updates.UpdatedCells
 		}
-		writeSheetsValueMutationPlainSingle(ctx, "append", spreadsheetIDOut, updatedRange, updatedRows, updatedColumns, updatedCells, 0)
+		writeSheetsValueMutationPlainSingle(ctx, "append", spreadsheetIDOut, updatedRange, updatedRows, updatedColumns, updatedCells)
 		return nil
 	}
 
@@ -390,10 +386,7 @@ func (c *SheetsClearCmd) Run(ctx context.Context, flags *RootFlags) error {
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		spreadsheetIDOut := spreadsheetID
-		if strings.TrimSpace(resp.SpreadsheetId) != "" {
-			spreadsheetIDOut = resp.SpreadsheetId
-		}
+		spreadsheetIDOut := sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId)
 		writeSheetsValueMutationPlainClears(ctx, "clear", spreadsheetIDOut, []string{resp.ClearedRange})
 		return nil
 	}

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -228,6 +228,10 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"updatedCells":   resp.UpdatedCells,
 		})
 	}
+	if outfmt.IsPlain(ctx) {
+		writeSheetsValueMutationPlainSingle(ctx, "update", spreadsheetID, resp.UpdatedRange, resp.UpdatedRows, resp.UpdatedColumns, resp.UpdatedCells, 0)
+		return nil
+	}
 
 	u.Out().Printf("Updated %d cells in %s", resp.UpdatedCells, resp.UpdatedRange)
 	return nil
@@ -322,6 +326,24 @@ func (c *SheetsAppendCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"updatedCells":   resp.Updates.UpdatedCells,
 		})
 	}
+	if outfmt.IsPlain(ctx) {
+		spreadsheetIDOut := spreadsheetID
+		if resp.Updates != nil && strings.TrimSpace(resp.Updates.SpreadsheetId) != "" {
+			spreadsheetIDOut = resp.Updates.SpreadsheetId
+		} else if strings.TrimSpace(resp.SpreadsheetId) != "" {
+			spreadsheetIDOut = resp.SpreadsheetId
+		}
+		var updatedRange string
+		var updatedRows, updatedColumns, updatedCells int64
+		if resp.Updates != nil {
+			updatedRange = resp.Updates.UpdatedRange
+			updatedRows = resp.Updates.UpdatedRows
+			updatedColumns = resp.Updates.UpdatedColumns
+			updatedCells = resp.Updates.UpdatedCells
+		}
+		writeSheetsValueMutationPlainSingle(ctx, "append", spreadsheetIDOut, updatedRange, updatedRows, updatedColumns, updatedCells, 0)
+		return nil
+	}
 
 	u.Out().Printf("Appended %d cells to %s", resp.Updates.UpdatedCells, resp.Updates.UpdatedRange)
 	return nil
@@ -366,6 +388,14 @@ func (c *SheetsClearCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{
 			"clearedRange": resp.ClearedRange,
 		})
+	}
+	if outfmt.IsPlain(ctx) {
+		spreadsheetIDOut := spreadsheetID
+		if strings.TrimSpace(resp.SpreadsheetId) != "" {
+			spreadsheetIDOut = resp.SpreadsheetId
+		}
+		writeSheetsValueMutationPlainClears(ctx, "clear", spreadsheetIDOut, []string{resp.ClearedRange})
+		return nil
 	}
 
 	u.Out().Printf("Cleared %s", resp.ClearedRange)

--- a/internal/cmd/sheets_batch.go
+++ b/internal/cmd/sheets_batch.go
@@ -161,32 +161,22 @@ func (c *SheetsBatchUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		spreadsheetIDOut := id
-		if strings.TrimSpace(resp.SpreadsheetId) != "" {
-			spreadsheetIDOut = resp.SpreadsheetId
-		}
-		if len(resp.Responses) > 0 {
-			rows := make([]sheetsValueMutationPlainRow, 0, len(resp.Responses))
-			for _, r := range resp.Responses {
-				if r == nil {
-					continue
-				}
-				rows = append(rows, sheetsValueMutationPlainRow{
-					Action:         "batch-update",
-					SpreadsheetID:  spreadsheetIDOut,
-					Range:          r.UpdatedRange,
-					UpdatedRows:    formatInt64Field(r.UpdatedRows),
-					UpdatedColumns: formatInt64Field(r.UpdatedColumns),
-					UpdatedCells:   formatInt64Field(r.UpdatedCells),
-					Status:         "ok",
-				})
-			}
-			if len(rows) > 0 {
-				writeSheetsValueMutationPlain(ctx, rows)
-				return nil
+		spreadsheetIDOut := sheetsMutationSpreadsheetID(id, resp.SpreadsheetId)
+		rows := make([]sheetsValueMutationPlainRow, 0, len(resp.Responses)+1)
+		for _, response := range resp.Responses {
+			if response != nil {
+				rows = append(rows, newSheetsValueMutationUpdateRow("batch-update", spreadsheetIDOut, response.UpdatedRange, response.UpdatedRows, response.UpdatedColumns, response.UpdatedCells))
 			}
 		}
-		writeSheetsValueMutationPlainSingle(ctx, "batch-update", spreadsheetIDOut, "", resp.TotalUpdatedRows, resp.TotalUpdatedColumns, resp.TotalUpdatedCells, resp.TotalUpdatedSheets)
+		writeSheetsValueMutationPlain(ctx, sheetsValueMutationRowsWithTotals(
+			"batch-update",
+			spreadsheetIDOut,
+			rows,
+			resp.TotalUpdatedRows,
+			resp.TotalUpdatedColumns,
+			resp.TotalUpdatedCells,
+			resp.TotalUpdatedSheets,
+		))
 		return nil
 	}
 

--- a/internal/cmd/sheets_batch.go
+++ b/internal/cmd/sheets_batch.go
@@ -160,6 +160,35 @@ func (c *SheetsBatchUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 			"totalUpdatedSheets":  resp.TotalUpdatedSheets,
 		})
 	}
+	if outfmt.IsPlain(ctx) {
+		spreadsheetIDOut := id
+		if strings.TrimSpace(resp.SpreadsheetId) != "" {
+			spreadsheetIDOut = resp.SpreadsheetId
+		}
+		if len(resp.Responses) > 0 {
+			rows := make([]sheetsValueMutationPlainRow, 0, len(resp.Responses))
+			for _, r := range resp.Responses {
+				if r == nil {
+					continue
+				}
+				rows = append(rows, sheetsValueMutationPlainRow{
+					Action:         "batch-update",
+					SpreadsheetID:  spreadsheetIDOut,
+					Range:          r.UpdatedRange,
+					UpdatedRows:    formatInt64Field(r.UpdatedRows),
+					UpdatedColumns: formatInt64Field(r.UpdatedColumns),
+					UpdatedCells:   formatInt64Field(r.UpdatedCells),
+					Status:         "ok",
+				})
+			}
+			if len(rows) > 0 {
+				writeSheetsValueMutationPlain(ctx, rows)
+				return nil
+			}
+		}
+		writeSheetsValueMutationPlainSingle(ctx, "batch-update", spreadsheetIDOut, "", resp.TotalUpdatedRows, resp.TotalUpdatedColumns, resp.TotalUpdatedCells, resp.TotalUpdatedSheets)
+		return nil
+	}
 
 	u := ui.FromContext(ctx)
 	u.Out().Printf("Updated %d cells across %d sheets", resp.TotalUpdatedCells, resp.TotalUpdatedSheets)

--- a/internal/cmd/sheets_gaps.go
+++ b/internal/cmd/sheets_gaps.go
@@ -337,6 +337,14 @@ func (c *SheetsValuesBatchClearCmd) Run(ctx context.Context, flags *RootFlags) e
 			"clearedRanges": resp.ClearedRanges,
 		})
 	}
+	if outfmt.IsPlain(ctx) {
+		spreadsheetIDOut := spreadsheetID
+		if strings.TrimSpace(resp.SpreadsheetId) != "" {
+			spreadsheetIDOut = resp.SpreadsheetId
+		}
+		writeSheetsValueMutationPlainClears(ctx, "batch-clear", spreadsheetIDOut, resp.ClearedRanges)
+		return nil
+	}
 
 	u.Out().Printf("Cleared %d range(s)", len(resp.ClearedRanges))
 	return nil
@@ -393,6 +401,14 @@ func (c *SheetsValuesBatchClearByFilterCmd) Run(ctx context.Context, flags *Root
 			"spreadsheetId": resp.SpreadsheetId,
 			"clearedRanges": resp.ClearedRanges,
 		})
+	}
+	if outfmt.IsPlain(ctx) {
+		spreadsheetIDOut := spreadsheetID
+		if strings.TrimSpace(resp.SpreadsheetId) != "" {
+			spreadsheetIDOut = resp.SpreadsheetId
+		}
+		writeSheetsValueMutationPlainClears(ctx, "batch-clear-by-filter", spreadsheetIDOut, resp.ClearedRanges)
+		return nil
 	}
 
 	u.Out().Printf("Cleared %d range(s)", len(resp.ClearedRanges))
@@ -561,6 +577,35 @@ func (c *SheetsValuesBatchUpdateByFilterCmd) Run(ctx context.Context, flags *Roo
 			"totalUpdatedSheets":  resp.TotalUpdatedSheets,
 			"responses":           resp.Responses,
 		})
+	}
+	if outfmt.IsPlain(ctx) {
+		spreadsheetIDOut := spreadsheetID
+		if strings.TrimSpace(resp.SpreadsheetId) != "" {
+			spreadsheetIDOut = resp.SpreadsheetId
+		}
+		if len(resp.Responses) > 0 {
+			rows := make([]sheetsValueMutationPlainRow, 0, len(resp.Responses))
+			for _, r := range resp.Responses {
+				if r == nil {
+					continue
+				}
+				rows = append(rows, sheetsValueMutationPlainRow{
+					Action:         "batch-update-by-filter",
+					SpreadsheetID:  spreadsheetIDOut,
+					Range:          r.UpdatedRange,
+					UpdatedRows:    formatInt64Field(r.UpdatedRows),
+					UpdatedColumns: formatInt64Field(r.UpdatedColumns),
+					UpdatedCells:   formatInt64Field(r.UpdatedCells),
+					Status:         "ok",
+				})
+			}
+			if len(rows) > 0 {
+				writeSheetsValueMutationPlain(ctx, rows)
+				return nil
+			}
+		}
+		writeSheetsValueMutationPlainSingle(ctx, "batch-update-by-filter", spreadsheetIDOut, "", resp.TotalUpdatedRows, resp.TotalUpdatedColumns, resp.TotalUpdatedCells, resp.TotalUpdatedSheets)
+		return nil
 	}
 
 	u.Out().Printf("Updated %d cells in %d row(s)", resp.TotalUpdatedCells, resp.TotalUpdatedRows)

--- a/internal/cmd/sheets_gaps.go
+++ b/internal/cmd/sheets_gaps.go
@@ -338,10 +338,7 @@ func (c *SheetsValuesBatchClearCmd) Run(ctx context.Context, flags *RootFlags) e
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		spreadsheetIDOut := spreadsheetID
-		if strings.TrimSpace(resp.SpreadsheetId) != "" {
-			spreadsheetIDOut = resp.SpreadsheetId
-		}
+		spreadsheetIDOut := sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId)
 		writeSheetsValueMutationPlainClears(ctx, "batch-clear", spreadsheetIDOut, resp.ClearedRanges)
 		return nil
 	}
@@ -403,10 +400,7 @@ func (c *SheetsValuesBatchClearByFilterCmd) Run(ctx context.Context, flags *Root
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		spreadsheetIDOut := spreadsheetID
-		if strings.TrimSpace(resp.SpreadsheetId) != "" {
-			spreadsheetIDOut = resp.SpreadsheetId
-		}
+		spreadsheetIDOut := sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId)
 		writeSheetsValueMutationPlainClears(ctx, "batch-clear-by-filter", spreadsheetIDOut, resp.ClearedRanges)
 		return nil
 	}
@@ -579,32 +573,22 @@ func (c *SheetsValuesBatchUpdateByFilterCmd) Run(ctx context.Context, flags *Roo
 		})
 	}
 	if outfmt.IsPlain(ctx) {
-		spreadsheetIDOut := spreadsheetID
-		if strings.TrimSpace(resp.SpreadsheetId) != "" {
-			spreadsheetIDOut = resp.SpreadsheetId
-		}
-		if len(resp.Responses) > 0 {
-			rows := make([]sheetsValueMutationPlainRow, 0, len(resp.Responses))
-			for _, r := range resp.Responses {
-				if r == nil {
-					continue
-				}
-				rows = append(rows, sheetsValueMutationPlainRow{
-					Action:         "batch-update-by-filter",
-					SpreadsheetID:  spreadsheetIDOut,
-					Range:          r.UpdatedRange,
-					UpdatedRows:    formatInt64Field(r.UpdatedRows),
-					UpdatedColumns: formatInt64Field(r.UpdatedColumns),
-					UpdatedCells:   formatInt64Field(r.UpdatedCells),
-					Status:         "ok",
-				})
-			}
-			if len(rows) > 0 {
-				writeSheetsValueMutationPlain(ctx, rows)
-				return nil
+		spreadsheetIDOut := sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId)
+		rows := make([]sheetsValueMutationPlainRow, 0, len(resp.Responses)+1)
+		for _, response := range resp.Responses {
+			if response != nil {
+				rows = append(rows, newSheetsValueMutationUpdateRow("batch-update-by-filter", spreadsheetIDOut, response.UpdatedRange, response.UpdatedRows, response.UpdatedColumns, response.UpdatedCells))
 			}
 		}
-		writeSheetsValueMutationPlainSingle(ctx, "batch-update-by-filter", spreadsheetIDOut, "", resp.TotalUpdatedRows, resp.TotalUpdatedColumns, resp.TotalUpdatedCells, resp.TotalUpdatedSheets)
+		writeSheetsValueMutationPlain(ctx, sheetsValueMutationRowsWithTotals(
+			"batch-update-by-filter",
+			spreadsheetIDOut,
+			rows,
+			resp.TotalUpdatedRows,
+			resp.TotalUpdatedColumns,
+			resp.TotalUpdatedCells,
+			resp.TotalUpdatedSheets,
+		))
 		return nil
 	}
 

--- a/internal/cmd/sheets_value_mutation_plain.go
+++ b/internal/cmd/sheets_value_mutation_plain.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+// sheetsValueMutationPlainRow is one TSV receipt for a Sheets value mutation.
+// Header: ACTION SPREADSHEET_ID RANGE UPDATED_ROWS UPDATED_COLUMNS UPDATED_CELLS UPDATED_SHEETS STATUS
+type sheetsValueMutationPlainRow struct {
+	Action         string
+	SpreadsheetID  string
+	Range          string
+	UpdatedRows    string
+	UpdatedColumns string
+	UpdatedCells   string
+	UpdatedSheets  string
+	Status         string
+}
+
+func formatInt64Field(v int64) string {
+	if v == 0 {
+		return ""
+	}
+	return strconv.FormatInt(v, 10)
+}
+
+func writeSheetsValueMutationPlain(ctx context.Context, rows []sheetsValueMutationPlainRow) {
+	w, flush := tableWriter(ctx)
+	defer flush()
+	fmt.Fprintln(w, "ACTION\tSPREADSHEET_ID\tRANGE\tUPDATED_ROWS\tUPDATED_COLUMNS\tUPDATED_CELLS\tUPDATED_SHEETS\tSTATUS")
+	for _, row := range rows {
+		status := row.Status
+		if status == "" {
+			status = "ok"
+		}
+		writeTableRow(ctx, w, []string{
+			row.Action,
+			row.SpreadsheetID,
+			row.Range,
+			row.UpdatedRows,
+			row.UpdatedColumns,
+			row.UpdatedCells,
+			row.UpdatedSheets,
+			status,
+		})
+	}
+}
+
+func writeSheetsValueMutationPlainSingle(ctx context.Context, action, spreadsheetID, rangeSpec string, updatedRows, updatedColumns, updatedCells, updatedSheets int64) {
+	writeSheetsValueMutationPlain(ctx, []sheetsValueMutationPlainRow{{
+		Action:         action,
+		SpreadsheetID:  spreadsheetID,
+		Range:          rangeSpec,
+		UpdatedRows:    formatInt64Field(updatedRows),
+		UpdatedColumns: formatInt64Field(updatedColumns),
+		UpdatedCells:   formatInt64Field(updatedCells),
+		UpdatedSheets:  formatInt64Field(updatedSheets),
+		Status:         "ok",
+	}})
+}
+
+func writeSheetsValueMutationPlainClears(ctx context.Context, action, spreadsheetID string, ranges []string) {
+	if len(ranges) == 0 {
+		writeSheetsValueMutationPlain(ctx, []sheetsValueMutationPlainRow{{
+			Action:        action,
+			SpreadsheetID: spreadsheetID,
+			Status:        "ok",
+		}})
+		return
+	}
+	rows := make([]sheetsValueMutationPlainRow, 0, len(ranges))
+	for _, r := range ranges {
+		rows = append(rows, sheetsValueMutationPlainRow{
+			Action:        action,
+			SpreadsheetID: spreadsheetID,
+			Range:         r,
+			Status:        "ok",
+		})
+	}
+	writeSheetsValueMutationPlain(ctx, rows)
+}

--- a/internal/cmd/sheets_value_mutation_plain.go
+++ b/internal/cmd/sheets_value_mutation_plain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // sheetsValueMutationPlainRow is one TSV receipt for a Sheets value mutation.
@@ -19,11 +20,40 @@ type sheetsValueMutationPlainRow struct {
 	Status         string
 }
 
-func formatInt64Field(v int64) string {
-	if v == 0 {
-		return ""
+func sheetsMutationSpreadsheetID(requestID, responseID string) string {
+	if id := strings.TrimSpace(responseID); id != "" {
+		return id
 	}
+	return requestID
+}
+
+func formatSheetsMutationCount(v int64) string {
 	return strconv.FormatInt(v, 10)
+}
+
+func newSheetsValueMutationUpdateRow(action, spreadsheetID, updatedRange string, updatedRows, updatedColumns, updatedCells int64) sheetsValueMutationPlainRow {
+	return sheetsValueMutationPlainRow{
+		Action:         action,
+		SpreadsheetID:  spreadsheetID,
+		Range:          updatedRange,
+		UpdatedRows:    formatSheetsMutationCount(updatedRows),
+		UpdatedColumns: formatSheetsMutationCount(updatedColumns),
+		UpdatedCells:   formatSheetsMutationCount(updatedCells),
+		Status:         "ok",
+	}
+}
+
+func sheetsValueMutationRowsWithTotals(action, spreadsheetID string, rows []sheetsValueMutationPlainRow, totalRows, totalColumns, totalCells, totalSheets int64) []sheetsValueMutationPlainRow {
+	rows = append(rows, sheetsValueMutationPlainRow{
+		Action:         action,
+		SpreadsheetID:  spreadsheetID,
+		UpdatedRows:    formatSheetsMutationCount(totalRows),
+		UpdatedColumns: formatSheetsMutationCount(totalColumns),
+		UpdatedCells:   formatSheetsMutationCount(totalCells),
+		UpdatedSheets:  formatSheetsMutationCount(totalSheets),
+		Status:         "ok",
+	})
+	return rows
 }
 
 func writeSheetsValueMutationPlain(ctx context.Context, rows []sheetsValueMutationPlainRow) {
@@ -48,15 +78,14 @@ func writeSheetsValueMutationPlain(ctx context.Context, rows []sheetsValueMutati
 	}
 }
 
-func writeSheetsValueMutationPlainSingle(ctx context.Context, action, spreadsheetID, rangeSpec string, updatedRows, updatedColumns, updatedCells, updatedSheets int64) {
+func writeSheetsValueMutationPlainSingle(ctx context.Context, action, spreadsheetID, rangeSpec string, updatedRows, updatedColumns, updatedCells int64) {
 	writeSheetsValueMutationPlain(ctx, []sheetsValueMutationPlainRow{{
 		Action:         action,
 		SpreadsheetID:  spreadsheetID,
 		Range:          rangeSpec,
-		UpdatedRows:    formatInt64Field(updatedRows),
-		UpdatedColumns: formatInt64Field(updatedColumns),
-		UpdatedCells:   formatInt64Field(updatedCells),
-		UpdatedSheets:  formatInt64Field(updatedSheets),
+		UpdatedRows:    formatSheetsMutationCount(updatedRows),
+		UpdatedColumns: formatSheetsMutationCount(updatedColumns),
+		UpdatedCells:   formatSheetsMutationCount(updatedCells),
 		Status:         "ok",
 	}})
 }

--- a/internal/cmd/sheets_value_mutation_plain_test.go
+++ b/internal/cmd/sheets_value_mutation_plain_test.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+)
+
+const sheetsValueMutationPlainHeader = "ACTION\tSPREADSHEET_ID\tRANGE\tUPDATED_ROWS\tUPDATED_COLUMNS\tUPDATED_CELLS\tUPDATED_SHEETS\tSTATUS\n"
+
+func TestSheetsValueMutations_PlainReceipts(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPut && strings.Contains(path, "/v4/spreadsheets/ss-update/values/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId":  "ss-update",
+				"updatedRange":   "Sheet1!A1:B2",
+				"updatedRows":    2,
+				"updatedColumns": 2,
+				"updatedCells":   4,
+			})
+			return
+
+		case r.Method == http.MethodPost && strings.Contains(path, "/v4/spreadsheets/ss-append/values/") && strings.Contains(path, ":append"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId": "ss-append",
+				"updates": map[string]any{
+					"spreadsheetId":  "ss-append",
+					"updatedRange":   "Sheet1!A3:B3",
+					"updatedRows":    1,
+					"updatedColumns": 2,
+					"updatedCells":   2,
+				},
+			})
+			return
+
+		case r.Method == http.MethodPost && strings.Contains(path, "/v4/spreadsheets/ss-clear/values/") && strings.Contains(path, ":clear"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId": "ss-clear",
+				"clearedRange":  "Sheet1!A1:B2",
+			})
+			return
+
+		case r.Method == http.MethodPost && strings.Contains(path, "/v4/spreadsheets/ss-batch-update/values:batchUpdate"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId":       "ss-batch-update",
+				"totalUpdatedRows":    3,
+				"totalUpdatedColumns": 2,
+				"totalUpdatedCells":   5,
+				"totalUpdatedSheets":  1,
+				"responses": []map[string]any{
+					{
+						"spreadsheetId":  "ss-batch-update",
+						"updatedRange":   "Sheet1!A1:B2",
+						"updatedRows":    2,
+						"updatedColumns": 2,
+						"updatedCells":   4,
+					},
+					{
+						"spreadsheetId":  "ss-batch-update",
+						"updatedRange":   "Sheet1!C1",
+						"updatedRows":    1,
+						"updatedColumns": 1,
+						"updatedCells":   1,
+					},
+				},
+			})
+			return
+
+		case r.Method == http.MethodPost && strings.Contains(path, "/v4/spreadsheets/ss-batch-clear/values:batchClear"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId": "ss-batch-clear",
+				"clearedRanges": []string{"Sheet1!A1:B2", "Sheet1!D1:E2"},
+			})
+			return
+
+		case r.Method == http.MethodPost && strings.Contains(path, "/v4/spreadsheets/ss-filter-update/values:batchUpdateByDataFilter"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId":       "ss-filter-update",
+				"totalUpdatedRows":    2,
+				"totalUpdatedColumns": 2,
+				"totalUpdatedCells":   4,
+				"totalUpdatedSheets":  1,
+				"responses": []map[string]any{
+					{
+						"updatedRange":   "Sheet1!A1:B2",
+						"updatedRows":    2,
+						"updatedColumns": 2,
+						"updatedCells":   4,
+					},
+				},
+			})
+			return
+
+		case r.Method == http.MethodPost && strings.Contains(path, "/v4/spreadsheets/ss-filter-clear/values:batchClearByDataFilter"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId": "ss-filter-clear",
+				"clearedRanges": []string{"Sheet1!A1:B2"},
+			})
+			return
+
+		case r.Method == http.MethodPost && strings.Contains(path, "/v4/spreadsheets/ss-batch-update-totals/values:batchUpdate"):
+			// Multi-range API response without per-range details: emit totals once.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId":       "ss-batch-update-totals",
+				"totalUpdatedRows":    2,
+				"totalUpdatedColumns": 2,
+				"totalUpdatedCells":   4,
+				"totalUpdatedSheets":  1,
+			})
+			return
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "update",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "update", "ss-update", "Sheet1!A1:B2",
+				"--values-json", `[["a","b"],["c","d"]]`,
+			},
+			want: sheetsValueMutationPlainHeader + "update\tss-update\tSheet1!A1:B2\t2\t2\t4\t\tok\n",
+		},
+		{
+			name: "append",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "append", "ss-append", "Sheet1!A:B",
+				"--values-json", `[["e","f"]]`,
+			},
+			want: sheetsValueMutationPlainHeader + "append\tss-append\tSheet1!A3:B3\t1\t2\t2\t\tok\n",
+		},
+		{
+			name: "clear",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "clear", "ss-clear", "Sheet1!A1:B2",
+			},
+			want: sheetsValueMutationPlainHeader + "clear\tss-clear\tSheet1!A1:B2\t\t\t\t\tok\n",
+		},
+		{
+			name: "batch-update multi-range",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "batch-update", "ss-batch-update",
+				"--values-json", `[{"range":"Sheet1!A1:B2","values":[["a","b"],["c","d"]]},{"range":"Sheet1!C1","values":[["x"]]}]`,
+			},
+			want: sheetsValueMutationPlainHeader +
+				"batch-update\tss-batch-update\tSheet1!A1:B2\t2\t2\t4\t\tok\n" +
+				"batch-update\tss-batch-update\tSheet1!C1\t1\t1\t1\t\tok\n",
+		},
+		{
+			name: "batch-update totals only",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "batch-update", "ss-batch-update-totals",
+				"--values-json", `[{"range":"Sheet1!A1:B2","values":[["a","b"],["c","d"]]}]`,
+			},
+			want: sheetsValueMutationPlainHeader + "batch-update\tss-batch-update-totals\t\t2\t2\t4\t1\tok\n",
+		},
+		{
+			name: "batch-clear",
+			args: []string{
+				"--plain", "--account", "a@b.com", "--force",
+				"sheets", "batch-clear", "ss-batch-clear",
+				"--ranges", "Sheet1!A1:B2",
+				"--ranges", "Sheet1!D1:E2",
+			},
+			want: sheetsValueMutationPlainHeader +
+				"batch-clear\tss-batch-clear\tSheet1!A1:B2\t\t\t\t\tok\n" +
+				"batch-clear\tss-batch-clear\tSheet1!D1:E2\t\t\t\t\tok\n",
+		},
+		{
+			name: "batch-update-by-filter",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "batch-update-by-filter", "ss-filter-update",
+				"--data-json", `[{"dataFilter":{"a1Range":"Sheet1!A1:B2"},"values":[["a","b"],["c","d"]]}]`,
+			},
+			want: sheetsValueMutationPlainHeader + "batch-update-by-filter\tss-filter-update\tSheet1!A1:B2\t2\t2\t4\t\tok\n",
+		},
+		{
+			name: "batch-clear-by-filter",
+			args: []string{
+				"--plain", "--account", "a@b.com", "--force",
+				"sheets", "batch-clear-by-filter", "ss-filter-clear",
+				"--filters-json", `[{"a1Range":"Sheet1!A1:B2"}]`,
+			},
+			want: sheetsValueMutationPlainHeader + "batch-clear-by-filter\tss-filter-clear\tSheet1!A1:B2\t\t\t\t\tok\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				_ = captureStderr(t, func() {
+					if err := Execute(tt.args); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+			if out != tt.want {
+				t.Fatalf("plain output mismatch:\nwant %q\ngot  %q", tt.want, out)
+			}
+			for _, prose := range []string{"Updated ", "Appended ", "Cleared "} {
+				if strings.Contains(out, prose) {
+					t.Fatalf("plain stdout contains prose %q: %q", prose, out)
+				}
+			}
+		})
+	}
+}

--- a/internal/cmd/sheets_value_mutation_plain_test.go
+++ b/internal/cmd/sheets_value_mutation_plain_test.go
@@ -25,11 +25,21 @@ func TestSheetsValueMutations_PlainReceipts(t *testing.T) {
 		switch {
 		case r.Method == http.MethodPut && strings.Contains(path, "/v4/spreadsheets/ss-update/values/"):
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"spreadsheetId":  "ss-update",
+				"spreadsheetId":  "ss-update-response",
 				"updatedRange":   "Sheet1!A1:B2",
 				"updatedRows":    2,
 				"updatedColumns": 2,
 				"updatedCells":   4,
+			})
+			return
+
+		case r.Method == http.MethodPut && strings.Contains(path, "/v4/spreadsheets/ss-update-zero/values/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId":  "ss-update-zero",
+				"updatedRange":   "Sheet1!A1",
+				"updatedRows":    0,
+				"updatedColumns": 0,
+				"updatedCells":   0,
 			})
 			return
 
@@ -150,7 +160,16 @@ func TestSheetsValueMutations_PlainReceipts(t *testing.T) {
 				"sheets", "update", "ss-update", "Sheet1!A1:B2",
 				"--values-json", `[["a","b"],["c","d"]]`,
 			},
-			want: sheetsValueMutationPlainHeader + "update\tss-update\tSheet1!A1:B2\t2\t2\t4\t\tok\n",
+			want: sheetsValueMutationPlainHeader + "update\tss-update-response\tSheet1!A1:B2\t2\t2\t4\t\tok\n",
+		},
+		{
+			name: "update preserves zero counts",
+			args: []string{
+				"--plain", "--account", "a@b.com",
+				"sheets", "update", "ss-update-zero", "Sheet1!A1",
+				"--values-json", `[[""]]`,
+			},
+			want: sheetsValueMutationPlainHeader + "update\tss-update-zero\tSheet1!A1\t0\t0\t0\t\tok\n",
 		},
 		{
 			name: "append",
@@ -178,7 +197,8 @@ func TestSheetsValueMutations_PlainReceipts(t *testing.T) {
 			},
 			want: sheetsValueMutationPlainHeader +
 				"batch-update\tss-batch-update\tSheet1!A1:B2\t2\t2\t4\t\tok\n" +
-				"batch-update\tss-batch-update\tSheet1!C1\t1\t1\t1\t\tok\n",
+				"batch-update\tss-batch-update\tSheet1!C1\t1\t1\t1\t\tok\n" +
+				"batch-update\tss-batch-update\t\t3\t2\t5\t1\tok\n",
 		},
 		{
 			name: "batch-update totals only",
@@ -208,7 +228,9 @@ func TestSheetsValueMutations_PlainReceipts(t *testing.T) {
 				"sheets", "batch-update-by-filter", "ss-filter-update",
 				"--data-json", `[{"dataFilter":{"a1Range":"Sheet1!A1:B2"},"values":[["a","b"],["c","d"]]}]`,
 			},
-			want: sheetsValueMutationPlainHeader + "batch-update-by-filter\tss-filter-update\tSheet1!A1:B2\t2\t2\t4\t\tok\n",
+			want: sheetsValueMutationPlainHeader +
+				"batch-update-by-filter\tss-filter-update\tSheet1!A1:B2\t2\t2\t4\t\tok\n" +
+				"batch-update-by-filter\tss-filter-update\t\t2\t2\t4\t1\tok\n",
 		},
 		{
 			name: "batch-clear-by-filter",

--- a/internal/cmd/sheets_value_mutation_plain_test.go
+++ b/internal/cmd/sheets_value_mutation_plain_test.go
@@ -164,7 +164,7 @@ func TestSheetsValueMutations_PlainReceipts(t *testing.T) {
 		{
 			name: "clear",
 			args: []string{
-				"--plain", "--account", "a@b.com",
+				"--plain", "--account", "a@b.com", "--force",
 				"sheets", "clear", "ss-clear", "Sheet1!A1:B2",
 			},
 			want: sheetsValueMutationPlainHeader + "clear\tss-clear\tSheet1!A1:B2\t\t\t\t\tok\n",


### PR DESCRIPTION
## Summary
- emit the issue-defined 8-column TSV receipt for Sheets value update, append, clear, batch update/clear, and data-filter mutations under `--plain`
- preserve per-range rows and add deterministic aggregate rows for batch totals
- preserve API-returned counts, including zero values, while keeping clear count fields empty and status explicit
- retain merged #85 structural receipts, existing confirmation policy, JSON output, and default human messages

## Testing
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" go test ./internal/cmd -run 'TestSheets(ValueMutations|StructuralMutations)_PlainReceipts' -count=1`
- `PATH="$HOME/.local/go-sdk/go/bin:$PATH" make ci`

Closes #86
