### PR TITLE
fix(calendar): report incomplete multi-calendar event fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,10 @@ gog calendar events <calendarId> --from 2025-01-01T00:00:00Z --to 2025-01-08T00:
 gog calendar events --all             # Fetch events from all calendars
 gog calendar events --calendars 1,3   # Fetch events from calendar indices (see gog calendar calendars)
 gog calendar events --cal Work --cal Personal  # Fetch events from calendars by name/ID
+# Multi-calendar --plain rows use: TYPE CALENDAR ID START END SUMMARY ERROR
+# With --weekday: TYPE CALENDAR ID START START_DOW END END_DOW SUMMARY ERROR
+# TYPE is "event" or "calendar_error"; errors occupy CALENDAR and ERROR.
+# Multi-calendar --json returns events, per-calendar errors, and a complete boolean.
 gog calendar event <calendarId> <eventId>
 gog calendar get <calendarId> <eventId>                     # Alias for event
 gog calendar search "meeting" --today

--- a/internal/cmd/calendar_all_events_test.go
+++ b/internal/cmd/calendar_all_events_test.go
@@ -103,3 +103,48 @@ func TestListAllCalendarsEvents_JSON(t *testing.T) {
 		t.Fatalf("unexpected completeness metadata: complete=%v errors=%#v", parsed.Complete, parsed.Errors)
 	}
 }
+
+func TestListAllCalendarsEvents_JSON_EmptySelectionIsComplete(t *testing.T) {
+	srv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendarList") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+			return
+		}
+		http.NotFound(w, r)
+	})))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := outfmt.WithMode(ui.WithUI(context.Background(), u), outfmt.Mode{JSON: true})
+
+	jsonOut := captureStdout(t, func() {
+		if err := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", "", "", "", "", false); err != nil {
+			t.Fatalf("listAllCalendarsEvents: %v", err)
+		}
+	})
+
+	var parsed struct {
+		Events   []map[string]any `json:"events"`
+		Errors   []map[string]any `json:"errors"`
+		Complete bool             `json:"complete"`
+	}
+	if err := json.Unmarshal([]byte(jsonOut), &parsed); err != nil {
+		t.Fatalf("json parse: %v", err)
+	}
+	if !parsed.Complete || len(parsed.Events) != 0 || len(parsed.Errors) != 0 {
+		t.Fatalf("unexpected empty result: %#v", parsed)
+	}
+}

--- a/internal/cmd/calendar_all_events_test.go
+++ b/internal/cmd/calendar_all_events_test.go
@@ -89,12 +89,17 @@ func TestListAllCalendarsEvents_JSON(t *testing.T) {
 	})
 
 	var parsed struct {
-		Events []map[string]any `json:"events"`
+		Events   []map[string]any `json:"events"`
+		Errors   []map[string]any `json:"errors"`
+		Complete bool             `json:"complete"`
 	}
 	if err := json.Unmarshal([]byte(jsonOut), &parsed); err != nil {
 		t.Fatalf("json parse: %v", err)
 	}
 	if len(parsed.Events) != 2 {
 		t.Fatalf("unexpected events: %#v", parsed.Events)
+	}
+	if !parsed.Complete || len(parsed.Errors) != 0 {
+		t.Fatalf("unexpected completeness metadata: complete=%v errors=%#v", parsed.Complete, parsed.Errors)
 	}
 }

--- a/internal/cmd/calendar_list.go
+++ b/internal/cmd/calendar_list.go
@@ -83,6 +83,11 @@ type eventWithCalendar struct {
 	EndLocal       string `json:"endLocal,omitempty"`
 }
 
+type calendarEventError struct {
+	CalendarID string `json:"calendarId"`
+	Error      string `json:"error"`
+}
+
 func listAllCalendarsEvents(ctx context.Context, svc *calendar.Service, from, to string, maxResults int64, page, query, privatePropFilter, sharedPropFilter, fields string, showWeekday bool) error {
 	u := ui.FromContext(ctx)
 
@@ -118,6 +123,7 @@ func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarI
 	u := ui.FromContext(ctx)
 
 	all := []*eventWithCalendar{}
+	failures := []calendarEventError{}
 	for _, calID := range calendarIDs {
 		calID = strings.TrimSpace(calID)
 		if calID == "" {
@@ -144,7 +150,9 @@ func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarI
 		}
 		events, err := call.Context(ctx).Do()
 		if err != nil {
-			u.Err().Printf("calendar %s: %v", calID, err)
+			failure := calendarEventError{CalendarID: calID, Error: err.Error()}
+			failures = append(failures, failure)
+			u.Err().Printf("calendar %s: %s", failure.CalendarID, failure.Error)
 			continue
 		}
 		for _, e := range events.Items {
@@ -164,10 +172,22 @@ func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarI
 		}
 	}
 
-	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"events": all})
+	var resultErr error
+	if len(failures) > 0 {
+		resultErr = fmt.Errorf("failed to fetch events from %d calendar(s)", len(failures))
 	}
-	if len(all) == 0 {
+
+	if outfmt.IsJSON(ctx) {
+		if err := outfmt.WriteJSON(os.Stdout, map[string]any{
+			"events":   all,
+			"errors":   failures,
+			"complete": len(failures) == 0,
+		}); err != nil {
+			return err
+		}
+		return resultErr
+	}
+	if len(all) == 0 && len(failures) == 0 {
 		u.Err().Println("No events")
 		return nil
 	}
@@ -175,18 +195,24 @@ func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarI
 	w, flush := tableWriter(ctx)
 	defer flush()
 	if showWeekday {
-		fmt.Fprintln(w, "CALENDAR\tID\tSTART\tSTART_DOW\tEND\tEND_DOW\tSUMMARY")
+		fmt.Fprintln(w, "TYPE\tCALENDAR\tID\tSTART\tSTART_DOW\tEND\tEND_DOW\tSUMMARY\tERROR")
 		for _, e := range all {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.CalendarID, e.Id, eventStart(e.Event), e.StartDayOfWeek, eventEnd(e.Event), e.EndDayOfWeek, e.Summary)
+			fmt.Fprintf(w, "event\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n", e.CalendarID, e.Id, eventStart(e.Event), e.StartDayOfWeek, eventEnd(e.Event), e.EndDayOfWeek, e.Summary)
 		}
-		return nil
+		for _, failure := range failures {
+			fmt.Fprintf(w, "calendar_error\t%s\t\t\t\t\t\t\t%s\n", failure.CalendarID, sanitizeTab(strings.NewReplacer("\r", " ", "\n", " ").Replace(failure.Error)))
+		}
+		return resultErr
 	}
 
-	fmt.Fprintln(w, "CALENDAR\tID\tSTART\tEND\tSUMMARY")
+	fmt.Fprintln(w, "TYPE\tCALENDAR\tID\tSTART\tEND\tSUMMARY\tERROR")
 	for _, e := range all {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", e.CalendarID, e.Id, eventStart(e.Event), eventEnd(e.Event), e.Summary)
+		fmt.Fprintf(w, "event\t%s\t%s\t%s\t%s\t%s\t\n", e.CalendarID, e.Id, eventStart(e.Event), eventEnd(e.Event), e.Summary)
 	}
-	return nil
+	for _, failure := range failures {
+		fmt.Fprintf(w, "calendar_error\t%s\t\t\t\t\t%s\n", failure.CalendarID, sanitizeTab(strings.NewReplacer("\r", " ", "\n", " ").Replace(failure.Error)))
+	}
+	return resultErr
 }
 
 func resolveCalendarIDs(ctx context.Context, svc *calendar.Service, inputs []string) ([]string, error) {

--- a/internal/cmd/calendar_list.go
+++ b/internal/cmd/calendar_list.go
@@ -89,16 +89,9 @@ type calendarEventError struct {
 }
 
 func listAllCalendarsEvents(ctx context.Context, svc *calendar.Service, from, to string, maxResults int64, page, query, privatePropFilter, sharedPropFilter, fields string, showWeekday bool) error {
-	u := ui.FromContext(ctx)
-
 	calendars, err := listCalendarList(ctx, svc)
 	if err != nil {
 		return err
-	}
-
-	if len(calendars) == 0 {
-		u.Err().Println("No calendars")
-		return nil
 	}
 
 	ids := make([]string, 0, len(calendars))
@@ -107,10 +100,6 @@ func listAllCalendarsEvents(ctx context.Context, svc *calendar.Service, from, to
 			continue
 		}
 		ids = append(ids, cal.Id)
-	}
-	if len(ids) == 0 {
-		u.Err().Println("No calendars")
-		return nil
 	}
 	return listCalendarIDsEvents(ctx, svc, ids, from, to, maxResults, page, query, privatePropFilter, sharedPropFilter, fields, showWeekday)
 }
@@ -194,23 +183,26 @@ func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarI
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	if showWeekday {
-		writeTableRow(ctx, w, []string{"TYPE", "CALENDAR", "ID", "START", "START_DOW", "END", "END_DOW", "SUMMARY", "ERROR"})
-		for _, e := range all {
-			writeTableRow(ctx, w, []string{"event", e.CalendarID, e.Id, eventStart(e.Event), e.StartDayOfWeek, eventEnd(e.Event), e.EndDayOfWeek, e.Summary, ""})
-		}
-		for _, failure := range failures {
-			writeTableRow(ctx, w, []string{"calendar_error", failure.CalendarID, "", "", "", "", "", "", sanitizeTab(failure.Error)})
-		}
-		return resultErr
-	}
 
-	writeTableRow(ctx, w, []string{"TYPE", "CALENDAR", "ID", "START", "END", "SUMMARY", "ERROR"})
+	header := []string{"TYPE", "CALENDAR", "ID", "START", "END", "SUMMARY", "ERROR"}
+	if showWeekday {
+		header = []string{"TYPE", "CALENDAR", "ID", "START", "START_DOW", "END", "END_DOW", "SUMMARY", "ERROR"}
+	}
+	writeTableRow(ctx, w, header)
+
 	for _, e := range all {
-		writeTableRow(ctx, w, []string{"event", e.CalendarID, e.Id, eventStart(e.Event), eventEnd(e.Event), e.Summary, ""})
+		row := []string{"event", e.CalendarID, e.Id, eventStart(e.Event), eventEnd(e.Event), e.Summary, ""}
+		if showWeekday {
+			row = []string{"event", e.CalendarID, e.Id, eventStart(e.Event), e.StartDayOfWeek, eventEnd(e.Event), e.EndDayOfWeek, e.Summary, ""}
+		}
+		writeTableRow(ctx, w, row)
 	}
 	for _, failure := range failures {
-		writeTableRow(ctx, w, []string{"calendar_error", failure.CalendarID, "", "", "", "", sanitizeTab(failure.Error)})
+		row := make([]string, len(header))
+		row[0] = "calendar_error"
+		row[1] = failure.CalendarID
+		row[len(row)-1] = sanitizeTab(failure.Error)
+		writeTableRow(ctx, w, row)
 	}
 	return resultErr
 }

--- a/internal/cmd/calendar_list.go
+++ b/internal/cmd/calendar_list.go
@@ -195,22 +195,22 @@ func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarI
 	w, flush := tableWriter(ctx)
 	defer flush()
 	if showWeekday {
-		fmt.Fprintln(w, "TYPE\tCALENDAR\tID\tSTART\tSTART_DOW\tEND\tEND_DOW\tSUMMARY\tERROR")
+		writeTableRow(ctx, w, []string{"TYPE", "CALENDAR", "ID", "START", "START_DOW", "END", "END_DOW", "SUMMARY", "ERROR"})
 		for _, e := range all {
-			fmt.Fprintf(w, "event\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n", e.CalendarID, e.Id, eventStart(e.Event), e.StartDayOfWeek, eventEnd(e.Event), e.EndDayOfWeek, e.Summary)
+			writeTableRow(ctx, w, []string{"event", e.CalendarID, e.Id, eventStart(e.Event), e.StartDayOfWeek, eventEnd(e.Event), e.EndDayOfWeek, e.Summary, ""})
 		}
 		for _, failure := range failures {
-			fmt.Fprintf(w, "calendar_error\t%s\t\t\t\t\t\t\t%s\n", failure.CalendarID, sanitizeTab(strings.NewReplacer("\r", " ", "\n", " ").Replace(failure.Error)))
+			writeTableRow(ctx, w, []string{"calendar_error", failure.CalendarID, "", "", "", "", "", "", sanitizeTab(failure.Error)})
 		}
 		return resultErr
 	}
 
-	fmt.Fprintln(w, "TYPE\tCALENDAR\tID\tSTART\tEND\tSUMMARY\tERROR")
+	writeTableRow(ctx, w, []string{"TYPE", "CALENDAR", "ID", "START", "END", "SUMMARY", "ERROR"})
 	for _, e := range all {
-		fmt.Fprintf(w, "event\t%s\t%s\t%s\t%s\t%s\t\n", e.CalendarID, e.Id, eventStart(e.Event), eventEnd(e.Event), e.Summary)
+		writeTableRow(ctx, w, []string{"event", e.CalendarID, e.Id, eventStart(e.Event), eventEnd(e.Event), e.Summary, ""})
 	}
 	for _, failure := range failures {
-		fmt.Fprintf(w, "calendar_error\t%s\t\t\t\t\t%s\n", failure.CalendarID, sanitizeTab(strings.NewReplacer("\r", " ", "\n", " ").Replace(failure.Error)))
+		writeTableRow(ctx, w, []string{"calendar_error", failure.CalendarID, "", "", "", "", sanitizeTab(failure.Error)})
 	}
 	return resultErr
 }

--- a/internal/cmd/execute_calendar_events_text_test.go
+++ b/internal/cmd/execute_calendar_events_text_test.go
@@ -132,6 +132,22 @@ func TestExecute_CalendarEvents_Text_AllReportsPartialFailure(t *testing.T) {
 	if !strings.Contains(errOut, "calendar c2:") || !strings.Contains(errOut, "access denied") {
 		t.Fatalf("missing actionable diagnostic: %q", errOut)
 	}
+
+	weekdayOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			execErr = Execute([]string{"--plain", "--account", "a@b.com", "calendar", "events", "--all", "--weekday", "--from", "2025-12-17T00:00:00Z", "--to", "2025-12-18T00:00:00Z"})
+		})
+	})
+	if execErr == nil {
+		t.Fatal("expected weekday partial failure to return nonzero")
+	}
+	weekdayLines := strings.Split(strings.TrimSpace(weekdayOut), "\n")
+	if len(weekdayLines) != 3 || weekdayLines[0] != "TYPE\tCALENDAR\tID\tSTART\tSTART_DOW\tEND\tEND_DOW\tSUMMARY\tERROR" {
+		t.Fatalf("unexpected weekday records=%q", weekdayOut)
+	}
+	if strings.Count(weekdayLines[1], "\t") != 8 || strings.Count(weekdayLines[2], "\t") != 8 || !strings.HasPrefix(weekdayLines[2], "calendar_error\tc2\t") {
+		t.Fatalf("weekday rows are not stable TSV: %q", weekdayOut)
+	}
 }
 
 func TestExecute_CalendarEvents_JSON_CalendarsReportsPartialFailure(t *testing.T) {

--- a/internal/cmd/execute_calendar_events_text_test.go
+++ b/internal/cmd/execute_calendar_events_text_test.go
@@ -78,7 +78,7 @@ func TestExecute_CalendarEvents_Text_AllReportsPartialFailure(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"items": []map[string]any{
-					{"id": "e1", "summary": "S1", "start": map[string]any{"dateTime": "2025-12-17T10:00:00Z"}, "end": map[string]any{"dateTime": "2025-12-17T11:00:00Z"}},
+					{"id": "e1", "summary": "S1\tteam\nsync", "start": map[string]any{"dateTime": "2025-12-17T10:00:00Z"}, "end": map[string]any{"dateTime": "2025-12-17T11:00:00Z"}},
 				},
 			})
 			return
@@ -120,7 +120,7 @@ func TestExecute_CalendarEvents_Text_AllReportsPartialFailure(t *testing.T) {
 	if lines[0] != "TYPE\tCALENDAR\tID\tSTART\tEND\tSUMMARY\tERROR" {
 		t.Fatalf("unexpected header=%q", lines[0])
 	}
-	if !strings.HasPrefix(lines[1], "event\tc1\te1\t") || !strings.Contains(lines[1], "\tS1\t") {
+	if !strings.HasPrefix(lines[1], "event\tc1\te1\t") || !strings.Contains(lines[1], "\tS1 team sync\t") {
 		t.Fatalf("unexpected event record=%q", lines[1])
 	}
 	if !strings.HasPrefix(lines[2], "calendar_error\tc2\t\t\t\t\t") || !strings.Contains(lines[2], "access denied") {

--- a/internal/cmd/execute_calendar_events_text_test.go
+++ b/internal/cmd/execute_calendar_events_text_test.go
@@ -59,7 +59,9 @@ func TestExecute_CalendarEvents_Text_WithPaging(t *testing.T) {
 	}
 }
 
-func TestExecute_CalendarEvents_Text_AllReportsPartialFailure(t *testing.T) {
+func setupCalendarPartialFailureService(t *testing.T) {
+	t.Helper()
+
 	origNew := newCalendarService
 	t.Cleanup(func() { newCalendarService = origNew })
 
@@ -68,29 +70,24 @@ func TestExecute_CalendarEvents_Text_AllReportsPartialFailure(t *testing.T) {
 		case strings.Contains(r.URL.Path, "/users/me/calendarList"):
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"items": []map[string]any{
-					{"id": "c1"},
-					{"id": "c2"},
-				},
+				"items": []map[string]any{{"id": "c1"}, {"id": "c2"}},
 			})
-			return
 		case strings.Contains(r.URL.Path, "/calendars/c1/events"):
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"items": []map[string]any{
-					{"id": "e1", "summary": "S1\tteam\nsync", "start": map[string]any{"dateTime": "2025-12-17T10:00:00Z"}, "end": map[string]any{"dateTime": "2025-12-17T11:00:00Z"}},
-				},
+				"items": []map[string]any{{
+					"id": "e1", "summary": "S1\tteam\nsync",
+					"start": map[string]any{"dateTime": "2025-12-17T10:00:00Z"},
+					"end":   map[string]any{"dateTime": "2025-12-17T11:00:00Z"},
+				}},
 			})
-			return
 		case strings.Contains(r.URL.Path, "/calendars/c2/events"):
 			http.Error(w, "access denied", http.StatusForbidden)
-			return
 		default:
 			http.NotFound(w, r)
-			return
 		}
 	})))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	svc, err := calendar.NewService(context.Background(),
 		option.WithoutAuthentication(),
@@ -101,6 +98,10 @@ func TestExecute_CalendarEvents_Text_AllReportsPartialFailure(t *testing.T) {
 		t.Fatalf("NewService: %v", err)
 	}
 	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+}
+
+func TestExecute_CalendarEvents_Text_AllReportsPartialFailure(t *testing.T) {
+	setupCalendarPartialFailureService(t)
 
 	var execErr error
 	var errOut string
@@ -151,42 +152,7 @@ func TestExecute_CalendarEvents_Text_AllReportsPartialFailure(t *testing.T) {
 }
 
 func TestExecute_CalendarEvents_JSON_CalendarsReportsPartialFailure(t *testing.T) {
-	origNew := newCalendarService
-	t.Cleanup(func() { newCalendarService = origNew })
-
-	srv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.Contains(r.URL.Path, "/users/me/calendarList"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"items": []map[string]any{{"id": "c1"}, {"id": "c2"}},
-			})
-		case strings.Contains(r.URL.Path, "/calendars/c1/events"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"items": []map[string]any{{
-					"id": "e1", "summary": "S1",
-					"start": map[string]any{"dateTime": "2025-12-17T10:00:00Z"},
-					"end":   map[string]any{"dateTime": "2025-12-17T11:00:00Z"},
-				}},
-			})
-		case strings.Contains(r.URL.Path, "/calendars/c2/events"):
-			http.Error(w, "access denied", http.StatusForbidden)
-		default:
-			http.NotFound(w, r)
-		}
-	})))
-	defer srv.Close()
-
-	svc, err := calendar.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+	setupCalendarPartialFailureService(t)
 
 	var execErr error
 	var errOut string

--- a/internal/cmd/execute_calendar_events_text_test.go
+++ b/internal/cmd/execute_calendar_events_text_test.go
@@ -59,7 +59,7 @@ func TestExecute_CalendarEvents_Text_WithPaging(t *testing.T) {
 	}
 }
 
-func TestExecute_CalendarEvents_Text_All(t *testing.T) {
+func TestExecute_CalendarEvents_Text_AllReportsPartialFailure(t *testing.T) {
 	origNew := newCalendarService
 	t.Cleanup(func() { newCalendarService = origNew })
 
@@ -83,8 +83,7 @@ func TestExecute_CalendarEvents_Text_All(t *testing.T) {
 			})
 			return
 		case strings.Contains(r.URL.Path, "/calendars/c2/events"):
-			// Simulate calendar fetch failure path (ignored).
-			http.Error(w, "nope", http.StatusForbidden)
+			http.Error(w, "access denied", http.StatusForbidden)
 			return
 		default:
 			http.NotFound(w, r)
@@ -103,14 +102,108 @@ func TestExecute_CalendarEvents_Text_All(t *testing.T) {
 	}
 	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
 
+	var execErr error
+	var errOut string
 	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			if err := Execute([]string{"--account", "a@b.com", "calendar", "events", "--all", "--from", "2025-12-17T00:00:00Z", "--to", "2025-12-18T00:00:00Z"}); err != nil {
-				t.Fatalf("Execute: %v", err)
-			}
+		errOut = captureStderr(t, func() {
+			execErr = Execute([]string{"--plain", "--account", "a@b.com", "calendar", "events", "--all", "--from", "2025-12-17T00:00:00Z", "--to", "2025-12-18T00:00:00Z"})
 		})
 	})
-	if !strings.Contains(out, "CALENDAR") || !strings.Contains(out, "c1") || !strings.Contains(out, "e1") || !strings.Contains(out, "S1") {
-		t.Fatalf("unexpected out=%q", out)
+	if execErr == nil {
+		t.Fatal("expected partial failure to return nonzero")
+	}
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected header, event, and error records; got %q", out)
+	}
+	if lines[0] != "TYPE\tCALENDAR\tID\tSTART\tEND\tSUMMARY\tERROR" {
+		t.Fatalf("unexpected header=%q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "event\tc1\te1\t") || !strings.Contains(lines[1], "\tS1\t") {
+		t.Fatalf("unexpected event record=%q", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "calendar_error\tc2\t\t\t\t\t") || !strings.Contains(lines[2], "access denied") {
+		t.Fatalf("unexpected error record=%q", lines[2])
+	}
+	if strings.Contains(lines[2], "\n") || strings.Count(lines[2], "\t") != 6 {
+		t.Fatalf("error record is not parseable TSV: %q", lines[2])
+	}
+	if !strings.Contains(errOut, "calendar c2:") || !strings.Contains(errOut, "access denied") {
+		t.Fatalf("missing actionable diagnostic: %q", errOut)
+	}
+}
+
+func TestExecute_CalendarEvents_JSON_CalendarsReportsPartialFailure(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/users/me/calendarList"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{{"id": "c1"}, {"id": "c2"}},
+			})
+		case strings.Contains(r.URL.Path, "/calendars/c1/events"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{{
+					"id": "e1", "summary": "S1",
+					"start": map[string]any{"dateTime": "2025-12-17T10:00:00Z"},
+					"end":   map[string]any{"dateTime": "2025-12-17T11:00:00Z"},
+				}},
+			})
+		case strings.Contains(r.URL.Path, "/calendars/c2/events"):
+			http.Error(w, "access denied", http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	})))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	var execErr error
+	var errOut string
+	out := captureStdout(t, func() {
+		errOut = captureStderr(t, func() {
+			execErr = Execute([]string{"--json", "--account", "a@b.com", "calendar", "events", "--calendars", "c1,c2", "--from", "2025-12-17T00:00:00Z", "--to", "2025-12-18T00:00:00Z"})
+		})
+	})
+	if execErr == nil {
+		t.Fatal("expected partial failure to return nonzero")
+	}
+
+	var parsed struct {
+		Events []map[string]any `json:"events"`
+		Errors []struct {
+			CalendarID string `json:"calendarId"`
+			Error      string `json:"error"`
+		} `json:"errors"`
+		Complete bool `json:"complete"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nout=%q", err, out)
+	}
+	if parsed.Complete {
+		t.Fatalf("expected complete=false: %#v", parsed)
+	}
+	if len(parsed.Events) != 1 || parsed.Events[0]["id"] != "e1" {
+		t.Fatalf("successful events not preserved: %#v", parsed.Events)
+	}
+	if len(parsed.Errors) != 1 || parsed.Errors[0].CalendarID != "c2" || !strings.Contains(parsed.Errors[0].Error, "access denied") {
+		t.Fatalf("failed calendar not reported: %#v", parsed.Errors)
+	}
+	if !strings.Contains(errOut, "calendar c2:") || !strings.Contains(errOut, "access denied") {
+		t.Fatalf("missing actionable diagnostic: %q", errOut)
 	}
 }


### PR DESCRIPTION
## Summary
- preserve successful multi-calendar events while reporting every failed calendar
- expose `events`, per-calendar `errors`, and `complete` in JSON; emit stable typed TSV records in plain mode
- return nonzero for partial/all-failed results and preserve explicit successful empty results
- document both plain schemas and keep single-calendar listing unchanged

## Testing
- `/home/jeremy-johnson/.local/go/bin/go test ./internal/cmd -run 'TestListAllCalendarsEvents_JSON|TestExecute_CalendarEvents_(Text_AllReportsPartialFailure|JSON_CalendarsReportsPartialFailure)' -count=1`
- `PATH=/home/jeremy-johnson/.local/go/bin:$PATH make ci`
- Standards/Fowler review: PASS
- Exact-spec review: PASS

Closes #90
