### PR TITLE
fix(calendar): report incomplete team event results

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,14 @@ gog calendar team <group-email> --week            # Show team's events for the w
 gog calendar team <group-email> --freebusy        # Show only busy/free blocks (faster)
 gog calendar team <group-email> --query "standup" # Filter by event title
 
+# In event mode, --json includes complete and errors fields. If any member
+# calendar fails, successful events are still rendered with complete=false and
+# one {calendarId,error} entry per failure, then the command exits nonzero.
+# In --plain mode, incomplete results use this six-column TSV schema:
+# TYPE  WHO  START  END  SUMMARY  ERROR
+# Records are typed as event or calendar_error. Complete results keep the
+# existing WHO/START/END/SUMMARY schema; --freebusy behavior is unchanged.
+
 # Create and update
 gog calendar create <calendarId> \
   --summary "Meeting" \

--- a/internal/cmd/calendar_team.go
+++ b/internal/cmd/calendar_team.go
@@ -164,11 +164,11 @@ func (c *CalendarTeamCmd) runFreeBusy(ctx context.Context, svc *calendar.Service
 
 func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, u *ui.UI, emails []string, tr *TimeRange) error {
 	var (
-		mu     sync.Mutex
-		events []teamEvent
-		errors []string
-		wg     sync.WaitGroup
-		sem    = make(chan struct{}, 10) // max 10 concurrent requests
+		mu       sync.Mutex
+		events   []teamEvent
+		failures []calendarEventError
+		wg       sync.WaitGroup
+		sem      = make(chan struct{}, 10) // max 10 concurrent requests
 	)
 
 	queryLower := strings.ToLower(c.Query)
@@ -190,8 +190,9 @@ func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, 
 
 			resp, err := call.Do()
 			if err != nil {
+				failure := calendarEventError{CalendarID: email, Error: err.Error()}
 				mu.Lock()
-				errors = append(errors, fmt.Sprintf("%s: %v", email, err))
+				failures = append(failures, failure)
 				mu.Unlock()
 				return
 			}
@@ -249,9 +250,17 @@ func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, 
 
 	wg.Wait()
 
-	// Print warnings for errors
-	for _, e := range errors {
-		u.Err().Printf("Warning: %s", e)
+	// Stable order for deterministic output / diagnostics.
+	sort.Slice(failures, func(i, j int) bool {
+		if failures[i].CalendarID == failures[j].CalendarID {
+			return failures[i].Error < failures[j].Error
+		}
+		return failures[i].CalendarID < failures[j].CalendarID
+	})
+
+	// Print warnings for failed calendars.
+	for _, failure := range failures {
+		u.Err().Printf("Warning: %s: %s", failure.CalendarID, failure.Error)
 	}
 
 	// Sort by start time
@@ -264,23 +273,58 @@ func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, 
 		events = dedupeTeamEvents(events)
 	}
 
+	var resultErr error
+	if len(failures) > 0 {
+		resultErr = fmt.Errorf("failed to fetch events from %d calendar(s)", len(failures))
+	}
+
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		if err := outfmt.WriteJSON(os.Stdout, map[string]any{
 			"group":    c.GroupEmail,
 			"timeMin":  tr.From.Format(time.RFC3339),
 			"timeMax":  tr.To.Format(time.RFC3339),
 			"timezone": tr.Location.String(),
 			"events":   events,
-		})
+			"errors":   failures,
+			"complete": len(failures) == 0,
+		}); err != nil {
+			return err
+		}
+		return resultErr
 	}
 
-	if len(events) == 0 {
+	if len(events) == 0 && len(failures) == 0 {
 		u.Err().Println("No events found")
 		return nil
 	}
 
 	w, flush := tableWriter(ctx)
 	defer flush()
+	if outfmt.IsPlain(ctx) || len(failures) > 0 {
+		writeTableRow(ctx, w, []string{"TYPE", "WHO", "START", "END", "SUMMARY", "ERROR"})
+		for _, ev := range events {
+			writeTableRow(ctx, w, []string{
+				"event",
+				ev.Who,
+				ev.Start,
+				ev.End,
+				truncate(ev.Summary, 40),
+				"",
+			})
+		}
+		for _, failure := range failures {
+			writeTableRow(ctx, w, []string{
+				"calendar_error",
+				failure.CalendarID,
+				"",
+				"",
+				"",
+				sanitizeTab(failure.Error),
+			})
+		}
+		return resultErr
+	}
+
 	fmt.Fprintln(w, "WHO\tSTART\tEND\tSUMMARY")
 	for _, ev := range events {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",

--- a/internal/cmd/calendar_team.go
+++ b/internal/cmd/calendar_team.go
@@ -300,22 +300,24 @@ func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, 
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	if outfmt.IsPlain(ctx) || len(failures) > 0 {
+	// Typed rows only for incomplete results so successful --plain keeps the
+	// historical 4-column WHO/START/END/SUMMARY schema.
+	if len(failures) > 0 {
 		writeTableRow(ctx, w, []string{"TYPE", "WHO", "START", "END", "SUMMARY", "ERROR"})
 		for _, ev := range events {
 			writeTableRow(ctx, w, []string{
 				"event",
-				ev.Who,
-				ev.Start,
-				ev.End,
-				truncate(ev.Summary, 40),
+				sanitizeTab(ev.Who),
+				sanitizeTab(ev.Start),
+				sanitizeTab(ev.End),
+				sanitizeTab(truncate(ev.Summary, 40)),
 				"",
 			})
 		}
 		for _, failure := range failures {
 			writeTableRow(ctx, w, []string{
 				"calendar_error",
-				failure.CalendarID,
+				sanitizeTab(failure.CalendarID),
 				"",
 				"",
 				"",

--- a/internal/cmd/calendar_team.go
+++ b/internal/cmd/calendar_team.go
@@ -38,6 +38,11 @@ type teamEvent struct {
 	sortKey        time.Time
 }
 
+type teamEventError struct {
+	CalendarID string `json:"calendarId"`
+	Error      string `json:"error"`
+}
+
 func (c *CalendarTeamCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 	account, err := requireAccount(flags)
@@ -166,7 +171,7 @@ func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, 
 	var (
 		mu       sync.Mutex
 		events   []teamEvent
-		failures []calendarEventError
+		failures []teamEventError
 		wg       sync.WaitGroup
 		sem      = make(chan struct{}, 10) // max 10 concurrent requests
 	)
@@ -190,7 +195,7 @@ func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, 
 
 			resp, err := call.Do()
 			if err != nil {
-				failure := calendarEventError{CalendarID: email, Error: err.Error()}
+				failure := teamEventError{CalendarID: email, Error: err.Error()}
 				mu.Lock()
 				failures = append(failures, failure)
 				mu.Unlock()
@@ -307,21 +312,21 @@ func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, 
 		for _, ev := range events {
 			writeTableRow(ctx, w, []string{
 				"event",
-				sanitizeTab(ev.Who),
-				sanitizeTab(ev.Start),
-				sanitizeTab(ev.End),
-				sanitizeTab(truncate(ev.Summary, 40)),
+				sanitizePlainField(ev.Who),
+				sanitizePlainField(ev.Start),
+				sanitizePlainField(ev.End),
+				sanitizePlainField(truncate(ev.Summary, 40)),
 				"",
 			})
 		}
 		for _, failure := range failures {
 			writeTableRow(ctx, w, []string{
 				"calendar_error",
-				sanitizeTab(failure.CalendarID),
+				sanitizePlainField(failure.CalendarID),
 				"",
 				"",
 				"",
-				sanitizeTab(failure.Error),
+				sanitizePlainField(failure.Error),
 			})
 		}
 		return resultErr
@@ -330,10 +335,10 @@ func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, 
 	fmt.Fprintln(w, "WHO\tSTART\tEND\tSUMMARY")
 	for _, ev := range events {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
-			sanitizeTab(ev.Who),
-			sanitizeTab(ev.Start),
-			sanitizeTab(ev.End),
-			sanitizeTab(truncate(ev.Summary, 40)),
+			sanitizePlainField(ev.Who),
+			sanitizePlainField(ev.Start),
+			sanitizePlainField(ev.End),
+			sanitizePlainField(truncate(ev.Summary, 40)),
 		)
 	}
 	return nil

--- a/internal/cmd/execute_calendar_team_test.go
+++ b/internal/cmd/execute_calendar_team_test.go
@@ -338,3 +338,415 @@ func TestExecute_CalendarTeam_Text(t *testing.T) {
 		t.Fatalf("missing event summary in output: %q", out)
 	}
 }
+
+func TestExecute_CalendarTeam_JSON_PartialFailure(t *testing.T) {
+	origCalSvc := newCalendarService
+	origCloudSvc := newCloudIdentityService
+	t.Cleanup(func() {
+		newCalendarService = origCalSvc
+		newCloudIdentityService = origCloudSvc
+	})
+
+	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "groups:lookup"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
+		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"memberships": []map[string]any{
+					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
+					{"preferredMemberKey": map[string]any{"id": "bob@example.com"}, "type": "USER"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cloudSrv.Close()
+
+	cloudSvc, err := cloudidentity.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(cloudSrv.Client()),
+		option.WithEndpoint(cloudSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cloud): %v", err)
+	}
+	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
+
+	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/calendars/alice@example.com/events"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id":      "ev1",
+						"summary": "Alice Sync",
+						"start":   map[string]any{"dateTime": "2026-01-05T09:00:00Z"},
+						"end":     map[string]any{"dateTime": "2026-01-05T09:30:00Z"},
+					},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/calendars/bob@example.com/events"):
+			http.Error(w, "access denied", http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	})))
+	defer calSrv.Close()
+
+	calSvc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(calSrv.Client()),
+		option.WithEndpoint(calSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cal): %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
+
+	var execErr error
+	var errOut string
+	out := captureStdout(t, func() {
+		errOut = captureStderr(t, func() {
+			execErr = Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"calendar", "team", "engineering@example.com",
+				"--from", "2026-01-05T00:00:00Z",
+				"--to", "2026-01-06T00:00:00Z",
+			})
+		})
+	})
+	if execErr == nil {
+		t.Fatal("expected partial failure to return nonzero")
+	}
+	if ExitCode(execErr) == 0 {
+		t.Fatalf("expected nonzero exit code, got 0 (%v)", execErr)
+	}
+
+	var parsed struct {
+		Events []struct {
+			Who     string `json:"who"`
+			ID      string `json:"id"`
+			Summary string `json:"summary"`
+		} `json:"events"`
+		Errors []struct {
+			CalendarID string `json:"calendarId"`
+			Error      string `json:"error"`
+		} `json:"errors"`
+		Complete bool `json:"complete"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if parsed.Complete {
+		t.Fatalf("expected complete=false: %#v", parsed)
+	}
+	if len(parsed.Events) != 1 || parsed.Events[0].ID != "ev1" || parsed.Events[0].Who != "alice@example.com" {
+		t.Fatalf("successful events not preserved: %#v", parsed.Events)
+	}
+	if len(parsed.Errors) != 1 || parsed.Errors[0].CalendarID != "bob@example.com" || !strings.Contains(parsed.Errors[0].Error, "access denied") {
+		t.Fatalf("failed calendar not reported: %#v", parsed.Errors)
+	}
+	if !strings.Contains(errOut, "bob@example.com") || !strings.Contains(errOut, "access denied") {
+		t.Fatalf("missing actionable diagnostic: %q", errOut)
+	}
+}
+
+func TestExecute_CalendarTeam_Plain_PartialFailure(t *testing.T) {
+	origCalSvc := newCalendarService
+	origCloudSvc := newCloudIdentityService
+	t.Cleanup(func() {
+		newCalendarService = origCalSvc
+		newCloudIdentityService = origCloudSvc
+	})
+
+	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "groups:lookup"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
+		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"memberships": []map[string]any{
+					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
+					{"preferredMemberKey": map[string]any{"id": "bob@example.com"}, "type": "USER"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cloudSrv.Close()
+
+	cloudSvc, err := cloudidentity.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(cloudSrv.Client()),
+		option.WithEndpoint(cloudSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cloud): %v", err)
+	}
+	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
+
+	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/calendars/alice@example.com/events"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id":      "ev1",
+						"summary": "Alice Sync",
+						"start":   map[string]any{"dateTime": "2026-01-05T09:00:00Z"},
+						"end":     map[string]any{"dateTime": "2026-01-05T09:30:00Z"},
+					},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/calendars/bob@example.com/events"):
+			http.Error(w, "access denied", http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	})))
+	defer calSrv.Close()
+
+	calSvc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(calSrv.Client()),
+		option.WithEndpoint(calSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cal): %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
+
+	var execErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			execErr = Execute([]string{
+				"--plain",
+				"--account", "a@b.com",
+				"calendar", "team", "engineering@example.com",
+				"--from", "2026-01-05T00:00:00Z",
+				"--to", "2026-01-06T00:00:00Z",
+			})
+		})
+	})
+	if execErr == nil || ExitCode(execErr) == 0 {
+		t.Fatalf("plain execution error = %v, want nonzero incomplete result", execErr)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) < 2 {
+		t.Fatalf("expected event and error records, got %q", out)
+	}
+	if lines[0] != "TYPE\tWHO\tSTART\tEND\tSUMMARY\tERROR" {
+		t.Fatalf("unexpected header=%q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "event\talice@example.com\t") || !strings.Contains(lines[1], "\tAlice Sync\t") {
+		t.Fatalf("unexpected event record=%q", lines[1])
+	}
+	foundError := false
+	for _, line := range lines[1:] {
+		if strings.HasPrefix(line, "calendar_error\tbob@example.com\t") && strings.Contains(line, "access denied") {
+			foundError = true
+			if strings.Count(line, "\t") != 5 {
+				t.Fatalf("error record is not parseable TSV: %q", line)
+			}
+		}
+	}
+	if !foundError {
+		t.Fatalf("missing calendar_error record: %q", out)
+	}
+	if strings.Contains(out, "No events found") {
+		t.Fatalf("must not use empty-result path on partial failure: %q", out)
+	}
+}
+
+func TestExecute_CalendarTeam_JSON_AllFailed(t *testing.T) {
+	origCalSvc := newCalendarService
+	origCloudSvc := newCloudIdentityService
+	t.Cleanup(func() {
+		newCalendarService = origCalSvc
+		newCloudIdentityService = origCloudSvc
+	})
+
+	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "groups:lookup"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
+		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"memberships": []map[string]any{
+					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
+					{"preferredMemberKey": map[string]any{"id": "bob@example.com"}, "type": "USER"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cloudSrv.Close()
+
+	cloudSvc, err := cloudidentity.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(cloudSrv.Client()),
+		option.WithEndpoint(cloudSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cloud): %v", err)
+	}
+	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
+
+	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/events") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.NotFound(w, r)
+	})))
+	defer calSrv.Close()
+
+	calSvc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(calSrv.Client()),
+		option.WithEndpoint(calSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cal): %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
+
+	var execErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			execErr = Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"calendar", "team", "engineering@example.com",
+				"--from", "2026-01-05T00:00:00Z",
+				"--to", "2026-01-06T00:00:00Z",
+			})
+		})
+	})
+	if execErr == nil || ExitCode(execErr) == 0 {
+		t.Fatalf("all-failed execution error = %v, want nonzero", execErr)
+	}
+
+	var parsed struct {
+		Events   []map[string]any `json:"events"`
+		Errors   []map[string]any `json:"errors"`
+		Complete bool             `json:"complete"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if parsed.Complete {
+		t.Fatalf("expected complete=false on all-failed run: %#v", parsed)
+	}
+	if len(parsed.Events) != 0 {
+		t.Fatalf("expected no events on all-failed run: %#v", parsed.Events)
+	}
+	if len(parsed.Errors) != 2 {
+		t.Fatalf("expected 2 errors, got %#v", parsed.Errors)
+	}
+}
+
+func TestExecute_CalendarTeam_JSON_SuccessfulEmpty(t *testing.T) {
+	origCalSvc := newCalendarService
+	origCloudSvc := newCloudIdentityService
+	t.Cleanup(func() {
+		newCalendarService = origCalSvc
+		newCloudIdentityService = origCloudSvc
+	})
+
+	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "groups:lookup"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
+		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"memberships": []map[string]any{
+					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cloudSrv.Close()
+
+	cloudSvc, err := cloudidentity.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(cloudSrv.Client()),
+		option.WithEndpoint(cloudSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cloud): %v", err)
+	}
+	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
+
+	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/alice@example.com/events") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+			return
+		}
+		http.NotFound(w, r)
+	})))
+	defer calSrv.Close()
+
+	calSvc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(calSrv.Client()),
+		option.WithEndpoint(calSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cal): %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
+
+	var execErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			execErr = Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"calendar", "team", "engineering@example.com",
+				"--from", "2026-01-05T00:00:00Z",
+				"--to", "2026-01-06T00:00:00Z",
+			})
+		})
+	})
+	if execErr != nil {
+		t.Fatalf("successful empty schedule must succeed: %v", execErr)
+	}
+
+	var parsed struct {
+		Events   []map[string]any `json:"events"`
+		Errors   []map[string]any `json:"errors"`
+		Complete bool             `json:"complete"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if !parsed.Complete {
+		t.Fatalf("expected complete=true for successful empty schedule: %#v", parsed)
+	}
+	if len(parsed.Events) != 0 {
+		t.Fatalf("expected no events: %#v", parsed.Events)
+	}
+	if len(parsed.Errors) != 0 {
+		t.Fatalf("expected no errors: %#v", parsed.Errors)
+	}
+}

--- a/internal/cmd/execute_calendar_team_test.go
+++ b/internal/cmd/execute_calendar_team_test.go
@@ -339,7 +339,9 @@ func TestExecute_CalendarTeam_Text(t *testing.T) {
 	}
 }
 
-func TestExecute_CalendarTeam_JSON_PartialFailure(t *testing.T) {
+func executeCalendarTeamTest(t *testing.T, format string, members []string, calendarHandler http.Handler) (string, string, error) {
+	t.Helper()
+
 	origCalSvc := newCalendarService
 	origCloudSvc := newCloudIdentityService
 	t.Cleanup(func() {
@@ -353,18 +355,20 @@ func TestExecute_CalendarTeam_JSON_PartialFailure(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
 		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
+			memberships := make([]map[string]any, 0, len(members))
+			for _, member := range members {
+				memberships = append(memberships, map[string]any{
+					"preferredMemberKey": map[string]any{"id": member},
+					"type":               "USER",
+				})
+			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"memberships": []map[string]any{
-					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
-					{"preferredMemberKey": map[string]any{"id": "bob@example.com"}, "type": "USER"},
-				},
-			})
+			_ = json.NewEncoder(w).Encode(map[string]any{"memberships": memberships})
 		default:
 			http.NotFound(w, r)
 		}
 	}))
-	defer cloudSrv.Close()
+	t.Cleanup(cloudSrv.Close)
 
 	cloudSvc, err := cloudidentity.NewService(context.Background(),
 		option.WithoutAuthentication(),
@@ -376,7 +380,37 @@ func TestExecute_CalendarTeam_JSON_PartialFailure(t *testing.T) {
 	}
 	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
 
-	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	calSrv := httptest.NewServer(withPrimaryCalendar(calendarHandler))
+	t.Cleanup(calSrv.Close)
+
+	calSvc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(calSrv.Client()),
+		option.WithEndpoint(calSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cal): %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
+
+	var execErr error
+	var errOut string
+	out := captureStdout(t, func() {
+		errOut = captureStderr(t, func() {
+			execErr = Execute([]string{
+				"--" + format,
+				"--account", "a@b.com",
+				"calendar", "team", "engineering@example.com",
+				"--from", "2026-01-05T00:00:00Z",
+				"--to", "2026-01-06T00:00:00Z",
+			})
+		})
+	})
+	return out, errOut, execErr
+}
+
+func TestExecute_CalendarTeam_JSON_PartialFailure(t *testing.T) {
+	out, errOut, execErr := executeCalendarTeamTest(t, "json", []string{"alice@example.com", "bob@example.com"}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(r.URL.Path, "/calendars/alice@example.com/events"):
 			w.Header().Set("Content-Type", "application/json")
@@ -395,32 +429,7 @@ func TestExecute_CalendarTeam_JSON_PartialFailure(t *testing.T) {
 		default:
 			http.NotFound(w, r)
 		}
-	})))
-	defer calSrv.Close()
-
-	calSvc, err := calendar.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(calSrv.Client()),
-		option.WithEndpoint(calSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cal): %v", err)
-	}
-	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
-
-	var execErr error
-	var errOut string
-	out := captureStdout(t, func() {
-		errOut = captureStderr(t, func() {
-			execErr = Execute([]string{
-				"--json",
-				"--account", "a@b.com",
-				"calendar", "team", "engineering@example.com",
-				"--from", "2026-01-05T00:00:00Z",
-				"--to", "2026-01-06T00:00:00Z",
-			})
-		})
-	})
+	}))
 	if execErr == nil {
 		t.Fatal("expected partial failure to return nonzero")
 	}
@@ -458,43 +467,7 @@ func TestExecute_CalendarTeam_JSON_PartialFailure(t *testing.T) {
 }
 
 func TestExecute_CalendarTeam_Plain_PartialFailure(t *testing.T) {
-	origCalSvc := newCalendarService
-	origCloudSvc := newCloudIdentityService
-	t.Cleanup(func() {
-		newCalendarService = origCalSvc
-		newCloudIdentityService = origCloudSvc
-	})
-
-	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.Contains(r.URL.Path, "groups:lookup"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
-		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"memberships": []map[string]any{
-					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
-					{"preferredMemberKey": map[string]any{"id": "bob@example.com"}, "type": "USER"},
-				},
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer cloudSrv.Close()
-
-	cloudSvc, err := cloudidentity.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(cloudSrv.Client()),
-		option.WithEndpoint(cloudSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cloud): %v", err)
-	}
-	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
-
-	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	out, _, execErr := executeCalendarTeamTest(t, "plain", []string{"alice@example.com", "bob@example.com"}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(r.URL.Path, "/calendars/alice@example.com/events"):
 			w.Header().Set("Content-Type", "application/json")
@@ -513,31 +486,7 @@ func TestExecute_CalendarTeam_Plain_PartialFailure(t *testing.T) {
 		default:
 			http.NotFound(w, r)
 		}
-	})))
-	defer calSrv.Close()
-
-	calSvc, err := calendar.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(calSrv.Client()),
-		option.WithEndpoint(calSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cal): %v", err)
-	}
-	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
-
-	var execErr error
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			execErr = Execute([]string{
-				"--plain",
-				"--account", "a@b.com",
-				"calendar", "team", "engineering@example.com",
-				"--from", "2026-01-05T00:00:00Z",
-				"--to", "2026-01-06T00:00:00Z",
-			})
-		})
-	})
+	}))
 	if execErr == nil || ExitCode(execErr) == 0 {
 		t.Fatalf("plain execution error = %v, want nonzero incomplete result", execErr)
 	}
@@ -570,73 +519,13 @@ func TestExecute_CalendarTeam_Plain_PartialFailure(t *testing.T) {
 }
 
 func TestExecute_CalendarTeam_JSON_AllFailed(t *testing.T) {
-	origCalSvc := newCalendarService
-	origCloudSvc := newCloudIdentityService
-	t.Cleanup(func() {
-		newCalendarService = origCalSvc
-		newCloudIdentityService = origCloudSvc
-	})
-
-	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.Contains(r.URL.Path, "groups:lookup"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
-		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"memberships": []map[string]any{
-					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
-					{"preferredMemberKey": map[string]any{"id": "bob@example.com"}, "type": "USER"},
-				},
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer cloudSrv.Close()
-
-	cloudSvc, err := cloudidentity.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(cloudSrv.Client()),
-		option.WithEndpoint(cloudSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cloud): %v", err)
-	}
-	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
-
-	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	out, _, execErr := executeCalendarTeamTest(t, "json", []string{"alice@example.com", "bob@example.com"}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/events") {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
 		http.NotFound(w, r)
-	})))
-	defer calSrv.Close()
-
-	calSvc, err := calendar.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(calSrv.Client()),
-		option.WithEndpoint(calSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cal): %v", err)
-	}
-	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
-
-	var execErr error
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			execErr = Execute([]string{
-				"--json",
-				"--account", "a@b.com",
-				"calendar", "team", "engineering@example.com",
-				"--from", "2026-01-05T00:00:00Z",
-				"--to", "2026-01-06T00:00:00Z",
-			})
-		})
-	})
+	}))
 	if execErr == nil || ExitCode(execErr) == 0 {
 		t.Fatalf("all-failed execution error = %v, want nonzero", execErr)
 	}
@@ -661,73 +550,14 @@ func TestExecute_CalendarTeam_JSON_AllFailed(t *testing.T) {
 }
 
 func TestExecute_CalendarTeam_JSON_SuccessfulEmpty(t *testing.T) {
-	origCalSvc := newCalendarService
-	origCloudSvc := newCloudIdentityService
-	t.Cleanup(func() {
-		newCalendarService = origCalSvc
-		newCloudIdentityService = origCloudSvc
-	})
-
-	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.Contains(r.URL.Path, "groups:lookup"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
-		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"memberships": []map[string]any{
-					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
-				},
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer cloudSrv.Close()
-
-	cloudSvc, err := cloudidentity.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(cloudSrv.Client()),
-		option.WithEndpoint(cloudSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cloud): %v", err)
-	}
-	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
-
-	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	out, _, execErr := executeCalendarTeamTest(t, "json", []string{"alice@example.com"}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/calendars/alice@example.com/events") {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
 			return
 		}
 		http.NotFound(w, r)
-	})))
-	defer calSrv.Close()
-
-	calSvc, err := calendar.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(calSrv.Client()),
-		option.WithEndpoint(calSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cal): %v", err)
-	}
-	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
-
-	var execErr error
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			execErr = Execute([]string{
-				"--json",
-				"--account", "a@b.com",
-				"calendar", "team", "engineering@example.com",
-				"--from", "2026-01-05T00:00:00Z",
-				"--to", "2026-01-06T00:00:00Z",
-			})
-		})
-	})
+	}))
 	if execErr != nil {
 		t.Fatalf("successful empty schedule must succeed: %v", execErr)
 	}
@@ -752,42 +582,7 @@ func TestExecute_CalendarTeam_JSON_SuccessfulEmpty(t *testing.T) {
 }
 
 func TestExecute_CalendarTeam_Plain_SuccessfulKeepsFourColumnSchema(t *testing.T) {
-	origCalSvc := newCalendarService
-	origCloudSvc := newCloudIdentityService
-	t.Cleanup(func() {
-		newCalendarService = origCalSvc
-		newCloudIdentityService = origCloudSvc
-	})
-
-	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.Contains(r.URL.Path, "groups:lookup"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
-		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"memberships": []map[string]any{
-					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
-				},
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer cloudSrv.Close()
-
-	cloudSvc, err := cloudidentity.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(cloudSrv.Client()),
-		option.WithEndpoint(cloudSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cloud): %v", err)
-	}
-	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
-
-	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	out, _, execErr := executeCalendarTeamTest(t, "plain", []string{"alice@example.com"}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/calendars/alice@example.com/events") {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -803,31 +598,7 @@ func TestExecute_CalendarTeam_Plain_SuccessfulKeepsFourColumnSchema(t *testing.T
 			return
 		}
 		http.NotFound(w, r)
-	})))
-	defer calSrv.Close()
-
-	calSvc, err := calendar.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(calSrv.Client()),
-		option.WithEndpoint(calSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cal): %v", err)
-	}
-	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
-
-	var execErr error
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			execErr = Execute([]string{
-				"--plain",
-				"--account", "a@b.com",
-				"calendar", "team", "engineering@example.com",
-				"--from", "2026-01-05T00:00:00Z",
-				"--to", "2026-01-06T00:00:00Z",
-			})
-		})
-	})
+	}))
 	if execErr != nil {
 		t.Fatalf("successful plain schedule must succeed: %v", execErr)
 	}
@@ -851,43 +622,7 @@ func TestExecute_CalendarTeam_Plain_SuccessfulKeepsFourColumnSchema(t *testing.T
 }
 
 func TestExecute_CalendarTeam_Plain_AllFailed(t *testing.T) {
-	origCalSvc := newCalendarService
-	origCloudSvc := newCloudIdentityService
-	t.Cleanup(func() {
-		newCalendarService = origCalSvc
-		newCloudIdentityService = origCloudSvc
-	})
-
-	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.Contains(r.URL.Path, "groups:lookup"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
-		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"memberships": []map[string]any{
-					{"preferredMemberKey": map[string]any{"id": "bob@example.com"}, "type": "USER"},
-					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
-				},
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer cloudSrv.Close()
-
-	cloudSvc, err := cloudidentity.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(cloudSrv.Client()),
-		option.WithEndpoint(cloudSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cloud): %v", err)
-	}
-	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
-
-	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	out, _, execErr := executeCalendarTeamTest(t, "plain", []string{"bob@example.com", "alice@example.com"}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/calendars/bob@example.com/events") {
 			http.Error(w, "bob denied\tsecret", http.StatusForbidden)
 			return
@@ -897,31 +632,7 @@ func TestExecute_CalendarTeam_Plain_AllFailed(t *testing.T) {
 			return
 		}
 		http.NotFound(w, r)
-	})))
-	defer calSrv.Close()
-
-	calSvc, err := calendar.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(calSrv.Client()),
-		option.WithEndpoint(calSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService (cal): %v", err)
-	}
-	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
-
-	var execErr error
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			execErr = Execute([]string{
-				"--plain",
-				"--account", "a@b.com",
-				"calendar", "team", "engineering@example.com",
-				"--from", "2026-01-05T00:00:00Z",
-				"--to", "2026-01-06T00:00:00Z",
-			})
-		})
-	})
+	}))
 	if execErr == nil || ExitCode(execErr) == 0 {
 		t.Fatalf("all-failed plain execution error = %v, want nonzero", execErr)
 	}

--- a/internal/cmd/execute_calendar_team_test.go
+++ b/internal/cmd/execute_calendar_team_test.go
@@ -750,3 +750,202 @@ func TestExecute_CalendarTeam_JSON_SuccessfulEmpty(t *testing.T) {
 		t.Fatalf("expected no errors: %#v", parsed.Errors)
 	}
 }
+
+func TestExecute_CalendarTeam_Plain_SuccessfulKeepsFourColumnSchema(t *testing.T) {
+	origCalSvc := newCalendarService
+	origCloudSvc := newCloudIdentityService
+	t.Cleanup(func() {
+		newCalendarService = origCalSvc
+		newCloudIdentityService = origCloudSvc
+	})
+
+	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "groups:lookup"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
+		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"memberships": []map[string]any{
+					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cloudSrv.Close()
+
+	cloudSvc, err := cloudidentity.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(cloudSrv.Client()),
+		option.WithEndpoint(cloudSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cloud): %v", err)
+	}
+	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
+
+	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/alice@example.com/events") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id":      "ev1",
+						"summary": "Standup\tplanning\nnotes",
+						"start":   map[string]any{"dateTime": "2026-01-05T09:00:00Z"},
+						"end":     map[string]any{"dateTime": "2026-01-05T09:30:00Z"},
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	})))
+	defer calSrv.Close()
+
+	calSvc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(calSrv.Client()),
+		option.WithEndpoint(calSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cal): %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
+
+	var execErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			execErr = Execute([]string{
+				"--plain",
+				"--account", "a@b.com",
+				"calendar", "team", "engineering@example.com",
+				"--from", "2026-01-05T00:00:00Z",
+				"--to", "2026-01-06T00:00:00Z",
+			})
+		})
+	})
+	if execErr != nil {
+		t.Fatalf("successful plain schedule must succeed: %v", execErr)
+	}
+
+	lines := nonEmptyLines(out)
+	want := []string{
+		"WHO\tSTART\tEND\tSUMMARY",
+		"alice@example.com\t09:00\t09:30\tStandup planning notes",
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("plain rows = %q, want %q", lines, want)
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Fatalf("plain row %d = %q, want %q", i, lines[i], want[i])
+		}
+	}
+	if strings.Contains(out, "TYPE\t") || strings.Contains(out, "calendar_error") {
+		t.Fatalf("successful plain output must keep 4-column schema: %q", out)
+	}
+}
+
+func TestExecute_CalendarTeam_Plain_AllFailed(t *testing.T) {
+	origCalSvc := newCalendarService
+	origCloudSvc := newCloudIdentityService
+	t.Cleanup(func() {
+		newCalendarService = origCalSvc
+		newCloudIdentityService = origCloudSvc
+	})
+
+	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "groups:lookup"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
+		case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"memberships": []map[string]any{
+					{"preferredMemberKey": map[string]any{"id": "bob@example.com"}, "type": "USER"},
+					{"preferredMemberKey": map[string]any{"id": "alice@example.com"}, "type": "USER"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cloudSrv.Close()
+
+	cloudSvc, err := cloudidentity.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(cloudSrv.Client()),
+		option.WithEndpoint(cloudSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cloud): %v", err)
+	}
+	newCloudIdentityService = func(context.Context, string) (*cloudidentity.Service, error) { return cloudSvc, nil }
+
+	calSrv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/bob@example.com/events") {
+			http.Error(w, "bob denied\tsecret", http.StatusForbidden)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/calendars/alice@example.com/events") {
+			http.Error(w, "alice missing", http.StatusNotFound)
+			return
+		}
+		http.NotFound(w, r)
+	})))
+	defer calSrv.Close()
+
+	calSvc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(calSrv.Client()),
+		option.WithEndpoint(calSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService (cal): %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return calSvc, nil }
+
+	var execErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			execErr = Execute([]string{
+				"--plain",
+				"--account", "a@b.com",
+				"calendar", "team", "engineering@example.com",
+				"--from", "2026-01-05T00:00:00Z",
+				"--to", "2026-01-06T00:00:00Z",
+			})
+		})
+	})
+	if execErr == nil || ExitCode(execErr) == 0 {
+		t.Fatalf("all-failed plain execution error = %v, want nonzero", execErr)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Fatalf("expected header + 2 error rows, got %q", out)
+	}
+	if lines[0] != "TYPE\tWHO\tSTART\tEND\tSUMMARY\tERROR" {
+		t.Fatalf("unexpected header=%q", lines[0])
+	}
+	// Deterministic multi-error order by calendar id.
+	if !strings.HasPrefix(lines[1], "calendar_error\talice@example.com\t") || !strings.Contains(lines[1], "alice missing") {
+		t.Fatalf("expected alice error first: %q", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "calendar_error\tbob@example.com\t") || !strings.Contains(lines[2], "bob denied secret") {
+		t.Fatalf("expected bob error second and tab-safe: %q", lines[2])
+	}
+	if strings.Contains(out, "No events found") {
+		t.Fatalf("all-failed must not use empty success path: %q", out)
+	}
+	for _, line := range lines[1:] {
+		if strings.Count(line, "\t") != 5 {
+			t.Fatalf("error record is not parseable TSV: %q", line)
+		}
+	}
+}

--- a/internal/cmd/execute_calendar_team_test.go
+++ b/internal/cmd/execute_calendar_team_test.go
@@ -542,7 +542,7 @@ func TestExecute_CalendarTeam_Plain_PartialFailure(t *testing.T) {
 		t.Fatalf("plain execution error = %v, want nonzero incomplete result", execErr)
 	}
 
-	lines := nonEmptyLines(out)
+	lines := nonEmptyTeamLines(out)
 	if len(lines) < 2 {
 		t.Fatalf("expected event and error records, got %q", out)
 	}
@@ -832,7 +832,7 @@ func TestExecute_CalendarTeam_Plain_SuccessfulKeepsFourColumnSchema(t *testing.T
 		t.Fatalf("successful plain schedule must succeed: %v", execErr)
 	}
 
-	lines := nonEmptyLines(out)
+	lines := nonEmptyTeamLines(out)
 	want := []string{
 		"WHO\tSTART\tEND\tSUMMARY",
 		"alice@example.com\t09:00\t09:30\tStandup planning notes",
@@ -926,7 +926,7 @@ func TestExecute_CalendarTeam_Plain_AllFailed(t *testing.T) {
 		t.Fatalf("all-failed plain execution error = %v, want nonzero", execErr)
 	}
 
-	lines := nonEmptyLines(out)
+	lines := nonEmptyTeamLines(out)
 	if len(lines) != 3 {
 		t.Fatalf("expected header + 2 error rows, got %q", out)
 	}
@@ -948,4 +948,14 @@ func TestExecute_CalendarTeam_Plain_AllFailed(t *testing.T) {
 			t.Fatalf("error record is not parseable TSV: %q", line)
 		}
 	}
+}
+
+func nonEmptyTeamLines(s string) []string {
+	var lines []string
+	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
 }


### PR DESCRIPTION
## Summary
- include per-calendar event fetch errors and an explicit `complete` status in Calendar team JSON output
- render parseable incomplete plain records while preserving the successful four-column schema
- return nonzero after rendering any partial or all-failed event result
- document the structured incomplete-result contracts

## Testing
- `PATH=/home/jeremy-johnson/.local/go-sdk/go/bin:/usr/local/bin:/usr/bin:/bin go test ./internal/cmd -run TestExecute_CalendarTeam -count=1`
- `PATH=/home/jeremy-johnson/.local/go-sdk/go/bin:/usr/local/bin:/usr/bin:/bin make ci`
- final Standards/Fowler review: PASS
- final exact-spec review: PASS

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
