### PR TITLE
fix(output): keep plain records on one row

### DIFF
--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -170,5 +170,5 @@ func formatPartialDate(d *people.Date) string {
 }
 
 func sanitizeTab(s string) string {
-	return strings.ReplaceAll(s, "\t", " ")
+	return sanitizePlainField(s)
 }

--- a/internal/cmd/execute_chat_test.go
+++ b/internal/cmd/execute_chat_test.go
@@ -16,7 +16,7 @@ import (
 
 var errUnexpectedChatServiceCall = errors.New("unexpected chat service call")
 
-func TestExecute_ChatSpacesList_Text(t *testing.T) {
+func TestExecute_ChatSpacesList_PlainKeepsOneRowPerSpace(t *testing.T) {
 	origNew := newChatService
 	t.Cleanup(func() { newChatService = origNew })
 
@@ -28,7 +28,7 @@ func TestExecute_ChatSpacesList_Text(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"spaces": []map[string]any{
-				{"name": "spaces/aaa", "displayName": "Engineering", "spaceType": "SPACE"},
+				{"name": "spaces/aaa", "displayName": "Engineering\tNorth\nFloor\rOld\r\nWing", "spaceType": "SPACE"},
 				{"name": "spaces/bbb", "displayName": "", "spaceType": "DIRECT_MESSAGE"},
 			},
 			"nextPageToken": "npt",
@@ -48,7 +48,7 @@ func TestExecute_ChatSpacesList_Text(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		errOut := captureStderr(t, func() {
-			if err := Execute([]string{"--account", "a@b.com", "chat", "spaces", "list", "--max", "2"}); err != nil {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "chat", "spaces", "list", "--max", "2"}); err != nil {
 				t.Fatalf("Execute: %v", err)
 			}
 		})
@@ -56,8 +56,21 @@ func TestExecute_ChatSpacesList_Text(t *testing.T) {
 			t.Fatalf("unexpected stderr=%q", errOut)
 		}
 	})
-	if !strings.Contains(out, "RESOURCE") || !strings.Contains(out, "spaces/aaa") || !strings.Contains(out, "Engineering") {
-		t.Fatalf("unexpected out=%q", out)
+
+	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	if got, want := len(lines), 3; got != want {
+		t.Fatalf("physical rows = %d, want %d; output=%q", got, want, out)
+	}
+	for i, line := range lines {
+		if got, want := len(strings.Split(line, "\t")), 3; got != want {
+			t.Fatalf("row %d columns = %d, want %d; row=%q", i, got, want, line)
+		}
+		if strings.ContainsRune(line, '\r') {
+			t.Fatalf("row %d contains carriage return: %q", i, line)
+		}
+	}
+	if !strings.Contains(out, "Engineering North Floor Old Wing") {
+		t.Fatalf("sanitized display name missing from output: %q", out)
 	}
 }
 

--- a/internal/cmd/execute_chat_test.go
+++ b/internal/cmd/execute_chat_test.go
@@ -46,6 +46,17 @@ func TestExecute_ChatSpacesList_PlainKeepsOneRowPerSpace(t *testing.T) {
 	}
 	newChatService = func(context.Context, string) (*chat.Service, error) { return svc, nil }
 
+	textOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--account", "a@b.com", "chat", "spaces", "list", "--max", "2"}); err != nil {
+				t.Fatalf("Execute default output: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(textOut, "RESOURCE") || !strings.Contains(textOut, "spaces/aaa") || !strings.Contains(textOut, "Engineering North Floor Old Wing") {
+		t.Fatalf("unexpected default output=%q", textOut)
+	}
+
 	out := captureStdout(t, func() {
 		errOut := captureStderr(t, func() {
 			if err := Execute([]string{"--plain", "--account", "a@b.com", "chat", "spaces", "list", "--max", "2"}); err != nil {

--- a/internal/cmd/execute_gmail_messages_search_text_test.go
+++ b/internal/cmd/execute_gmail_messages_search_text_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-func TestExecute_GmailMessagesSearch_Text(t *testing.T) {
+func TestExecute_GmailMessagesSearch_PlainKeepsOneRowPerMessage(t *testing.T) {
 	origNew := newGmailService
 	t.Cleanup(func() { newGmailService = origNew })
 
@@ -37,8 +37,8 @@ func TestExecute_GmailMessagesSearch_Text(t *testing.T) {
 				"payload": map[string]any{
 					"mimeType": "text/plain",
 					"headers": []map[string]any{
-						{"name": "From", "value": "Example <no-reply@example.com>"},
-						{"name": "Subject", "value": "Receipt"},
+						{"name": "From", "value": "Example\tSender\nTeam"},
+						{"name": "Subject", "value": "Receipt\rArchive\r\nCopy"},
 						{"name": "Date", "value": "Mon, 02 Jan 2006 15:04:05 -0700"},
 					},
 				},
@@ -86,13 +86,26 @@ func TestExecute_GmailMessagesSearch_Text(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
-			if err := Execute([]string{"--account", "a@b.com", "gmail", "messages", "search", "from:example.com", "--max", "2"}); err != nil {
+			if err := Execute([]string{"--plain", "--account", "a@b.com", "gmail", "messages", "search", "from:example.com", "--max", "2"}); err != nil {
 				t.Fatalf("Execute: %v", err)
 			}
 		})
 	})
-	if !strings.Contains(out, "m1") || !strings.Contains(out, "m2") {
-		t.Fatalf("expected both message IDs, got: %q", out)
+
+	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	if got, want := len(lines), 3; got != want {
+		t.Fatalf("physical rows = %d, want %d; output=%q", got, want, out)
+	}
+	for i, line := range lines {
+		if got, want := len(strings.Split(line, "\t")), 6; got != want {
+			t.Fatalf("row %d columns = %d, want %d; row=%q", i, got, want, line)
+		}
+		if strings.ContainsRune(line, '\r') {
+			t.Fatalf("row %d contains carriage return: %q", i, line)
+		}
+	}
+	if !strings.Contains(out, "Example Sender Team") || !strings.Contains(out, "Receipt Archive Copy") {
+		t.Fatalf("sanitized fields missing from output: %q", out)
 	}
 }
 

--- a/internal/cmd/execute_gmail_messages_search_text_test.go
+++ b/internal/cmd/execute_gmail_messages_search_text_test.go
@@ -84,6 +84,17 @@ func TestExecute_GmailMessagesSearch_PlainKeepsOneRowPerMessage(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
+	textOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--account", "a@b.com", "gmail", "messages", "search", "from:example.com", "--max", "2"}); err != nil {
+				t.Fatalf("Execute default output: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(textOut, "m1") || !strings.Contains(textOut, "m2") {
+		t.Fatalf("expected both message IDs in default output, got: %q", textOut)
+	}
+
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
 			if err := Execute([]string{"--plain", "--account", "a@b.com", "gmail", "messages", "search", "from:example.com", "--max", "2"}); err != nil {

--- a/internal/cmd/gmail_test.go
+++ b/internal/cmd/gmail_test.go
@@ -55,8 +55,8 @@ func TestBestUnsubscribeLink(t *testing.T) {
 }
 
 func TestSanitizeTab(t *testing.T) {
-	if got := sanitizeTab("a\tb"); got != "a b" {
-		t.Fatalf("unexpected: %q", got)
+	if got, want := sanitizeTab("tab\tline\ncarriage\rwindows\r\nend"), "tab line carriage windows end"; got != want {
+		t.Fatalf("sanitizeTab() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/cmd/gmail_test.go
+++ b/internal/cmd/gmail_test.go
@@ -55,8 +55,24 @@ func TestBestUnsubscribeLink(t *testing.T) {
 }
 
 func TestSanitizeTab(t *testing.T) {
-	if got, want := sanitizeTab("tab\tline\ncarriage\rwindows\r\nend"), "tab line carriage windows end"; got != want {
-		t.Fatalf("sanitizeTab() = %q, want %q", got, want)
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "unchanged", input: "ordinary text", want: "ordinary text"},
+		{name: "delimiters at start", input: "\t\n\r\r\nstart", want: "    start"},
+		{name: "delimiters in middle", input: "tab\tline\ncarriage\rwindows\r\nend", want: "tab line carriage windows end"},
+		{name: "delimiters at end", input: "end\t\n\r\r\n", want: "end    "},
+		{name: "mixed positions", input: "\r\nstart\tmiddle\nend\r", want: " start middle end "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeTab(tt.input); got != tt.want {
+				t.Fatalf("sanitizeTab(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- route the shared `sanitizeTab` contract through the existing plain-field sanitizer
- replace tabs, LF, CR, and CRLF with inline spaces for all existing callers
- cover real Chat and Gmail `--plain` output seams plus delimiter positions and unchanged text

## Testing
- public-seam red/green verification with external Go 1.26.5 SDK
- focused Chat, Gmail, and sanitizer tests
- `make ci` with external Go 1.26.5 SDK

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
