### PR TITLE
fix(businessprofile): emit structured mutation receipts

### DIFF
--- a/internal/cmd/businessprofile.go
+++ b/internal/cmd/businessprofile.go
@@ -20,8 +20,8 @@ var (
 
 // writeBusinessProfileMutationReceipt emits a machine-readable success receipt for
 // empty-body Business Profile mutations. JSON: action/resource/success (+destination).
-// Plain: one TSV data row under stable headers. Returns true when a receipt was written.
-func writeBusinessProfileMutationReceipt(ctx context.Context, action, resource, destination string) (bool, error) {
+// Plain: one TSV data row under stable headers.
+func writeBusinessProfileMutationReceipt(ctx context.Context, action, resource, destination string) error {
 	if outfmt.IsJSON(ctx) {
 		payload := map[string]any{
 			"action":   action,
@@ -31,7 +31,7 @@ func writeBusinessProfileMutationReceipt(ctx context.Context, action, resource, 
 		if destination != "" {
 			payload["destination"] = destination
 		}
-		return true, outfmt.WriteJSON(os.Stdout, payload)
+		return outfmt.WriteJSON(os.Stdout, payload)
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -42,10 +42,9 @@ func writeBusinessProfileMutationReceipt(ctx context.Context, action, resource, 
 			fields = append(fields, destination)
 		}
 		writePlainReceipt(ctx, headers, fields)
-		return true, nil
 	}
 
-	return false, nil
+	return nil
 }
 
 type BusinessProfileCmd struct {

--- a/internal/cmd/businessprofile.go
+++ b/internal/cmd/businessprofile.go
@@ -41,7 +41,7 @@ func writeBusinessProfileMutationReceipt(ctx context.Context, action, resource, 
 			headers = append(headers, "DESTINATION")
 			fields = append(fields, destination)
 		}
-		writePlainReceipt(ctx, headers, fields)
+		return writePlainReceiptError(ctx, headers, fields)
 	}
 
 	return nil

--- a/internal/cmd/businessprofile.go
+++ b/internal/cmd/businessprofile.go
@@ -18,6 +18,38 @@ var (
 	newBusinessProfileInfoService     = googleapi.NewBusinessProfileInfo
 )
 
+// writeBusinessProfileMutationReceipt emits a machine-readable success receipt for
+// empty-body Business Profile mutations. JSON: action/resource/success (+destination).
+// Plain: one TSV data row under stable headers. Returns true when a receipt was written.
+func writeBusinessProfileMutationReceipt(ctx context.Context, action, resource, destination string) (bool, error) {
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"action":   action,
+			"resource": resource,
+			"success":  true,
+		}
+		if destination != "" {
+			payload["destination"] = destination
+		}
+		return true, outfmt.WriteJSON(os.Stdout, payload)
+	}
+
+	if outfmt.IsPlain(ctx) {
+		w, flush := tableWriter(ctx)
+		defer flush()
+		if destination != "" {
+			fmt.Fprintln(w, "ACTION\tRESOURCE\tSUCCESS\tDESTINATION")
+			writeTableRow(ctx, w, []string{action, resource, "true", destination})
+		} else {
+			fmt.Fprintln(w, "ACTION\tRESOURCE\tSUCCESS")
+			writeTableRow(ctx, w, []string{action, resource, "true"})
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
 type BusinessProfileCmd struct {
 	Accounts        BusinessProfileAccountsCmd            `cmd:"" name:"accounts" help:"Account management"`
 	Admins          BusinessProfileAccountAdminsCmd       `cmd:"" name:"account-admins" help:"Account admin management"`

--- a/internal/cmd/businessprofile.go
+++ b/internal/cmd/businessprofile.go
@@ -35,15 +35,13 @@ func writeBusinessProfileMutationReceipt(ctx context.Context, action, resource, 
 	}
 
 	if outfmt.IsPlain(ctx) {
-		w, flush := tableWriter(ctx)
-		defer flush()
+		headers := []string{"ACTION", "RESOURCE", "SUCCESS"}
+		fields := []string{action, resource, "true"}
 		if destination != "" {
-			fmt.Fprintln(w, "ACTION\tRESOURCE\tSUCCESS\tDESTINATION")
-			writeTableRow(ctx, w, []string{action, resource, "true", destination})
-		} else {
-			fmt.Fprintln(w, "ACTION\tRESOURCE\tSUCCESS")
-			writeTableRow(ctx, w, []string{action, resource, "true"})
+			headers = append(headers, "DESTINATION")
+			fields = append(fields, destination)
 		}
+		writePlainReceipt(ctx, headers, fields)
 		return true, nil
 	}
 

--- a/internal/cmd/businessprofile_admins.go
+++ b/internal/cmd/businessprofile_admins.go
@@ -159,6 +159,12 @@ func (c *BusinessProfileAccountAdminsDeleteCmd) Run(ctx context.Context, flags *
 		return delErr
 	}
 
+	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
+		return err
+	} else if wrote {
+		return nil
+	}
+
 	u.Err().Println("Deleted")
 	return nil
 }

--- a/internal/cmd/businessprofile_admins.go
+++ b/internal/cmd/businessprofile_admins.go
@@ -159,12 +159,8 @@ func (c *BusinessProfileAccountAdminsDeleteCmd) Run(ctx context.Context, flags *
 		return delErr
 	}
 
-	if _, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
-		return err
-	}
-
 	u.Err().Println("Deleted")
-	return nil
+	return writeBusinessProfileMutationReceipt(ctx, "delete", name, "")
 }
 
 // BusinessProfileAccountAdminsPatchCmd patches an admin's role.

--- a/internal/cmd/businessprofile_admins.go
+++ b/internal/cmd/businessprofile_admins.go
@@ -159,10 +159,8 @@ func (c *BusinessProfileAccountAdminsDeleteCmd) Run(ctx context.Context, flags *
 		return delErr
 	}
 
-	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
+	if _, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
 		return err
-	} else if wrote {
-		return nil
 	}
 
 	u.Err().Println("Deleted")

--- a/internal/cmd/businessprofile_admins_test.go
+++ b/internal/cmd/businessprofile_admins_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -422,6 +423,57 @@ func TestExecute_BusinessProfileAccountAdminsDelete_Human(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "Deleted") {
 		t.Fatalf("expected human stderr Deleted, got %q", stderr)
+	}
+}
+
+func TestExecute_BusinessProfileAccountAdminsDelete_JSONWriteErrorPreservesDiagnostic(t *testing.T) {
+	origAccounts := newBusinessProfileAccountsService
+	t.Cleanup(func() { newBusinessProfileAccountsService = origAccounts })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || !strings.Contains(r.URL.Path, "/admins/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	svc, err := mybusinessaccountmanagement.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newBusinessProfileAccountsService = func(context.Context, string) (*mybusinessaccountmanagement.Service, error) {
+		return svc, nil
+	}
+
+	oldStdout := os.Stdout
+	readEnd, closedStdout, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	_ = readEnd.Close()
+	_ = closedStdout.Close()
+	os.Stdout = closedStdout
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	var executeErr error
+	stderr := captureStderr(t, func() {
+		executeErr = Execute([]string{
+			"--json", "--account", "a@b.com", "--force",
+			"business-profile", "account-admins", "delete", "accounts/123/admins/456",
+		})
+	})
+	if executeErr == nil {
+		t.Fatal("expected stdout write error")
+	}
+	if !strings.Contains(stderr, "Deleted") {
+		t.Fatalf("expected success diagnostic before write error, got %q", stderr)
 	}
 }
 

--- a/internal/cmd/businessprofile_admins_test.go
+++ b/internal/cmd/businessprofile_admins_test.go
@@ -297,8 +297,9 @@ func TestExecute_BusinessProfileAccountAdminsDelete_JSON(t *testing.T) {
 		return svc, nil
 	}
 
+	var stderr string
 	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
+		stderr = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--account", "a@b.com", "--force",
 				"business-profile", "account-admins", "delete", "accounts/123/admins/456",
@@ -307,6 +308,9 @@ func TestExecute_BusinessProfileAccountAdminsDelete_JSON(t *testing.T) {
 			}
 		})
 	})
+	if !strings.Contains(stderr, "Deleted") {
+		t.Fatalf("expected success diagnostic, got %q", stderr)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -355,8 +359,9 @@ func TestExecute_BusinessProfileAccountAdminsDelete_Plain(t *testing.T) {
 		return svc, nil
 	}
 
+	var stderr string
 	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
+		stderr = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--plain", "--account", "a@b.com", "--force",
 				"business-profile", "account-admins", "delete", "accounts/123/admins/456",
@@ -365,6 +370,9 @@ func TestExecute_BusinessProfileAccountAdminsDelete_Plain(t *testing.T) {
 			}
 		})
 	})
+	if !strings.Contains(stderr, "Deleted") {
+		t.Fatalf("expected success diagnostic, got %q", stderr)
+	}
 
 	want := "ACTION\tRESOURCE\tSUCCESS\ndelete\taccounts/123/admins/456\ttrue\n"
 	if out != want {

--- a/internal/cmd/businessprofile_admins_test.go
+++ b/internal/cmd/businessprofile_admins_test.go
@@ -297,7 +297,7 @@ func TestExecute_BusinessProfileAccountAdminsDelete_JSON(t *testing.T) {
 		return svc, nil
 	}
 
-	_ = captureStdout(t, func() {
+	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--account", "a@b.com", "--force",
@@ -312,6 +312,108 @@ func TestExecute_BusinessProfileAccountAdminsDelete_JSON(t *testing.T) {
 	defer mu.Unlock()
 	if gotMethod != http.MethodDelete {
 		t.Fatalf("expected DELETE method, got %q", gotMethod)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parsing JSON: %v\nout=%q", err, out)
+	}
+	if result["action"] != "delete" {
+		t.Fatalf("expected action=delete, got %v", result["action"])
+	}
+	if result["resource"] != "accounts/123/admins/456" {
+		t.Fatalf("expected resource accounts/123/admins/456, got %v", result["resource"])
+	}
+	if result["success"] != true {
+		t.Fatalf("expected success=true, got %v", result["success"])
+	}
+}
+
+func TestExecute_BusinessProfileAccountAdminsDelete_Plain(t *testing.T) {
+	origAccounts := newBusinessProfileAccountsService
+	t.Cleanup(func() { newBusinessProfileAccountsService = origAccounts })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || !strings.Contains(r.URL.Path, "/admins/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	svc, err := mybusinessaccountmanagement.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newBusinessProfileAccountsService = func(context.Context, string) (*mybusinessaccountmanagement.Service, error) {
+		return svc, nil
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com", "--force",
+				"business-profile", "account-admins", "delete", "accounts/123/admins/456",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	want := "ACTION\tRESOURCE\tSUCCESS\ndelete\taccounts/123/admins/456\ttrue\n"
+	if out != want {
+		t.Fatalf("plain receipt mismatch:\n got %q\nwant %q", out, want)
+	}
+}
+
+func TestExecute_BusinessProfileAccountAdminsDelete_Human(t *testing.T) {
+	origAccounts := newBusinessProfileAccountsService
+	t.Cleanup(func() { newBusinessProfileAccountsService = origAccounts })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || !strings.Contains(r.URL.Path, "/admins/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	svc, err := mybusinessaccountmanagement.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newBusinessProfileAccountsService = func(context.Context, string) (*mybusinessaccountmanagement.Service, error) {
+		return svc, nil
+	}
+
+	var stderr string
+	out := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--account", "a@b.com", "--force",
+				"business-profile", "account-admins", "delete", "accounts/123/admins/456",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected empty stdout in human mode, got %q", out)
+	}
+	if !strings.Contains(stderr, "Deleted") {
+		t.Fatalf("expected human stderr Deleted, got %q", stderr)
 	}
 }
 

--- a/internal/cmd/businessprofile_admins_test.go
+++ b/internal/cmd/businessprofile_admins_test.go
@@ -426,7 +426,7 @@ func TestExecute_BusinessProfileAccountAdminsDelete_Human(t *testing.T) {
 	}
 }
 
-func TestExecute_BusinessProfileAccountAdminsDelete_JSONWriteErrorPreservesDiagnostic(t *testing.T) {
+func TestExecute_BusinessProfileAccountAdminsDelete_WriteErrorPreservesDiagnostic(t *testing.T) {
 	origAccounts := newBusinessProfileAccountsService
 	t.Cleanup(func() { newBusinessProfileAccountsService = origAccounts })
 
@@ -452,28 +452,32 @@ func TestExecute_BusinessProfileAccountAdminsDelete_JSONWriteErrorPreservesDiagn
 		return svc, nil
 	}
 
-	oldStdout := os.Stdout
-	readEnd, closedStdout, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	_ = readEnd.Close()
-	_ = closedStdout.Close()
-	os.Stdout = closedStdout
-	t.Cleanup(func() { os.Stdout = oldStdout })
+	for _, mode := range []string{"--json", "--plain"} {
+		t.Run(mode, func(t *testing.T) {
+			oldStdout := os.Stdout
+			readEnd, closedStdout, pipeErr := os.Pipe()
+			if pipeErr != nil {
+				t.Fatalf("os.Pipe: %v", pipeErr)
+			}
+			_ = readEnd.Close()
+			_ = closedStdout.Close()
+			os.Stdout = closedStdout
+			t.Cleanup(func() { os.Stdout = oldStdout })
 
-	var executeErr error
-	stderr := captureStderr(t, func() {
-		executeErr = Execute([]string{
-			"--json", "--account", "a@b.com", "--force",
-			"business-profile", "account-admins", "delete", "accounts/123/admins/456",
+			var executeErr error
+			stderr := captureStderr(t, func() {
+				executeErr = Execute([]string{
+					mode, "--account", "a@b.com", "--force",
+					"business-profile", "account-admins", "delete", "accounts/123/admins/456",
+				})
+			})
+			if executeErr == nil {
+				t.Fatal("expected stdout write error")
+			}
+			if !strings.Contains(stderr, "Deleted") {
+				t.Fatalf("expected success diagnostic before write error, got %q", stderr)
+			}
 		})
-	})
-	if executeErr == nil {
-		t.Fatal("expected stdout write error")
-	}
-	if !strings.Contains(stderr, "Deleted") {
-		t.Fatalf("expected success diagnostic before write error, got %q", stderr)
 	}
 }
 

--- a/internal/cmd/businessprofile_info_locations.go
+++ b/internal/cmd/businessprofile_info_locations.go
@@ -197,12 +197,8 @@ func (c *BusinessProfileInfoLocationsDeleteCmd) Run(ctx context.Context, flags *
 		return delErr
 	}
 
-	if _, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
-		return err
-	}
-
 	u.Err().Println("Deleted")
-	return nil
+	return writeBusinessProfileMutationReceipt(ctx, "delete", name, "")
 }
 
 // BusinessProfileInfoLocationsGetGoogleUpdatedCmd gets the Google-updated version.

--- a/internal/cmd/businessprofile_info_locations.go
+++ b/internal/cmd/businessprofile_info_locations.go
@@ -197,6 +197,12 @@ func (c *BusinessProfileInfoLocationsDeleteCmd) Run(ctx context.Context, flags *
 		return delErr
 	}
 
+	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
+		return err
+	} else if wrote {
+		return nil
+	}
+
 	u.Err().Println("Deleted")
 	return nil
 }

--- a/internal/cmd/businessprofile_info_locations.go
+++ b/internal/cmd/businessprofile_info_locations.go
@@ -197,10 +197,8 @@ func (c *BusinessProfileInfoLocationsDeleteCmd) Run(ctx context.Context, flags *
 		return delErr
 	}
 
-	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
+	if _, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
 		return err
-	} else if wrote {
-		return nil
 	}
 
 	u.Err().Println("Deleted")

--- a/internal/cmd/businessprofile_info_locations_test.go
+++ b/internal/cmd/businessprofile_info_locations_test.go
@@ -171,7 +171,7 @@ func TestExecute_BusinessProfileInfoLocationsDelete_JSON(t *testing.T) {
 		return svc, nil
 	}
 
-	_ = captureStdout(t, func() {
+	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--force", "--account", "a@b.com",
@@ -189,6 +189,63 @@ func TestExecute_BusinessProfileInfoLocationsDelete_JSON(t *testing.T) {
 	}
 	if !strings.Contains(gotPath, "locations/123") {
 		t.Fatalf("expected path to contain 'locations/123', got %q", gotPath)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parsing JSON: %v\nout=%q", err, out)
+	}
+	if result["action"] != "delete" {
+		t.Fatalf("expected action=delete, got %v", result["action"])
+	}
+	if result["resource"] != "locations/123" {
+		t.Fatalf("expected resource locations/123, got %v", result["resource"])
+	}
+	if result["success"] != true {
+		t.Fatalf("expected success=true, got %v", result["success"])
+	}
+}
+
+func TestExecute_BusinessProfileInfoLocationsDelete_Plain(t *testing.T) {
+	origInfo := newBusinessProfileInfoService
+	t.Cleanup(func() { newBusinessProfileInfoService = origInfo })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || !strings.Contains(r.URL.Path, "/locations/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	svc, err := mybusinessbusinessinformation.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newBusinessProfileInfoService = func(context.Context, string) (*mybusinessbusinessinformation.Service, error) {
+		return svc, nil
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--force", "--account", "a@b.com",
+				"business-profile", "info-locations", "delete", "123",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	want := "ACTION\tRESOURCE\tSUCCESS\ndelete\tlocations/123\ttrue\n"
+	if out != want {
+		t.Fatalf("plain receipt mismatch:\n got %q\nwant %q", out, want)
 	}
 }
 

--- a/internal/cmd/businessprofile_info_locations_test.go
+++ b/internal/cmd/businessprofile_info_locations_test.go
@@ -171,8 +171,9 @@ func TestExecute_BusinessProfileInfoLocationsDelete_JSON(t *testing.T) {
 		return svc, nil
 	}
 
+	var stderr string
 	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
+		stderr = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--force", "--account", "a@b.com",
 				"business-profile", "info-locations", "delete", "123",
@@ -181,6 +182,9 @@ func TestExecute_BusinessProfileInfoLocationsDelete_JSON(t *testing.T) {
 			}
 		})
 	})
+	if !strings.Contains(stderr, "Deleted") {
+		t.Fatalf("expected success diagnostic, got %q", stderr)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/cmd/businessprofile_invitations.go
+++ b/internal/cmd/businessprofile_invitations.go
@@ -102,12 +102,8 @@ func (c *BusinessProfileInvitationsAcceptCmd) Run(ctx context.Context, flags *Ro
 		return err
 	}
 
-	if _, err := writeBusinessProfileMutationReceipt(ctx, "accept", name, ""); err != nil {
-		return err
-	}
-
 	u.Err().Println("Invitation accepted")
-	return nil
+	return writeBusinessProfileMutationReceipt(ctx, "accept", name, "")
 }
 
 // BusinessProfileInvitationsDeclineCmd declines an invitation.
@@ -137,10 +133,6 @@ func (c *BusinessProfileInvitationsDeclineCmd) Run(ctx context.Context, flags *R
 		return err
 	}
 
-	if _, err := writeBusinessProfileMutationReceipt(ctx, "decline", name, ""); err != nil {
-		return err
-	}
-
 	u.Err().Println("Invitation declined")
-	return nil
+	return writeBusinessProfileMutationReceipt(ctx, "decline", name, "")
 }

--- a/internal/cmd/businessprofile_invitations.go
+++ b/internal/cmd/businessprofile_invitations.go
@@ -102,6 +102,12 @@ func (c *BusinessProfileInvitationsAcceptCmd) Run(ctx context.Context, flags *Ro
 		return err
 	}
 
+	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "accept", name, ""); err != nil {
+		return err
+	} else if wrote {
+		return nil
+	}
+
 	u.Err().Println("Invitation accepted")
 	return nil
 }
@@ -131,6 +137,12 @@ func (c *BusinessProfileInvitationsDeclineCmd) Run(ctx context.Context, flags *R
 	req := &mybusinessaccountmanagement.DeclineInvitationRequest{}
 	if _, err := svc.Accounts.Invitations.Decline(name, req).Do(); err != nil {
 		return err
+	}
+
+	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "decline", name, ""); err != nil {
+		return err
+	} else if wrote {
+		return nil
 	}
 
 	u.Err().Println("Invitation declined")

--- a/internal/cmd/businessprofile_invitations.go
+++ b/internal/cmd/businessprofile_invitations.go
@@ -102,10 +102,8 @@ func (c *BusinessProfileInvitationsAcceptCmd) Run(ctx context.Context, flags *Ro
 		return err
 	}
 
-	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "accept", name, ""); err != nil {
+	if _, err := writeBusinessProfileMutationReceipt(ctx, "accept", name, ""); err != nil {
 		return err
-	} else if wrote {
-		return nil
 	}
 
 	u.Err().Println("Invitation accepted")
@@ -139,10 +137,8 @@ func (c *BusinessProfileInvitationsDeclineCmd) Run(ctx context.Context, flags *R
 		return err
 	}
 
-	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "decline", name, ""); err != nil {
+	if _, err := writeBusinessProfileMutationReceipt(ctx, "decline", name, ""); err != nil {
 		return err
-	} else if wrote {
-		return nil
 	}
 
 	u.Err().Println("Invitation declined")

--- a/internal/cmd/businessprofile_invitations_test.go
+++ b/internal/cmd/businessprofile_invitations_test.go
@@ -245,8 +245,9 @@ func TestExecute_BusinessProfileInvitationsAccept_JSON(t *testing.T) {
 		return svc, nil
 	}
 
+	var stderr string
 	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
+		stderr = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--account", "a@b.com",
 				"business-profile", "account-invitations", "accept",
@@ -256,6 +257,9 @@ func TestExecute_BusinessProfileInvitationsAccept_JSON(t *testing.T) {
 			}
 		})
 	})
+	if !strings.Contains(stderr, "accepted") {
+		t.Fatalf("expected success diagnostic, got %q", stderr)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -360,8 +364,9 @@ func TestExecute_BusinessProfileInvitationsDecline_JSON(t *testing.T) {
 		return svc, nil
 	}
 
+	var stderr string
 	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
+		stderr = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--account", "a@b.com",
 				"business-profile", "account-invitations", "decline",
@@ -371,6 +376,9 @@ func TestExecute_BusinessProfileInvitationsDecline_JSON(t *testing.T) {
 			}
 		})
 	})
+	if !strings.Contains(stderr, "declined") {
+		t.Fatalf("expected success diagnostic, got %q", stderr)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/cmd/businessprofile_invitations_test.go
+++ b/internal/cmd/businessprofile_invitations_test.go
@@ -245,8 +245,8 @@ func TestExecute_BusinessProfileInvitationsAccept_JSON(t *testing.T) {
 		return svc, nil
 	}
 
-	stderr := captureStderr(t, func() {
-		captureStdout(t, func() {
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--account", "a@b.com",
 				"business-profile", "account-invitations", "accept",
@@ -265,8 +265,63 @@ func TestExecute_BusinessProfileInvitationsAccept_JSON(t *testing.T) {
 	if !strings.Contains(gotPath, ":accept") {
 		t.Fatalf("expected path to contain ':accept', got %q", gotPath)
 	}
-	if !strings.Contains(stderr, "accepted") {
-		t.Fatalf("expected stderr to contain 'accepted', got %q", stderr)
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parsing JSON: %v\nout=%q", err, out)
+	}
+	if result["action"] != "accept" {
+		t.Fatalf("expected action=accept, got %v", result["action"])
+	}
+	if result["resource"] != "accounts/123/invitations/456" {
+		t.Fatalf("expected resource accounts/123/invitations/456, got %v", result["resource"])
+	}
+	if result["success"] != true {
+		t.Fatalf("expected success=true, got %v", result["success"])
+	}
+}
+
+func TestExecute_BusinessProfileInvitationsAccept_Plain(t *testing.T) {
+	origAccounts := newBusinessProfileAccountsService
+	t.Cleanup(func() { newBusinessProfileAccountsService = origAccounts })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, ":accept") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	svc, err := mybusinessaccountmanagement.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newBusinessProfileAccountsService = func(context.Context, string) (*mybusinessaccountmanagement.Service, error) {
+		return svc, nil
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"business-profile", "account-invitations", "accept",
+				"accounts/123/invitations/456",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	want := "ACTION\tRESOURCE\tSUCCESS\naccept\taccounts/123/invitations/456\ttrue\n"
+	if out != want {
+		t.Fatalf("plain receipt mismatch:\n got %q\nwant %q", out, want)
 	}
 }
 
@@ -305,8 +360,8 @@ func TestExecute_BusinessProfileInvitationsDecline_JSON(t *testing.T) {
 		return svc, nil
 	}
 
-	stderr := captureStderr(t, func() {
-		captureStdout(t, func() {
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--account", "a@b.com",
 				"business-profile", "account-invitations", "decline",
@@ -325,7 +380,62 @@ func TestExecute_BusinessProfileInvitationsDecline_JSON(t *testing.T) {
 	if !strings.Contains(gotPath, ":decline") {
 		t.Fatalf("expected path to contain ':decline', got %q", gotPath)
 	}
-	if !strings.Contains(stderr, "declined") {
-		t.Fatalf("expected stderr to contain 'declined', got %q", stderr)
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parsing JSON: %v\nout=%q", err, out)
+	}
+	if result["action"] != "decline" {
+		t.Fatalf("expected action=decline, got %v", result["action"])
+	}
+	if result["resource"] != "accounts/123/invitations/456" {
+		t.Fatalf("expected resource accounts/123/invitations/456, got %v", result["resource"])
+	}
+	if result["success"] != true {
+		t.Fatalf("expected success=true, got %v", result["success"])
+	}
+}
+
+func TestExecute_BusinessProfileInvitationsDecline_Plain(t *testing.T) {
+	origAccounts := newBusinessProfileAccountsService
+	t.Cleanup(func() { newBusinessProfileAccountsService = origAccounts })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, ":decline") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	svc, err := mybusinessaccountmanagement.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newBusinessProfileAccountsService = func(context.Context, string) (*mybusinessaccountmanagement.Service, error) {
+		return svc, nil
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"business-profile", "account-invitations", "decline",
+				"accounts/123/invitations/456",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	want := "ACTION\tRESOURCE\tSUCCESS\ndecline\taccounts/123/invitations/456\ttrue\n"
+	if out != want {
+		t.Fatalf("plain receipt mismatch:\n got %q\nwant %q", out, want)
 	}
 }

--- a/internal/cmd/businessprofile_location_admins.go
+++ b/internal/cmd/businessprofile_location_admins.go
@@ -159,6 +159,12 @@ func (c *BusinessProfileLocationAdminsDeleteCmd) Run(ctx context.Context, flags 
 		return delErr
 	}
 
+	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
+		return err
+	} else if wrote {
+		return nil
+	}
+
 	u.Err().Println("Deleted")
 	return nil
 }
@@ -266,6 +272,12 @@ func (c *BusinessProfileLocationTransferCmd) Run(ctx context.Context, flags *Roo
 
 	if _, transferErr := svc.Locations.Transfer(name, req).Do(); transferErr != nil {
 		return transferErr
+	}
+
+	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "transfer", name, dest); err != nil {
+		return err
+	} else if wrote {
+		return nil
 	}
 
 	u.Err().Println("Location transferred")

--- a/internal/cmd/businessprofile_location_admins.go
+++ b/internal/cmd/businessprofile_location_admins.go
@@ -159,12 +159,8 @@ func (c *BusinessProfileLocationAdminsDeleteCmd) Run(ctx context.Context, flags 
 		return delErr
 	}
 
-	if _, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
-		return err
-	}
-
 	u.Err().Println("Deleted")
-	return nil
+	return writeBusinessProfileMutationReceipt(ctx, "delete", name, "")
 }
 
 // BusinessProfileLocationAdminsPatchCmd patches a location admin's role.
@@ -272,10 +268,6 @@ func (c *BusinessProfileLocationTransferCmd) Run(ctx context.Context, flags *Roo
 		return transferErr
 	}
 
-	if _, err := writeBusinessProfileMutationReceipt(ctx, "transfer", name, dest); err != nil {
-		return err
-	}
-
 	u.Err().Println("Location transferred")
-	return nil
+	return writeBusinessProfileMutationReceipt(ctx, "transfer", name, dest)
 }

--- a/internal/cmd/businessprofile_location_admins.go
+++ b/internal/cmd/businessprofile_location_admins.go
@@ -159,10 +159,8 @@ func (c *BusinessProfileLocationAdminsDeleteCmd) Run(ctx context.Context, flags 
 		return delErr
 	}
 
-	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
+	if _, err := writeBusinessProfileMutationReceipt(ctx, "delete", name, ""); err != nil {
 		return err
-	} else if wrote {
-		return nil
 	}
 
 	u.Err().Println("Deleted")
@@ -274,10 +272,8 @@ func (c *BusinessProfileLocationTransferCmd) Run(ctx context.Context, flags *Roo
 		return transferErr
 	}
 
-	if wrote, err := writeBusinessProfileMutationReceipt(ctx, "transfer", name, dest); err != nil {
+	if _, err := writeBusinessProfileMutationReceipt(ctx, "transfer", name, dest); err != nil {
 		return err
-	} else if wrote {
-		return nil
 	}
 
 	u.Err().Println("Location transferred")

--- a/internal/cmd/businessprofile_location_admins_test.go
+++ b/internal/cmd/businessprofile_location_admins_test.go
@@ -226,7 +226,7 @@ func TestExecute_BusinessProfileLocationAdminsDelete_JSON(t *testing.T) {
 		return svc, nil
 	}
 
-	_ = captureStdout(t, func() {
+	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--account", "a@b.com",
@@ -245,6 +245,60 @@ func TestExecute_BusinessProfileLocationAdminsDelete_JSON(t *testing.T) {
 	}
 	if !strings.Contains(gotPath, "/admins/") {
 		t.Fatalf("expected path to contain '/admins/', got %q", gotPath)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parsing JSON: %v\nout=%q", err, out)
+	}
+	if result["action"] != "delete" {
+		t.Fatalf("expected action=delete, got %v", result["action"])
+	}
+	if result["resource"] != "locations/123/admins/1" {
+		t.Fatalf("expected resource locations/123/admins/1, got %v", result["resource"])
+	}
+	if result["success"] != true {
+		t.Fatalf("expected success=true, got %v", result["success"])
+	}
+}
+
+func TestExecute_BusinessProfileLocationAdminsDelete_Plain(t *testing.T) {
+	origAccounts := newBusinessProfileAccountsService
+	t.Cleanup(func() { newBusinessProfileAccountsService = origAccounts })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	svc, err := mybusinessaccountmanagement.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newBusinessProfileAccountsService = func(context.Context, string) (*mybusinessaccountmanagement.Service, error) {
+		return svc, nil
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"business-profile", "location-admins", "delete",
+				"--force", "locations/123/admins/1",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	want := "ACTION\tRESOURCE\tSUCCESS\ndelete\tlocations/123/admins/1\ttrue\n"
+	if out != want {
+		t.Fatalf("plain receipt mismatch:\n got %q\nwant %q", out, want)
 	}
 }
 
@@ -366,7 +420,7 @@ func TestExecute_BusinessProfileLocationTransfer_JSON(t *testing.T) {
 		return svc, nil
 	}
 
-	_ = captureStdout(t, func() {
+	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--account", "a@b.com",
@@ -389,6 +443,64 @@ func TestExecute_BusinessProfileLocationTransfer_JSON(t *testing.T) {
 	}
 	if gotBody["destinationAccount"] != "accounts/456" {
 		t.Fatalf("expected destinationAccount 'accounts/456', got %v", gotBody["destinationAccount"])
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parsing JSON: %v\nout=%q", err, out)
+	}
+	if result["action"] != "transfer" {
+		t.Fatalf("expected action=transfer, got %v", result["action"])
+	}
+	if result["resource"] != "locations/123" {
+		t.Fatalf("expected resource locations/123, got %v", result["resource"])
+	}
+	if result["destination"] != "accounts/456" {
+		t.Fatalf("expected destination accounts/456, got %v", result["destination"])
+	}
+	if result["success"] != true {
+		t.Fatalf("expected success=true, got %v", result["success"])
+	}
+}
+
+func TestExecute_BusinessProfileLocationTransfer_Plain(t *testing.T) {
+	origAccounts := newBusinessProfileAccountsService
+	t.Cleanup(func() { newBusinessProfileAccountsService = origAccounts })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	svc, err := mybusinessaccountmanagement.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newBusinessProfileAccountsService = func(context.Context, string) (*mybusinessaccountmanagement.Service, error) {
+		return svc, nil
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"business-profile", "locations-transfer",
+				"--force", "--destination-account", "accounts/456",
+				"locations/123",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	want := "ACTION\tRESOURCE\tSUCCESS\tDESTINATION\ntransfer\tlocations/123\ttrue\taccounts/456\n"
+	if out != want {
+		t.Fatalf("plain receipt mismatch:\n got %q\nwant %q", out, want)
 	}
 }
 

--- a/internal/cmd/businessprofile_location_admins_test.go
+++ b/internal/cmd/businessprofile_location_admins_test.go
@@ -226,8 +226,9 @@ func TestExecute_BusinessProfileLocationAdminsDelete_JSON(t *testing.T) {
 		return svc, nil
 	}
 
+	var stderr string
 	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
+		stderr = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--account", "a@b.com",
 				"business-profile", "location-admins", "delete",
@@ -237,6 +238,9 @@ func TestExecute_BusinessProfileLocationAdminsDelete_JSON(t *testing.T) {
 			}
 		})
 	})
+	if !strings.Contains(stderr, "Deleted") {
+		t.Fatalf("expected success diagnostic, got %q", stderr)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -420,8 +424,9 @@ func TestExecute_BusinessProfileLocationTransfer_JSON(t *testing.T) {
 		return svc, nil
 	}
 
+	var stderr string
 	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
+		stderr = captureStderr(t, func() {
 			if err := Execute([]string{
 				"--json", "--account", "a@b.com",
 				"business-profile", "locations-transfer",
@@ -432,6 +437,9 @@ func TestExecute_BusinessProfileLocationTransfer_JSON(t *testing.T) {
 			}
 		})
 	})
+	if !strings.Contains(stderr, "Location transferred") {
+		t.Fatalf("expected success diagnostic, got %q", stderr)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -49,10 +49,19 @@ func sanitizePlainField(s string) string {
 // writePlainReceipt writes a fixed-schema TSV receipt (header + one data row)
 // for --plain mutation output. Fields are sanitized for tab/newline safety.
 func writePlainReceipt(ctx context.Context, headers []string, fields []string) {
+	_ = writePlainReceiptError(ctx, headers, fields)
+}
+
+func writePlainReceiptError(ctx context.Context, headers []string, fields []string) error {
 	w, flush := tableWriter(ctx)
-	defer flush()
-	writeTableRow(ctx, w, headers)
-	writeTableRow(ctx, w, fields)
+	if _, err := fmt.Fprintln(w, strings.Join(plainTableFields(ctx, headers), "\t")); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, strings.Join(plainTableFields(ctx, fields), "\t")); err != nil {
+		return err
+	}
+	flush()
+	return nil
 }
 
 // writePlainRoutingReceipt emits the shared Gmail routing mutation receipt:


### PR DESCRIPTION
## Summary
- emit JSON and stable TSV success receipts for Business Profile account admin, location admin, location, transfer, and invitation mutations
- preserve existing stderr success diagnostics and destructive confirmation behavior
- propagate JSON and plain receipt write failures while keeping success diagnostics visible

## Testing
- `PATH="$HOME/.local/share/Trash/files/gogcli-go-1.26.0/go/bin:$PATH" make ci`
- focused public CLI receipt and write-error regression tests
- independent repository/Fowler and exact-spec reviews: no findings

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)