### PR TITLE
feat(search-console): add query start row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Search Console: add `--start-row` to `search-console query` for zero-based Search Analytics result windows. (#98)
 - Tag Manager: add workspace trigger and variable create/delete/get/revert/update commands plus built-in-variable management. (#12, #45, #46, #47)
 - Tag Manager: add composable workspace version creation and container-version publishing commands. (#11)
 

--- a/internal/cmd/searchconsole.go
+++ b/internal/cmd/searchconsole.go
@@ -88,6 +88,7 @@ type SearchConsoleQueryCmd struct {
 	EndDate    string `name:"end-date" required:"" help:"End date (YYYY-MM-DD)"`
 	Dimensions string `name:"dimensions" help:"Comma-separated dimensions: query,page,country,device,date" default:""`
 	RowLimit   int64  `name:"row-limit" help:"Max rows to return" default:"25"`
+	StartRow   int64  `name:"start-row" help:"Zero-based index of the first row to return" default:"0"`
 }
 
 func (c *SearchConsoleQueryCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -109,6 +110,9 @@ func (c *SearchConsoleQueryCmd) Run(ctx context.Context, flags *RootFlags) error
 	if endDate == "" {
 		return usage("--end-date required")
 	}
+	if c.StartRow < 0 {
+		return usage("--start-row must be >= 0")
+	}
 
 	svc, err := newSearchConsoleService(ctx, account)
 	if err != nil {
@@ -119,6 +123,7 @@ func (c *SearchConsoleQueryCmd) Run(ctx context.Context, flags *RootFlags) error
 		StartDate: startDate,
 		EndDate:   endDate,
 		RowLimit:  c.RowLimit,
+		StartRow:  c.StartRow,
 	}
 
 	if dims := strings.TrimSpace(c.Dimensions); dims != "" {

--- a/internal/cmd/searchconsole.go
+++ b/internal/cmd/searchconsole.go
@@ -120,10 +120,11 @@ func (c *SearchConsoleQueryCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	req := &searchconsole.SearchAnalyticsQueryRequest{
-		StartDate: startDate,
-		EndDate:   endDate,
-		RowLimit:  c.RowLimit,
-		StartRow:  c.StartRow,
+		StartDate:       startDate,
+		EndDate:         endDate,
+		RowLimit:        c.RowLimit,
+		StartRow:        c.StartRow,
+		ForceSendFields: []string{"StartRow"},
 	}
 
 	if dims := strings.TrimSpace(c.Dimensions); dims != "" {

--- a/internal/cmd/searchconsole_query_start_row_test.go
+++ b/internal/cmd/searchconsole_query_start_row_test.go
@@ -57,12 +57,19 @@ func TestExecute_SearchConsoleQuery_StartRow_OmittedAndExplicit(t *testing.T) {
 			origNew := newSearchConsoleService
 			t.Cleanup(func() { newSearchConsoleService = origNew })
 
-			var got searchconsole.SearchAnalyticsQueryRequest
-			var sawBody bool
+			var gotStartRow int64
+			var sawBody, sawStartRow bool
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if strings.Contains(r.URL.Path, "searchAnalytics/query") && r.Method == http.MethodPost {
-					if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+					var body map[string]json.RawMessage
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 						t.Errorf("decode body: %v", err)
+					}
+					if raw, ok := body["startRow"]; ok {
+						sawStartRow = true
+						if err := json.Unmarshal(raw, &gotStartRow); err != nil {
+							t.Errorf("decode startRow: %v", err)
+						}
 					}
 					sawBody = true
 					w.Header().Set("Content-Type", "application/json")
@@ -115,8 +122,11 @@ func TestExecute_SearchConsoleQuery_StartRow_OmittedAndExplicit(t *testing.T) {
 			if !sawBody {
 				t.Fatal("expected Search Analytics query request body")
 			}
-			if got.StartRow != tc.wantStartRow {
-				t.Fatalf("startRow=%d, want %d", got.StartRow, tc.wantStartRow)
+			if !sawStartRow {
+				t.Fatal("expected request body to contain startRow")
+			}
+			if gotStartRow != tc.wantStartRow {
+				t.Fatalf("startRow=%d, want %d", gotStartRow, tc.wantStartRow)
 			}
 
 			var parsed struct {

--- a/internal/cmd/searchconsole_query_start_row_test.go
+++ b/internal/cmd/searchconsole_query_start_row_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -92,14 +93,15 @@ func TestExecute_SearchConsoleQuery_StartRow_OmittedAndExplicit(t *testing.T) {
 			}
 			newSearchConsoleService = func(context.Context, string) (*searchconsole.Service, error) { return svc, nil }
 
-			args := []string{
+			args := make([]string, 0, 13+len(tc.extraArgs))
+			args = append(args,
 				"--json", "--account", "a@b.com",
 				"search-console", "query",
 				"--site-url", "https://example.com/",
 				"--start-date", "2026-01-01",
 				"--end-date", "2026-01-31",
 				"--dimensions", "query",
-			}
+			)
 			args = append(args, tc.extraArgs...)
 
 			out := captureStdout(t, func() {
@@ -144,7 +146,7 @@ func TestExecute_SearchConsoleQuery_StartRow_NegativeFailsBeforeService(t *testi
 	newSearchConsoleService = func(context.Context, string) (*searchconsole.Service, error) {
 		serviceCalls++
 		t.Fatal("service must not be constructed for negative --start-row")
-		return nil, nil
+		return nil, errors.New("unexpected service construction")
 	}
 
 	err := Execute([]string{

--- a/internal/cmd/searchconsole_query_start_row_test.go
+++ b/internal/cmd/searchconsole_query_start_row_test.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/searchconsole/v1"
+)
+
+func TestExecute_SearchConsoleQuery_StartRow_HelpDocumentsFlag(t *testing.T) {
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"search-console", "query", "--help"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(out, "--start-row") {
+		t.Fatalf("expected help to document --start-row, got: %q", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "zero-based") {
+		t.Fatalf("expected help to mention zero-based start row meaning, got: %q", out)
+	}
+}
+
+func TestExecute_SearchConsoleQuery_StartRow_OmittedAndExplicit(t *testing.T) {
+	cases := []struct {
+		name         string
+		extraArgs    []string
+		wantStartRow int64
+	}{
+		{
+			name:         "omitted defaults to first window",
+			extraArgs:    nil,
+			wantStartRow: 0,
+		},
+		{
+			name:         "explicit zero",
+			extraArgs:    []string{"--start-row", "0"},
+			wantStartRow: 0,
+		},
+		{
+			name:         "positive offset",
+			extraArgs:    []string{"--start-row", "25"},
+			wantStartRow: 25,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			origNew := newSearchConsoleService
+			t.Cleanup(func() { newSearchConsoleService = origNew })
+
+			var got searchconsole.SearchAnalyticsQueryRequest
+			var sawBody bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, "searchAnalytics/query") && r.Method == http.MethodPost {
+					if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+						t.Errorf("decode body: %v", err)
+					}
+					sawBody = true
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"rows": []map[string]any{
+							{
+								"keys":        []string{"keyword"},
+								"clicks":      1.0,
+								"impressions": 10.0,
+								"ctr":         0.1,
+								"position":    2.0,
+							},
+						},
+					})
+					return
+				}
+				http.NotFound(w, r)
+			}))
+			t.Cleanup(srv.Close)
+
+			svc, err := searchconsole.NewService(context.Background(),
+				option.WithoutAuthentication(),
+				option.WithHTTPClient(srv.Client()),
+				option.WithEndpoint(srv.URL+"/"),
+			)
+			if err != nil {
+				t.Fatalf("NewService: %v", err)
+			}
+			newSearchConsoleService = func(context.Context, string) (*searchconsole.Service, error) { return svc, nil }
+
+			args := []string{
+				"--json", "--account", "a@b.com",
+				"search-console", "query",
+				"--site-url", "https://example.com/",
+				"--start-date", "2026-01-01",
+				"--end-date", "2026-01-31",
+				"--dimensions", "query",
+			}
+			args = append(args, tc.extraArgs...)
+
+			out := captureStdout(t, func() {
+				_ = captureStderr(t, func() {
+					if err := Execute(args); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+
+			if !sawBody {
+				t.Fatal("expected Search Analytics query request body")
+			}
+			if got.StartRow != tc.wantStartRow {
+				t.Fatalf("startRow=%d, want %d", got.StartRow, tc.wantStartRow)
+			}
+
+			var parsed struct {
+				Rows []struct {
+					Keys        []string `json:"keys"`
+					Clicks      float64  `json:"clicks"`
+					Impressions float64  `json:"impressions"`
+					Ctr         float64  `json:"ctr"`
+					Position    float64  `json:"position"`
+				} `json:"rows"`
+			}
+			if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+				t.Fatalf("json parse: %v\nout=%q", err, out)
+			}
+			if len(parsed.Rows) != 1 || parsed.Rows[0].Keys[0] != "keyword" {
+				t.Fatalf("unexpected JSON shape: %q", out)
+			}
+		})
+	}
+}
+
+func TestExecute_SearchConsoleQuery_StartRow_NegativeFailsBeforeService(t *testing.T) {
+	origNew := newSearchConsoleService
+	t.Cleanup(func() { newSearchConsoleService = origNew })
+
+	serviceCalls := 0
+	newSearchConsoleService = func(context.Context, string) (*searchconsole.Service, error) {
+		serviceCalls++
+		t.Fatal("service must not be constructed for negative --start-row")
+		return nil, nil
+	}
+
+	err := Execute([]string{
+		"--json", "--account", "a@b.com",
+		"search-console", "query",
+		"--site-url", "https://example.com/",
+		"--start-date", "2026-01-01",
+		"--end-date", "2026-01-31",
+		// Equals form avoids Kong treating a bare "-1" as another short flag.
+		"--start-row=-1",
+	})
+	if err == nil {
+		t.Fatal("expected error for negative --start-row")
+	}
+	if serviceCalls != 0 {
+		t.Fatalf("expected validation before service construction, got %d call(s)", serviceCalls)
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "start-row") {
+		t.Fatalf("expected error to mention start-row, got: %v", err)
+	}
+	if !strings.Contains(msg, ">=") && !strings.Contains(msg, "negative") && !strings.Contains(msg, "must be") {
+		t.Fatalf("expected non-negative validation message, got: %v", err)
+	}
+	code := ExitCode(err)
+	if code != 2 {
+		t.Fatalf("expected usage exit code 2, got %v", code)
+	}
+}
+
+func TestExecute_SearchConsoleQuery_StartRow_PlainShapeUnchanged(t *testing.T) {
+	origNew := newSearchConsoleService
+	t.Cleanup(func() { newSearchConsoleService = origNew })
+
+	var got searchconsole.SearchAnalyticsQueryRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "searchAnalytics/query") && r.Method == http.MethodPost {
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"rows": []map[string]any{
+					{
+						"keys":        []string{"keyword a", "keyword b"},
+						"clicks":      42.0,
+						"impressions": 1000.0,
+						"ctr":         0.042,
+						"position":    3.5,
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := searchconsole.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSearchConsoleService = func(context.Context, string) (*searchconsole.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain", "--account", "a@b.com",
+				"search-console", "query",
+				"--site-url", "https://example.com/",
+				"--start-date", "2026-01-01",
+				"--end-date", "2026-01-31",
+				"--start-row", "50",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if got.StartRow != 50 {
+		t.Fatalf("startRow=%d, want 50", got.StartRow)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected header + one data row, got %d lines: %q", len(lines), out)
+	}
+	if lines[0] != "KEYS\tCLICKS\tIMPRESSIONS\tCTR\tPOSITION" {
+		t.Fatalf("unexpected header: %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "keyword a, keyword b\t") {
+		t.Fatalf("unexpected data row: %q", lines[1])
+	}
+}

--- a/internal/cmd/searchconsole_query_start_row_test.go
+++ b/internal/cmd/searchconsole_query_start_row_test.go
@@ -54,12 +54,9 @@ func TestExecute_SearchConsoleQuery_StartRow_OmittedAndExplicit(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			origNew := newSearchConsoleService
-			t.Cleanup(func() { newSearchConsoleService = origNew })
-
 			var gotStartRow int64
 			var sawBody, sawStartRow bool
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			stubSearchConsoleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if strings.Contains(r.URL.Path, "searchAnalytics/query") && r.Method == http.MethodPost {
 					var body map[string]json.RawMessage
 					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -88,17 +85,6 @@ func TestExecute_SearchConsoleQuery_StartRow_OmittedAndExplicit(t *testing.T) {
 				}
 				http.NotFound(w, r)
 			}))
-			t.Cleanup(srv.Close)
-
-			svc, err := searchconsole.NewService(context.Background(),
-				option.WithoutAuthentication(),
-				option.WithHTTPClient(srv.Client()),
-				option.WithEndpoint(srv.URL+"/"),
-			)
-			if err != nil {
-				t.Fatalf("NewService: %v", err)
-			}
-			newSearchConsoleService = func(context.Context, string) (*searchconsole.Service, error) { return svc, nil }
 
 			args := make([]string, 0, 13+len(tc.extraArgs))
 			args = append(args,
@@ -188,11 +174,8 @@ func TestExecute_SearchConsoleQuery_StartRow_NegativeFailsBeforeService(t *testi
 }
 
 func TestExecute_SearchConsoleQuery_StartRow_PlainShapeUnchanged(t *testing.T) {
-	origNew := newSearchConsoleService
-	t.Cleanup(func() { newSearchConsoleService = origNew })
-
 	var got searchconsole.SearchAnalyticsQueryRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	stubSearchConsoleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "searchAnalytics/query") && r.Method == http.MethodPost {
 			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
 				t.Errorf("decode body: %v", err)
@@ -213,17 +196,6 @@ func TestExecute_SearchConsoleQuery_StartRow_PlainShapeUnchanged(t *testing.T) {
 		}
 		http.NotFound(w, r)
 	}))
-	t.Cleanup(srv.Close)
-
-	svc, err := searchconsole.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	newSearchConsoleService = func(context.Context, string) (*searchconsole.Service, error) { return svc, nil }
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
@@ -253,4 +225,23 @@ func TestExecute_SearchConsoleQuery_StartRow_PlainShapeUnchanged(t *testing.T) {
 	if !strings.HasPrefix(lines[1], "keyword a, keyword b\t") {
 		t.Fatalf("unexpected data row: %q", lines[1])
 	}
+}
+
+func stubSearchConsoleService(t *testing.T, handler http.Handler) {
+	t.Helper()
+	origNew := newSearchConsoleService
+	t.Cleanup(func() { newSearchConsoleService = origNew })
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	svc, err := searchconsole.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSearchConsoleService = func(context.Context, string) (*searchconsole.Service, error) { return svc, nil }
 }

--- a/skills/pack/google-search-console/SKILL.md
+++ b/skills/pack/google-search-console/SKILL.md
@@ -23,7 +23,7 @@ GOG_KEYRING_PASSWORD=cli-tools gog --json --no-input --account jeremy@robbenmedi
 | Command | Description | Key Flags |
 |---------|-------------|-----------|
 | `sites` | List verified sites | |
-| `query` | Query search analytics data | `--site-url`, `--start-date`, `--end-date`, `--dimensions`, `--row-limit` |
+| `query` | Query search analytics data | `--site-url`, `--start-date`, `--end-date`, `--dimensions`, `--row-limit`, `--start-row` |
 | `sitemaps` | List sitemaps for a site | `--site-url` |
 | `submit-sitemap` | Submit a sitemap | `--site-url`, `--sitemap-url` |
 | `inspect` | Inspect URL indexing status | `--site-url`, `--url` |


### PR DESCRIPTION
## Summary
- add a documented zero-based `--start-row` option to `search-console query`
- reject negative offsets before Search Console service construction
- serialize omitted, explicit-zero, and positive offsets unchanged through the Google Search Console SDK
- preserve existing JSON/TSV query output and Search Console mutation receipts

## Testing
- `/tmp/gogcli-go-sdk/go/bin/go test ./internal/cmd -run 'TestExecute_SearchConsole(Query_StartRow|MutationReceipt)' -count=1`
- `env PATH=/tmp/gogcli-go-sdk/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make ci`
- independent repository-standards/Fowler review: no findings
- independent exact-spec review: no findings

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)
