### PR TITLE
fix(cli): skip update checks for shell completion

### DIFF
--- a/internal/cmd/execute_update_notify_test.go
+++ b/internal/cmd/execute_update_notify_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/gogcli/internal/selfupdate"
+)
+
+func TestExecute_SkipsUpdateNotifyForCompletionCommands(t *testing.T) {
+	// Serial: overrides package-level maybeNotifyUpdate seam.
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "completion bash", args: []string{"completion", "bash"}},
+		{name: "completion zsh", args: []string{"completion", "zsh"}},
+		{name: "completion fish", args: []string{"completion", "fish"}},
+		{name: "completion powershell", args: []string{"completion", "powershell"}},
+		{name: "__complete", args: []string{"__complete", "--cword", "1", "--", "gog", ""}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			orig := maybeNotifyUpdate
+			maybeNotifyUpdate = func(context.Context, *selfupdate.Client, string, time.Duration) string {
+				calls++
+				return "gog: update available 1.0.0 → 9.9.9; run: gog update"
+			}
+			t.Cleanup(func() { maybeNotifyUpdate = orig })
+
+			errText := captureStderr(t, func() {
+				_ = captureStdout(t, func() {
+					if err := Execute(tc.args); err != nil {
+						t.Fatalf("Execute(%v): %v", tc.args, err)
+					}
+				})
+			})
+			if calls != 0 {
+				t.Fatalf("update notifier calls = %d, want 0 for %v", calls, tc.args)
+			}
+			if strings.Contains(errText, "update available") {
+				t.Fatalf("stderr should not contain update notice, got %q", errText)
+			}
+		})
+	}
+}
+
+func TestExecute_InvokesUpdateNotifyForNormalCommand(t *testing.T) {
+	calls := 0
+	orig := maybeNotifyUpdate
+	maybeNotifyUpdate = func(context.Context, *selfupdate.Client, string, time.Duration) string {
+		calls++
+		return ""
+	}
+	t.Cleanup(func() { maybeNotifyUpdate = orig })
+
+	_ = captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := Execute([]string{"version"}); err != nil {
+				t.Fatalf("Execute(version): %v", err)
+			}
+		})
+	})
+	if calls != 1 {
+		t.Fatalf("update notifier calls = %d, want 1 for normal command", calls)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -30,6 +30,10 @@ const (
 
 var rootHelpDescription = helpDescription
 
+// maybeNotifyUpdate is the background update-check seam used by Execute.
+// Tests override it to assert which command paths invoke the notifier.
+var maybeNotifyUpdate = selfupdate.MaybeNotify
+
 type RootFlags struct {
 	Color          string `help:"Color output: auto|always|never" default:"${color}"`
 	Account        string `help:"Account email for API commands (gmail/calendar/chat/classroom/drive/docs/slides/contacts/tasks/people/sheets)"`
@@ -159,11 +163,15 @@ func Execute(args []string) (err error) {
 	kctx.Bind(&cli.RootFlags)
 
 	// Throttled non-fatal update notice for humans and agents (stderr only).
-	if notice := selfupdate.MaybeNotify(ctx, &selfupdate.Client{
-		Repo:  strings.TrimSpace(os.Getenv("GOG_UPDATE_REPO")),
-		Token: envOr("GITHUB_TOKEN", envOr("GH_TOKEN", "")),
-	}, version, 0); notice != "" {
-		_, _ = fmt.Fprintln(os.Stderr, notice)
+	// Shell completion must stay fast/deterministic: never touch update cache
+	// or the release service for completion-script generation or __complete.
+	if !isCompletionCommand(kctx.Command()) {
+		if notice := maybeNotifyUpdate(ctx, &selfupdate.Client{
+			Repo:  strings.TrimSpace(os.Getenv("GOG_UPDATE_REPO")),
+			Token: envOr("GITHUB_TOKEN", envOr("GH_TOKEN", "")),
+		}, version, 0); notice != "" {
+			_, _ = fmt.Fprintln(os.Stderr, notice)
+		}
 	}
 
 	err = kctx.Run()
@@ -195,6 +203,21 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// isCompletionCommand reports whether the parsed kong command is shell-completion
+// related and must bypass background update checks.
+func isCompletionCommand(command string) bool {
+	parts := strings.Fields(command)
+	if len(parts) == 0 {
+		return false
+	}
+	switch parts[0] {
+	case "completion", "__complete":
+		return true
+	default:
+		return false
+	}
 }
 
 func boolString(v bool) string {


### PR DESCRIPTION
## Summary
- bypass the self-update notifier for completion script generation
- bypass the notifier for the hidden `__complete` transport
- retain existing notifier behavior for normal commands

## Testing
- `/home/jeremy-johnson/.local/go/bin/go test ./internal/cmd -run TestExecute_ -count=1`
- `make ci PATH=/home/jeremy-johnson/.local/go/bin:/usr/local/bin:/usr/bin:/bin`

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)