### PR TITLE
fix(calendar): surface per-calendar free/busy errors

### DIFF
--- a/internal/cmd/calendar_conflicts.go
+++ b/internal/cmd/calendar_conflicts.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -19,6 +20,12 @@ type conflict struct {
 	Start     string   `json:"start"`
 	End       string   `json:"end"`
 	Calendars []string `json:"calendars"`
+}
+
+type freeBusySourceError struct {
+	Calendar string `json:"calendar"`
+	Domain   string `json:"domain,omitempty"`
+	Reason   string `json:"reason,omitempty"`
 }
 
 type CalendarConflictsCmd struct {
@@ -77,13 +84,46 @@ func (c *CalendarConflictsCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return err
 	}
 
+	sourceErrors := collectFreeBusySourceErrors(resp.Calendars)
 	conflicts := detectConflicts(resp.Calendars)
+	incomplete := len(sourceErrors) > 0
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
-			"conflicts": conflicts,
-			"count":     len(conflicts),
-		})
+		payload := map[string]any{
+			"conflicts":  conflicts,
+			"count":      len(conflicts),
+			"incomplete": incomplete,
+		}
+		if incomplete {
+			payload["errors"] = sourceErrors
+		}
+		if err := outfmt.WriteJSON(os.Stdout, payload); err != nil {
+			return err
+		}
+		if incomplete {
+			return &ExitError{Code: 1, Err: errors.New("incomplete free/busy data: one or more calendars failed")}
+		}
+		return nil
+	}
+
+	if incomplete {
+		fmt.Printf("INCOMPLETE: source calendar errors\n")
+		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "CALENDAR\tERROR_DOMAIN\tERROR_REASON")
+		for _, se := range sourceErrors {
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", se.Calendar, se.Domain, se.Reason)
+		}
+		_ = tw.Flush()
+		if len(conflicts) > 0 {
+			fmt.Printf("\nCONFLICTS FOUND: %d\n\n", len(conflicts))
+			tw = tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(tw, "START\tEND\tCALENDARS")
+			for _, c := range conflicts {
+				fmt.Fprintf(tw, "%s\t%s\t%s\n", c.Start, c.End, strings.Join(c.Calendars, ", "))
+			}
+			_ = tw.Flush()
+		}
+		return &ExitError{Code: 1, Err: errors.New("incomplete free/busy data: one or more calendars failed")}
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -107,6 +147,33 @@ func (c *CalendarConflictsCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 	_ = tw.Flush()
 	return nil
+}
+
+func collectFreeBusySourceErrors(calendars map[string]calendar.FreeBusyCalendar) []freeBusySourceError {
+	if len(calendars) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(calendars))
+	for id := range calendars {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	var out []freeBusySourceError
+	for _, id := range ids {
+		cal := calendars[id]
+		for _, e := range cal.Errors {
+			if e == nil {
+				continue
+			}
+			out = append(out, freeBusySourceError{
+				Calendar: id,
+				Domain:   e.Domain,
+				Reason:   e.Reason,
+			})
+		}
+	}
+	return out
 }
 
 // detectConflicts finds overlapping busy periods across calendars

--- a/internal/cmd/calendar_conflicts.go
+++ b/internal/cmd/calendar_conflicts.go
@@ -106,32 +106,46 @@ func (c *CalendarConflictsCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return nil
 	}
 
+	if outfmt.IsPlain(ctx) {
+		if incomplete {
+			writeTableRow(ctx, os.Stdout, []string{"STATUS", "CALENDAR", "ERROR_DOMAIN", "ERROR_REASON"})
+			for _, sourceErr := range sourceErrors {
+				writeTableRow(ctx, os.Stdout, []string{"incomplete", sourceErr.Calendar, sourceErr.Domain, sourceErr.Reason})
+			}
+			if len(conflicts) > 0 {
+				writeTableRow(ctx, os.Stdout, []string{"START", "END", "CALENDARS"})
+				for _, conflict := range conflicts {
+					writeTableRow(ctx, os.Stdout, []string{conflict.Start, conflict.End, strings.Join(conflict.Calendars, ", ")})
+				}
+			}
+			return &ExitError{Code: 1, Err: errors.New("incomplete free/busy data: one or more calendars failed")}
+		}
+
+		writeTableRow(ctx, os.Stdout, []string{"START", "END", "CALENDARS"})
+		for _, conflict := range conflicts {
+			writeTableRow(ctx, os.Stdout, []string{conflict.Start, conflict.End, strings.Join(conflict.Calendars, ", ")})
+		}
+		return nil
+	}
+
 	if incomplete {
 		fmt.Printf("INCOMPLETE: source calendar errors\n")
 		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 		fmt.Fprintln(tw, "CALENDAR\tERROR_DOMAIN\tERROR_REASON")
-		for _, se := range sourceErrors {
-			fmt.Fprintf(tw, "%s\t%s\t%s\n", se.Calendar, se.Domain, se.Reason)
+		for _, sourceErr := range sourceErrors {
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", sourceErr.Calendar, sourceErr.Domain, sourceErr.Reason)
 		}
 		_ = tw.Flush()
 		if len(conflicts) > 0 {
 			fmt.Printf("\nCONFLICTS FOUND: %d\n\n", len(conflicts))
 			tw = tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 			fmt.Fprintln(tw, "START\tEND\tCALENDARS")
-			for _, c := range conflicts {
-				fmt.Fprintf(tw, "%s\t%s\t%s\n", c.Start, c.End, strings.Join(c.Calendars, ", "))
+			for _, conflict := range conflicts {
+				fmt.Fprintf(tw, "%s\t%s\t%s\n", conflict.Start, conflict.End, strings.Join(conflict.Calendars, ", "))
 			}
 			_ = tw.Flush()
 		}
 		return &ExitError{Code: 1, Err: errors.New("incomplete free/busy data: one or more calendars failed")}
-	}
-
-	if outfmt.IsPlain(ctx) {
-		writeTableRow(ctx, os.Stdout, []string{"START", "END", "CALENDARS"})
-		for _, c := range conflicts {
-			writeTableRow(ctx, os.Stdout, []string{c.Start, c.End, strings.Join(c.Calendars, ", ")})
-		}
-		return nil
 	}
 
 	if len(conflicts) == 0 {

--- a/internal/cmd/calendar_conflicts.go
+++ b/internal/cmd/calendar_conflicts.go
@@ -108,15 +108,12 @@ func (c *CalendarConflictsCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 	if outfmt.IsPlain(ctx) {
 		if incomplete {
-			writeTableRow(ctx, os.Stdout, []string{"STATUS", "CALENDAR", "ERROR_DOMAIN", "ERROR_REASON"})
+			writeTableRow(ctx, os.Stdout, []string{"TYPE", "STATUS", "CALENDAR", "ERROR_DOMAIN", "ERROR_REASON", "START", "END", "CALENDARS"})
 			for _, sourceErr := range sourceErrors {
-				writeTableRow(ctx, os.Stdout, []string{"incomplete", sourceErr.Calendar, sourceErr.Domain, sourceErr.Reason})
+				writeTableRow(ctx, os.Stdout, []string{"error", "incomplete", sourceErr.Calendar, sourceErr.Domain, sourceErr.Reason, "", "", ""})
 			}
-			if len(conflicts) > 0 {
-				writeTableRow(ctx, os.Stdout, []string{"START", "END", "CALENDARS"})
-				for _, conflict := range conflicts {
-					writeTableRow(ctx, os.Stdout, []string{conflict.Start, conflict.End, strings.Join(conflict.Calendars, ", ")})
-				}
+			for _, conflict := range conflicts {
+				writeTableRow(ctx, os.Stdout, []string{"conflict", "incomplete", "", "", "", conflict.Start, conflict.End, strings.Join(conflict.Calendars, ", ")})
 			}
 			return &ExitError{Code: 1, Err: errors.New("incomplete free/busy data: one or more calendars failed")}
 		}

--- a/internal/cmd/calendar_freebusy.go
+++ b/internal/cmd/calendar_freebusy.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"google.golang.org/api/calendar/v3"
@@ -63,16 +63,23 @@ func (c *CalendarFreeBusyCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	fmt.Fprintln(w, "CALENDAR\tSTATUS\tSTART\tEND\tERROR_DOMAIN\tERROR_REASON")
-	for id, data := range resp.Calendars {
+	writeTableRow(ctx, w, []string{"CALENDAR", "STATUS", "START", "END", "ERROR_DOMAIN", "ERROR_REASON"})
+
+	ids := make([]string, 0, len(resp.Calendars))
+	for id := range resp.Calendars {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		data := resp.Calendars[id]
 		for _, b := range data.Busy {
-			fmt.Fprintf(w, "%s\tbusy\t%s\t%s\t\t\n", id, b.Start, b.End)
+			writeTableRow(ctx, w, []string{id, "busy", b.Start, b.End, "", ""})
 		}
 		for _, e := range data.Errors {
 			if e == nil {
 				continue
 			}
-			fmt.Fprintf(w, "%s\terror\t\t\t%s\t%s\n", id, e.Domain, e.Reason)
+			writeTableRow(ctx, w, []string{id, "error", "", "", e.Domain, e.Reason})
 		}
 	}
 	return nil

--- a/internal/cmd/calendar_freebusy.go
+++ b/internal/cmd/calendar_freebusy.go
@@ -63,10 +63,16 @@ func (c *CalendarFreeBusyCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	fmt.Fprintln(w, "CALENDAR\tSTART\tEND")
+	fmt.Fprintln(w, "CALENDAR\tSTATUS\tSTART\tEND\tERROR_DOMAIN\tERROR_REASON")
 	for id, data := range resp.Calendars {
 		for _, b := range data.Busy {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", id, b.Start, b.End)
+			fmt.Fprintf(w, "%s\tbusy\t%s\t%s\t\t\n", id, b.Start, b.End)
+		}
+		for _, e := range data.Errors {
+			if e == nil {
+				continue
+			}
+			fmt.Fprintf(w, "%s\terror\t\t\t%s\t%s\n", id, e.Domain, e.Reason)
 		}
 	}
 	return nil

--- a/internal/cmd/calendar_freebusy_errors_test.go
+++ b/internal/cmd/calendar_freebusy_errors_test.go
@@ -250,13 +250,73 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 	if plainErr == nil || ExitCode(plainErr) == 0 {
 		t.Fatalf("plain execution error = %v, want nonzero incomplete result", plainErr)
 	}
-	wantPlain := "STATUS\tCALENDAR\tERROR_DOMAIN\tERROR_REASON\n" +
-		"incomplete\tbad@example.com\tglobal\tnotFound\n"
+	wantPlain := "TYPE\tSTATUS\tCALENDAR\tERROR_DOMAIN\tERROR_REASON\tSTART\tEND\tCALENDARS\n" +
+		"error\tincomplete\tbad@example.com\tglobal\tnotFound\t\t\t\n"
 	if plainOut != wantPlain {
 		t.Fatalf("plain output = %q, want %q", plainOut, wantPlain)
 	}
 	if strings.Contains(plainOut, "INCOMPLETE:") || strings.Contains(plainOut, "No conflicts found") {
 		t.Fatalf("plain output leaked human prose: %q", plainOut)
+	}
+}
+
+func TestCalendarConflicts_SourceErrors_PlainUsesOneSchemaWithConflicts(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/freeBusy") && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"calendars": map[string]any{
+					"primary": map[string]any{
+						"busy": []map[string]any{{"start": "2024-12-13T10:00:00Z", "end": "2024-12-13T12:00:00Z"}},
+					},
+					"team@example.com": map[string]any{
+						"busy": []map[string]any{{"start": "2024-12-13T11:00:00Z", "end": "2024-12-13T13:00:00Z"}},
+					},
+					"bad@example.com": map[string]any{
+						"errors": []map[string]any{{"domain": "global", "reason": "notFound"}},
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	})))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	var execErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			execErr = Execute([]string{
+				"--plain",
+				"--account", "a@b.com",
+				"calendar", "conflicts",
+				"--from", "2024-12-13T09:00:00Z",
+				"--to", "2024-12-13T14:00:00Z",
+				"--calendars", "primary,team@example.com,bad@example.com",
+			})
+		})
+	})
+	if execErr == nil || ExitCode(execErr) == 0 {
+		t.Fatalf("execution error = %v, want nonzero incomplete result", execErr)
+	}
+	want := "TYPE\tSTATUS\tCALENDAR\tERROR_DOMAIN\tERROR_REASON\tSTART\tEND\tCALENDARS\n" +
+		"error\tincomplete\tbad@example.com\tglobal\tnotFound\t\t\t\n" +
+		"conflict\tincomplete\t\t\t\t2024-12-13T11:00:00Z\t2024-12-13T12:00:00Z\tprimary, team@example.com\n"
+	if out != want {
+		t.Fatalf("plain output = %q, want one stable schema %q", out, want)
 	}
 }
 

--- a/internal/cmd/calendar_freebusy_errors_test.go
+++ b/internal/cmd/calendar_freebusy_errors_test.go
@@ -65,20 +65,18 @@ func TestCalendarFreeBusy_TextEmitsBusyAndErrorRows(t *testing.T) {
 	})
 
 	lines := nonEmptyLines(out)
-	if len(lines) < 3 {
-		t.Fatalf("expected header + at least 2 data rows, got %q", out)
+	wantLines := []string{
+		"CALENDAR\tSTATUS\tSTART\tEND\tERROR_DOMAIN\tERROR_REASON",
+		"bad@example.com\terror\t\t\tglobal\tnotFound",
+		"ok@example.com\tbusy\t2025-12-17T10:00:00Z\t2025-12-17T11:00:00Z\t\t",
 	}
-	if lines[0] != "CALENDAR\tSTATUS\tSTART\tEND\tERROR_DOMAIN\tERROR_REASON" {
-		t.Fatalf("unexpected header: %q", lines[0])
+	if len(lines) != len(wantLines) {
+		t.Fatalf("plain rows = %q, want %q", lines, wantLines)
 	}
-
-	wantBusy := "ok@example.com\tbusy\t2025-12-17T10:00:00Z\t2025-12-17T11:00:00Z\t\t"
-	wantError := "bad@example.com\terror\t\t\tglobal\tnotFound"
-	if !containsLine(lines, wantBusy) {
-		t.Fatalf("missing busy row %q in output %q", wantBusy, out)
-	}
-	if !containsLine(lines, wantError) {
-		t.Fatalf("missing error row %q in output %q", wantError, out)
+	for i := range wantLines {
+		if lines[i] != wantLines[i] {
+			t.Fatalf("plain row %d = %q, want %q", i, lines[i], wantLines[i])
+		}
 	}
 }
 
@@ -235,6 +233,31 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 	if parsed.Errors[0].Domain != "global" || parsed.Errors[0].Reason != "notFound" {
 		t.Fatalf("unexpected error fields: %+v", parsed.Errors[0])
 	}
+
+	var plainErr error
+	plainOut := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			plainErr = Execute([]string{
+				"--plain",
+				"--account", "a@b.com",
+				"calendar", "conflicts",
+				"--from", "2024-12-13T09:00:00Z",
+				"--to", "2024-12-13T14:00:00Z",
+				"--calendars", "primary,bad@example.com",
+			})
+		})
+	})
+	if plainErr == nil || ExitCode(plainErr) == 0 {
+		t.Fatalf("plain execution error = %v, want nonzero incomplete result", plainErr)
+	}
+	wantPlain := "STATUS\tCALENDAR\tERROR_DOMAIN\tERROR_REASON\n" +
+		"incomplete\tbad@example.com\tglobal\tnotFound\n"
+	if plainOut != wantPlain {
+		t.Fatalf("plain output = %q, want %q", plainOut, wantPlain)
+	}
+	if strings.Contains(plainOut, "INCOMPLETE:") || strings.Contains(plainOut, "No conflicts found") {
+		t.Fatalf("plain output leaked human prose: %q", plainOut)
+	}
 }
 
 func TestCalendarConflicts_SourceErrors_SuppressCleanNoConflictMessage(t *testing.T) {
@@ -311,13 +334,4 @@ func nonEmptyLines(s string) []string {
 		out = append(out, line)
 	}
 	return out
-}
-
-func containsLine(lines []string, want string) bool {
-	for _, line := range lines {
-		if line == want {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/cmd/calendar_freebusy_errors_test.go
+++ b/internal/cmd/calendar_freebusy_errors_test.go
@@ -1,0 +1,323 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/option"
+)
+
+func TestCalendarFreeBusy_TextEmitsBusyAndErrorRows(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(strings.Contains(r.URL.Path, "/freeBusy") && r.Method == http.MethodPost) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"calendars": map[string]any{
+				"ok@example.com": map[string]any{
+					"busy": []map[string]any{
+						{"start": "2025-12-17T10:00:00Z", "end": "2025-12-17T11:00:00Z"},
+					},
+				},
+				"bad@example.com": map[string]any{
+					"errors": []map[string]any{
+						{"domain": "global", "reason": "notFound"},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--plain",
+				"--account", "a@b.com",
+				"calendar", "freebusy",
+				"ok@example.com,bad@example.com",
+				"--from", "2025-12-17T00:00:00Z",
+				"--to", "2025-12-18T00:00:00Z",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	lines := nonEmptyLines(out)
+	if len(lines) < 3 {
+		t.Fatalf("expected header + at least 2 data rows, got %q", out)
+	}
+	if lines[0] != "CALENDAR\tSTATUS\tSTART\tEND\tERROR_DOMAIN\tERROR_REASON" {
+		t.Fatalf("unexpected header: %q", lines[0])
+	}
+
+	wantBusy := "ok@example.com\tbusy\t2025-12-17T10:00:00Z\t2025-12-17T11:00:00Z\t\t"
+	wantError := "bad@example.com\terror\t\t\tglobal\tnotFound"
+	if !containsLine(lines, wantBusy) {
+		t.Fatalf("missing busy row %q in output %q", wantBusy, out)
+	}
+	if !containsLine(lines, wantError) {
+		t.Fatalf("missing error row %q in output %q", wantError, out)
+	}
+}
+
+func TestCalendarFreeBusy_JSONRetainsPerCalendarErrors(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(strings.Contains(r.URL.Path, "/freeBusy") && r.Method == http.MethodPost) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"calendars": map[string]any{
+				"bad@example.com": map[string]any{
+					"errors": []map[string]any{
+						{"domain": "calendar", "reason": "notFound"},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"calendar", "freebusy",
+				"bad@example.com",
+				"--from", "2025-12-17T00:00:00Z",
+				"--to", "2025-12-18T00:00:00Z",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Calendars map[string]struct {
+			Errors []struct {
+				Domain string `json:"domain"`
+				Reason string `json:"reason"`
+			} `json:"errors"`
+		} `json:"calendars"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	cal, ok := parsed.Calendars["bad@example.com"]
+	if !ok {
+		t.Fatalf("missing calendar in JSON: %q", out)
+	}
+	if len(cal.Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d (%q)", len(cal.Errors), out)
+	}
+	if cal.Errors[0].Domain != "calendar" || cal.Errors[0].Reason != "notFound" {
+		t.Fatalf("unexpected error payload: %+v", cal.Errors[0])
+	}
+}
+
+func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/freeBusy") && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"calendars": map[string]any{
+					"primary": map[string]any{
+						"busy": []map[string]any{},
+					},
+					"bad@example.com": map[string]any{
+						"errors": []map[string]any{
+							{"domain": "global", "reason": "notFound"},
+						},
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	})))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	var execErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			execErr = Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"calendar", "conflicts",
+				"--from", "2024-12-13T09:00:00Z",
+				"--to", "2024-12-13T14:00:00Z",
+				"--calendars", "primary,bad@example.com",
+			})
+		})
+	})
+	if execErr == nil {
+		t.Fatal("expected nonzero exit for source calendar errors")
+	}
+	if ExitCode(execErr) == 0 {
+		t.Fatalf("expected nonzero exit code, got 0 (%v)", execErr)
+	}
+
+	var parsed struct {
+		Conflicts  []map[string]any `json:"conflicts"`
+		Count      int              `json:"count"`
+		Incomplete bool             `json:"incomplete"`
+		Errors     []struct {
+			Calendar string `json:"calendar"`
+			Domain   string `json:"domain"`
+			Reason   string `json:"reason"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if !parsed.Incomplete {
+		t.Fatalf("expected incomplete=true, out=%q", out)
+	}
+	if parsed.Count != 0 || len(parsed.Conflicts) != 0 {
+		t.Fatalf("expected no conflicts, got count=%d conflicts=%v", parsed.Count, parsed.Conflicts)
+	}
+	if len(parsed.Errors) != 1 {
+		t.Fatalf("expected 1 source error, got %+v (out=%q)", parsed.Errors, out)
+	}
+	if parsed.Errors[0].Calendar != "bad@example.com" {
+		t.Fatalf("unexpected calendar: %+v", parsed.Errors[0])
+	}
+	if parsed.Errors[0].Domain != "global" || parsed.Errors[0].Reason != "notFound" {
+		t.Fatalf("unexpected error fields: %+v", parsed.Errors[0])
+	}
+}
+
+func TestCalendarConflicts_SourceErrors_SuppressCleanNoConflictMessage(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/freeBusy") && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"calendars": map[string]any{
+					"primary": map[string]any{
+						"busy": []map[string]any{},
+					},
+					"bad@example.com": map[string]any{
+						"errors": []map[string]any{
+							{"domain": "global", "reason": "notFound"},
+						},
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	})))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	var execErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			execErr = Execute([]string{
+				"--account", "a@b.com",
+				"calendar", "conflicts",
+				"--from", "2024-12-13T09:00:00Z",
+				"--to", "2024-12-13T14:00:00Z",
+				"--calendars", "primary,bad@example.com",
+			})
+		})
+	})
+	if execErr == nil {
+		t.Fatal("expected nonzero exit for source calendar errors")
+	}
+	if strings.Contains(out, "No conflicts found") {
+		t.Fatalf("must not report clean no-conflict result when a calendar failed: %q", out)
+	}
+	if !strings.Contains(out, "bad@example.com") {
+		t.Fatalf("expected failed calendar in output: %q", out)
+	}
+	if !strings.Contains(out, "notFound") {
+		t.Fatalf("expected error reason in output: %q", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "incomplete") {
+		t.Fatalf("expected incomplete status in output: %q", out)
+	}
+}
+
+func nonEmptyLines(s string) []string {
+	raw := strings.Split(s, "\n")
+	out := make([]string, 0, len(raw))
+	for _, line := range raw {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func containsLine(lines []string, want string) bool {
+	for _, line := range lines {
+		if line == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- expose embedded per-calendar errors in free/busy plain and JSON output
- mark conflict results incomplete and return nonzero when any calendar fails
- keep incomplete plain conflict output on one stable TSV schema, including detected conflicts

## Testing
- /home/jeremy-johnson/.local/go/bin/go test ./internal/cmd -run TestCalendar -count=1
- env PATH=/home/jeremy-johnson/.local/go/bin:/usr/local/bin:/usr/bin:/bin make ci

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)