### PR TITLE
fix(gmail): prevent watch state path collisions

### DIFF
--- a/internal/cmd/execute_gmail_watch_more_test.go
+++ b/internal/cmd/execute_gmail_watch_more_test.go
@@ -90,6 +90,15 @@ func TestExecute_GmailWatch_MoreCommands(t *testing.T) {
 			t.Fatalf("expected second watch call, got %d", watchCalls)
 		}
 
+		statePath, pathErr := gmailWatchStatePath("a@b.com")
+		if pathErr != nil {
+			t.Fatalf("state path: %v", pathErr)
+		}
+		legacyPath := filepath.Join(filepath.Dir(statePath), legacySanitizeAccountForPath("a@b.com")+".json")
+		if writeErr := os.WriteFile(legacyPath, []byte("{\"account\":\"a@b.com\"}\n"), 0o600); writeErr != nil {
+			t.Fatalf("write legacy state: %v", writeErr)
+		}
+
 		// Serve validations (should error before ListenAndServe).
 		if execErr := Execute([]string{"gmail", "watch", "serve", "--path", "nope"}); execErr == nil || !strings.Contains(execErr.Error(), "--path must start") {
 			t.Fatalf("expected path validation error, got: %v", execErr)
@@ -118,6 +127,10 @@ func TestExecute_GmailWatch_MoreCommands(t *testing.T) {
 	}
 	if _, err := os.Stat(p); err == nil {
 		t.Fatalf("expected watch state removed: %s", p)
+	}
+	legacyPath := filepath.Join(filepath.Dir(p), legacySanitizeAccountForPath("a@b.com")+".json")
+	if _, err := os.Stat(legacyPath); err == nil {
+		t.Fatalf("expected legacy watch state removed: %s", legacyPath)
 	}
 
 	// Ensure dir exists but file doesn't.

--- a/internal/cmd/execute_gmail_watch_more_test.go
+++ b/internal/cmd/execute_gmail_watch_more_test.go
@@ -14,6 +14,63 @@ import (
 	"google.golang.org/api/option"
 )
 
+func TestExecute_GmailWatchStop_PreservesUnownedLegacyState(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	for _, tc := range []struct {
+		name    string
+		payload []byte
+	}{
+		{name: "different account", payload: []byte("{\"account\":\"user_sales@example.com\"}\n")},
+		{name: "unparsable", payload: []byte("not json\n")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CONFIG_HOME", home)
+			t.Setenv("GOG_ACCOUNT", "user+sales@example.com")
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, "/gmail/v1/users/me/stop") && r.Method == http.MethodPost {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+				http.NotFound(w, r)
+			}))
+			defer srv.Close()
+
+			svc, err := gmail.NewService(context.Background(),
+				option.WithoutAuthentication(),
+				option.WithHTTPClient(srv.Client()),
+				option.WithEndpoint(srv.URL+"/"),
+			)
+			if err != nil {
+				t.Fatalf("NewService: %v", err)
+			}
+			newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+			statePath, err := gmailWatchStatePath("user+sales@example.com")
+			if err != nil {
+				t.Fatalf("state path: %v", err)
+			}
+			legacyPath := filepath.Join(filepath.Dir(statePath), legacySanitizeAccountForPath("user+sales@example.com")+".json")
+			if err := os.WriteFile(legacyPath, tc.payload, 0o600); err != nil {
+				t.Fatalf("write legacy state: %v", err)
+			}
+
+			_ = captureStdout(t, func() {
+				if err := Execute([]string{"--json", "--force", "gmail", "watch", "stop"}); err != nil {
+					t.Fatalf("stop: %v", err)
+				}
+			})
+			if got, err := os.ReadFile(legacyPath); err != nil || string(got) != string(tc.payload) {
+				t.Fatalf("unowned legacy state changed: data=%q err=%v", got, err)
+			}
+		})
+	}
+}
+
 func TestExecute_GmailWatch_MoreCommands(t *testing.T) {
 	origNew := newGmailService
 	t.Cleanup(func() { newGmailService = origNew })

--- a/internal/cmd/execute_gmail_watch_more_test.go
+++ b/internal/cmd/execute_gmail_watch_more_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -124,11 +125,23 @@ func TestExecute_GmailWatch_MoreCommands(t *testing.T) {
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
 	_ = captureStderr(t, func() {
+		statePath, pathErr := gmailWatchStatePath("a@b.com")
+		if pathErr != nil {
+			t.Fatalf("state path: %v", pathErr)
+		}
+		legacyPath := filepath.Join(filepath.Dir(statePath), legacySanitizeAccountForPath("a@b.com")+".json")
+		if writeErr := os.WriteFile(legacyPath, []byte("{\"account\":\"a@b.com\"}\n"), 0o600); writeErr != nil {
+			t.Fatalf("write legacy state: %v", writeErr)
+		}
+
 		_ = captureStdout(t, func() {
 			if execErr := Execute([]string{"--json", "gmail", "watch", "start", "--topic", "projects/p/topics/t", "--label", "INBOX"}); execErr != nil {
 				t.Fatalf("start: %v", execErr)
 			}
 		})
+		if _, statErr := os.Stat(legacyPath); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("legacy state still exists after start: %v", statErr)
+		}
 		if watchCalls != 1 {
 			t.Fatalf("expected watch call, got %d", watchCalls)
 		}
@@ -147,11 +160,11 @@ func TestExecute_GmailWatch_MoreCommands(t *testing.T) {
 			t.Fatalf("expected second watch call, got %d", watchCalls)
 		}
 
-		statePath, pathErr := gmailWatchStatePath("a@b.com")
+		statePath, pathErr = gmailWatchStatePath("a@b.com")
 		if pathErr != nil {
 			t.Fatalf("state path: %v", pathErr)
 		}
-		legacyPath := filepath.Join(filepath.Dir(statePath), legacySanitizeAccountForPath("a@b.com")+".json")
+		legacyPath = filepath.Join(filepath.Dir(statePath), legacySanitizeAccountForPath("a@b.com")+".json")
 		if writeErr := os.WriteFile(legacyPath, []byte("{\"account\":\"a@b.com\"}\n"), 0o600); writeErr != nil {
 			t.Fatalf("write legacy state: %v", writeErr)
 		}

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -92,6 +92,7 @@ func (c *GmailWatchStartCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 	}); err != nil {
 		return err
 	}
+	removeMatchingLegacyGmailWatchState(account, store.path)
 
 	return writeWatchState(ctx, state)
 }

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -182,6 +183,10 @@ func (c *GmailWatchStopCmd) Run(ctx context.Context, flags *RootFlags) error {
 	store, err := newGmailWatchStore(account)
 	if err == nil && store.path != "" {
 		_ = os.Remove(store.path)
+		legacyPath := filepath.Join(filepath.Dir(store.path), legacySanitizeAccountForPath(account)+".json")
+		if legacyPath != store.path {
+			_ = os.Remove(legacyPath)
+		}
 	}
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"stopped": true})

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -183,10 +182,7 @@ func (c *GmailWatchStopCmd) Run(ctx context.Context, flags *RootFlags) error {
 	store, err := newGmailWatchStore(account)
 	if err == nil && store.path != "" {
 		_ = os.Remove(store.path)
-		legacyPath := filepath.Join(filepath.Dir(store.path), legacySanitizeAccountForPath(account)+".json")
-		if legacyPath != store.path {
-			_ = os.Remove(legacyPath)
-		}
+		removeMatchingLegacyGmailWatchState(account, store.path)
 	}
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"stopped": true})

--- a/internal/cmd/gmail_watch_helpers_test.go
+++ b/internal/cmd/gmail_watch_helpers_test.go
@@ -217,9 +217,6 @@ func TestGmailWatchStore_StateHelpers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store: %v", err)
 	}
-	if !strings.Contains(store.path, "user_x_example_com.json") {
-		t.Fatalf("unexpected path: %s", store.path)
-	}
 	id, startErr := store.StartHistoryID("101")
 	if startErr != nil {
 		t.Fatalf("start history: %v", startErr)

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -39,6 +39,7 @@ var (
 	}
 	watchReplace = replaceFile
 	watchRemove  = os.Remove
+	watchLink    = os.Link
 )
 
 func gmailWatchStatePath(account string) (string, error) {
@@ -131,20 +132,28 @@ func loadGmailWatchStore(account string) (*gmailWatchStore, error) {
 }
 
 func migrateGmailWatchState(oldPath, newPath string, data []byte) error {
-	file, err := os.OpenFile(newPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) //nolint:gosec // derived from the configured watch directory and account hash
+	tmp, err := watchCreateTemp(filepath.Dir(newPath), "gmail-watch-migrate-*.tmp")
 	if err != nil {
 		return err
 	}
-	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
-		_ = os.Remove(newPath)
+	tmpName := tmp.Name()
+	defer func() { _ = watchRemove(tmpName) }()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
 		return err
 	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(newPath)
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
 		return err
 	}
-	return os.Remove(oldPath)
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := watchLink(tmpName, newPath); err != nil {
+		return err
+	}
+	return watchRemove(oldPath)
 }
 
 func (s *gmailWatchStore) Get() gmailWatchState {

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -172,7 +172,8 @@ func migrateGmailWatchState(oldPath, newPath string, data []byte) error {
 	if err := watchLink(tmpName, newPath); err != nil {
 		return err
 	}
-	return watchRemove(oldPath)
+	_ = watchRemove(oldPath)
+	return nil
 }
 
 func (s *gmailWatchStore) Get() gmailWatchState {

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -47,7 +49,20 @@ func gmailWatchStatePath(account string) (string, error) {
 }
 
 func sanitizeAccountForPath(account string) string {
-	clean := strings.TrimSpace(strings.ToLower(account))
+	clean := normalizeWatchAccount(account)
+	if clean == "" {
+		return "unknown"
+	}
+	digest := sha256.Sum256([]byte(clean))
+	return hex.EncodeToString(digest[:])
+}
+
+func normalizeWatchAccount(account string) string {
+	return strings.TrimSpace(strings.ToLower(account))
+}
+
+func legacySanitizeAccountForPath(account string) string {
+	clean := normalizeWatchAccount(account)
 	if clean == "" {
 		return "unknown"
 	}
@@ -84,16 +99,50 @@ func loadGmailWatchStore(account string) (*gmailWatchStore, error) {
 		return nil, err
 	}
 	data, err := os.ReadFile(store.path)
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
+		legacyPath := filepath.Join(filepath.Dir(store.path), legacySanitizeAccountForPath(account)+".json")
+		data, err = os.ReadFile(legacyPath)
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, errors.New("watch state not found; run gmail watch start")
 		}
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(data, &store.state); err != nil {
+			return nil, err
+		}
+		if normalizeWatchAccount(store.state.Account) != normalizeWatchAccount(account) {
+			return nil, errors.New("watch state not found; run gmail watch start")
+		}
+		if err := migrateGmailWatchState(legacyPath, store.path, data); err != nil {
+			return nil, err
+		}
+		return store, nil
+	}
+	if err != nil {
 		return nil, err
 	}
 	if err := json.Unmarshal(data, &store.state); err != nil {
 		return nil, err
 	}
 	return store, nil
+}
+
+func migrateGmailWatchState(oldPath, newPath string, data []byte) error {
+	file, err := os.OpenFile(newPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(newPath)
+		return err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(newPath)
+		return err
+	}
+	return os.Remove(oldPath)
 }
 
 func (s *gmailWatchStore) Get() gmailWatchState {

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -88,6 +88,25 @@ func legacySanitizeAccountForPath(account string) string {
 	return b.String()
 }
 
+func removeMatchingLegacyGmailWatchState(account, currentPath string) {
+	legacyPath := filepath.Join(filepath.Dir(currentPath), legacySanitizeAccountForPath(account)+".json")
+	if legacyPath == currentPath {
+		return
+	}
+	data, err := os.ReadFile(legacyPath) //nolint:gosec // derived from the configured watch directory and sanitized account
+	if err != nil {
+		return
+	}
+	var state gmailWatchState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return
+	}
+	if normalizeWatchAccount(state.Account) != normalizeWatchAccount(account) {
+		return
+	}
+	_ = watchRemove(legacyPath)
+}
+
 func newGmailWatchStore(account string) (*gmailWatchStore, error) {
 	path, err := gmailWatchStatePath(account)
 	if err != nil {

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -17,6 +17,8 @@ import (
 	"github.com/steipete/gogcli/internal/config"
 )
 
+const unknownWatchAccount = "unknown"
+
 type gmailWatchStore struct {
 	path  string
 	mu    sync.Mutex
@@ -51,7 +53,7 @@ func gmailWatchStatePath(account string) (string, error) {
 func sanitizeAccountForPath(account string) string {
 	clean := normalizeWatchAccount(account)
 	if clean == "" {
-		return "unknown"
+		return unknownWatchAccount
 	}
 	digest := sha256.Sum256([]byte(clean))
 	return hex.EncodeToString(digest[:])
@@ -64,7 +66,7 @@ func normalizeWatchAccount(account string) string {
 func legacySanitizeAccountForPath(account string) string {
 	clean := normalizeWatchAccount(account)
 	if clean == "" {
-		return "unknown"
+		return unknownWatchAccount
 	}
 	var b strings.Builder
 	b.Grow(len(clean))
@@ -98,29 +100,29 @@ func loadGmailWatchStore(account string) (*gmailWatchStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := os.ReadFile(store.path)
-	if errors.Is(err, os.ErrNotExist) {
+	data, readErr := os.ReadFile(store.path)
+	if errors.Is(readErr, os.ErrNotExist) {
 		legacyPath := filepath.Join(filepath.Dir(store.path), legacySanitizeAccountForPath(account)+".json")
-		data, err = os.ReadFile(legacyPath)
-		if errors.Is(err, os.ErrNotExist) {
+		data, readErr = os.ReadFile(legacyPath) //nolint:gosec // derived from the configured watch directory and sanitized account
+		if errors.Is(readErr, os.ErrNotExist) {
 			return nil, errors.New("watch state not found; run gmail watch start")
 		}
-		if err != nil {
-			return nil, err
+		if readErr != nil {
+			return nil, readErr
 		}
-		if err := json.Unmarshal(data, &store.state); err != nil {
-			return nil, err
+		if unmarshalErr := json.Unmarshal(data, &store.state); unmarshalErr != nil {
+			return nil, unmarshalErr
 		}
 		if normalizeWatchAccount(store.state.Account) != normalizeWatchAccount(account) {
 			return nil, errors.New("watch state not found; run gmail watch start")
 		}
-		if err := migrateGmailWatchState(legacyPath, store.path, data); err != nil {
-			return nil, err
+		if migrateErr := migrateGmailWatchState(legacyPath, store.path, data); migrateErr != nil {
+			return nil, migrateErr
 		}
 		return store, nil
 	}
-	if err != nil {
-		return nil, err
+	if readErr != nil {
+		return nil, readErr
 	}
 	if err := json.Unmarshal(data, &store.state); err != nil {
 		return nil, err
@@ -129,7 +131,7 @@ func loadGmailWatchStore(account string) (*gmailWatchStore, error) {
 }
 
 func migrateGmailWatchState(oldPath, newPath string, data []byte) error {
-	file, err := os.OpenFile(newPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	file, err := os.OpenFile(newPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) //nolint:gosec // derived from the configured watch directory and account hash
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/gmail_watch_state_more_test.go
+++ b/internal/cmd/gmail_watch_state_more_test.go
@@ -116,6 +116,41 @@ func TestLoadGmailWatchStore_RejectsUnparsableLegacyStateWithoutMutation(t *test
 	}
 }
 
+func TestLoadGmailWatchStore_LegacyCleanupFailureKeepsPublishedStateUsable(t *testing.T) {
+	setGmailWatchTestConfigDir(t)
+
+	newPath, pathErr := gmailWatchStatePath("user+sales@example.com")
+	if pathErr != nil {
+		t.Fatalf("new state path: %v", pathErr)
+	}
+	legacyPath := filepath.Join(filepath.Dir(newPath), legacySanitizeAccountForPath("user+sales@example.com")+".json")
+	payload := []byte("{\"account\":\"user+sales@example.com\",\"historyId\":\"123\"}\n")
+	if err := os.WriteFile(legacyPath, payload, 0o600); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+
+	origRemove := watchRemove
+	t.Cleanup(func() { watchRemove = origRemove })
+	cleanupErr := errors.New("remove legacy state")
+	watchRemove = func(path string) error {
+		if path == legacyPath {
+			return cleanupErr
+		}
+		return os.Remove(path)
+	}
+
+	store, err := loadGmailWatchStore("user+sales@example.com")
+	if err != nil {
+		t.Fatalf("load matching legacy state: %v", err)
+	}
+	if store.Get().HistoryID != "123" {
+		t.Fatalf("loaded history ID = %q, want 123", store.Get().HistoryID)
+	}
+	if got, err := os.ReadFile(newPath); err != nil || string(got) != string(payload) {
+		t.Fatalf("published state unusable: data=%q err=%v", got, err)
+	}
+}
+
 func TestLoadGmailWatchStore_PublishFailureLeavesLegacyStateIntact(t *testing.T) {
 	setGmailWatchTestConfigDir(t)
 

--- a/internal/cmd/gmail_watch_state_more_test.go
+++ b/internal/cmd/gmail_watch_state_more_test.go
@@ -7,8 +7,15 @@ import (
 	"testing"
 )
 
+func setGmailWatchTestConfigDir(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home)
+}
+
 func TestGmailWatchStatePath_CollisionFreeForNormalizedAccounts(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	setGmailWatchTestConfigDir(t)
 
 	plusPath, err := gmailWatchStatePath(" User+Sales@Example.com ")
 	if err != nil {
@@ -51,7 +58,7 @@ func TestGmailWatchStatePath_CollisionFreeForNormalizedAccounts(t *testing.T) {
 }
 
 func TestLoadGmailWatchStore_MigratesMatchingLegacyState(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	setGmailWatchTestConfigDir(t)
 
 	newPath, pathErr := gmailWatchStatePath("user+sales@example.com")
 	if pathErr != nil {
@@ -86,7 +93,7 @@ func TestLoadGmailWatchStore_MigratesMatchingLegacyState(t *testing.T) {
 }
 
 func TestLoadGmailWatchStore_RejectsUnparsableLegacyStateWithoutMutation(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	setGmailWatchTestConfigDir(t)
 
 	newPath, pathErr := gmailWatchStatePath("user+sales@example.com")
 	if pathErr != nil {
@@ -110,7 +117,7 @@ func TestLoadGmailWatchStore_RejectsUnparsableLegacyStateWithoutMutation(t *test
 }
 
 func TestLoadGmailWatchStore_PublishFailureLeavesLegacyStateIntact(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	setGmailWatchTestConfigDir(t)
 
 	newPath, pathErr := gmailWatchStatePath("user+sales@example.com")
 	if pathErr != nil {
@@ -139,7 +146,7 @@ func TestLoadGmailWatchStore_PublishFailureLeavesLegacyStateIntact(t *testing.T)
 }
 
 func TestLoadGmailWatchStore_RejectsCollidingLegacyStateForAnotherAccount(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	setGmailWatchTestConfigDir(t)
 
 	requestedPath, pathErr := gmailWatchStatePath("user+sales@example.com")
 	if pathErr != nil {

--- a/internal/cmd/gmail_watch_state_more_test.go
+++ b/internal/cmd/gmail_watch_state_more_test.go
@@ -14,12 +14,17 @@ func TestGmailWatchStatePath_CollisionFreeForNormalizedAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plus account path: %v", err)
 	}
-	underscorePath, err := gmailWatchStatePath("user_sales@example.com")
-	if err != nil {
-		t.Fatalf("underscore account path: %v", err)
-	}
-	if plusPath == underscorePath {
-		t.Fatalf("distinct normalized accounts share path %q", plusPath)
+	for _, other := range []string{
+		"user_sales@example.com",
+		"user!sales@example.com",
+	} {
+		otherPath, pathErr := gmailWatchStatePath(other)
+		if pathErr != nil {
+			t.Fatalf("account %q path: %v", other, pathErr)
+		}
+		if plusPath == otherPath {
+			t.Fatalf("distinct normalized accounts %q and %q share path %q", "user+sales@example.com", other, plusPath)
+		}
 	}
 
 	normalizedPath, err := gmailWatchStatePath("user+sales@example.com")
@@ -28,6 +33,17 @@ func TestGmailWatchStatePath_CollisionFreeForNormalizedAccounts(t *testing.T) {
 	}
 	if plusPath != normalizedPath {
 		t.Fatalf("equivalent normalized accounts resolved to %q and %q", plusPath, normalizedPath)
+	}
+	nonASCIIPath, err := gmailWatchStatePath("üser@example.com")
+	if err != nil {
+		t.Fatalf("non-ASCII account path: %v", err)
+	}
+	legacyCollisionPath, err := gmailWatchStatePath("_ser@example.com")
+	if err != nil {
+		t.Fatalf("legacy collision account path: %v", err)
+	}
+	if nonASCIIPath == legacyCollisionPath {
+		t.Fatalf("non-ASCII collision pair shares path %q", nonASCIIPath)
 	}
 	if filepath.Ext(plusPath) != ".json" {
 		t.Fatalf("watch state path must remain a JSON file: %q", plusPath)
@@ -66,6 +82,59 @@ func TestLoadGmailWatchStore_MigratesMatchingLegacyState(t *testing.T) {
 	}
 	if _, err := os.Stat(legacyPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("legacy state still exists after migration: %v", err)
+	}
+}
+
+func TestLoadGmailWatchStore_RejectsUnparsableLegacyStateWithoutMutation(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	newPath, pathErr := gmailWatchStatePath("user+sales@example.com")
+	if pathErr != nil {
+		t.Fatalf("new state path: %v", pathErr)
+	}
+	legacyPath := filepath.Join(filepath.Dir(newPath), legacySanitizeAccountForPath("user+sales@example.com")+".json")
+	payload := []byte("not json\n")
+	if err := os.WriteFile(legacyPath, payload, 0o600); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+
+	if _, err := loadGmailWatchStore("user+sales@example.com"); err == nil {
+		t.Fatal("unparsable legacy state was accepted")
+	}
+	if got, err := os.ReadFile(legacyPath); err != nil || string(got) != string(payload) {
+		t.Fatalf("unparsable legacy state changed: data=%q err=%v", got, err)
+	}
+	if _, err := os.Stat(newPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unparsable legacy state was migrated: %v", err)
+	}
+}
+
+func TestLoadGmailWatchStore_PublishFailureLeavesLegacyStateIntact(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	newPath, pathErr := gmailWatchStatePath("user+sales@example.com")
+	if pathErr != nil {
+		t.Fatalf("new state path: %v", pathErr)
+	}
+	legacyPath := filepath.Join(filepath.Dir(newPath), legacySanitizeAccountForPath("user+sales@example.com")+".json")
+	payload := []byte("{\"account\":\"user+sales@example.com\",\"historyId\":\"123\"}\n")
+	if err := os.WriteFile(legacyPath, payload, 0o600); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+
+	origLink := watchLink
+	t.Cleanup(func() { watchLink = origLink })
+	publishErr := errors.New("publish migrated state")
+	watchLink = func(_, _ string) error { return publishErr }
+
+	if _, err := loadGmailWatchStore("user+sales@example.com"); !errors.Is(err, publishErr) {
+		t.Fatalf("load error = %v, want %v", err, publishErr)
+	}
+	if got, err := os.ReadFile(legacyPath); err != nil || string(got) != string(payload) {
+		t.Fatalf("legacy state changed: data=%q err=%v", got, err)
+	}
+	if _, err := os.Stat(newPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("new state published after failure: %v", err)
 	}
 }
 

--- a/internal/cmd/gmail_watch_state_more_test.go
+++ b/internal/cmd/gmail_watch_state_more_test.go
@@ -1,6 +1,97 @@
 package cmd
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGmailWatchStatePath_CollisionFreeForNormalizedAccounts(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	plusPath, err := gmailWatchStatePath(" User+Sales@Example.com ")
+	if err != nil {
+		t.Fatalf("plus account path: %v", err)
+	}
+	underscorePath, err := gmailWatchStatePath("user_sales@example.com")
+	if err != nil {
+		t.Fatalf("underscore account path: %v", err)
+	}
+	if plusPath == underscorePath {
+		t.Fatalf("distinct normalized accounts share path %q", plusPath)
+	}
+
+	normalizedPath, err := gmailWatchStatePath("user+sales@example.com")
+	if err != nil {
+		t.Fatalf("normalized account path: %v", err)
+	}
+	if plusPath != normalizedPath {
+		t.Fatalf("equivalent normalized accounts resolved to %q and %q", plusPath, normalizedPath)
+	}
+	if filepath.Ext(plusPath) != ".json" {
+		t.Fatalf("watch state path must remain a JSON file: %q", plusPath)
+	}
+}
+
+func TestLoadGmailWatchStore_MigratesMatchingLegacyState(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	newPath, err := gmailWatchStatePath("user+sales@example.com")
+	if err != nil {
+		t.Fatalf("new state path: %v", err)
+	}
+	legacyPath := filepath.Join(filepath.Dir(newPath), "user_sales_example_com.json")
+	payload := []byte("{\"account\":\" User+Sales@Example.COM \",\"topic\":\"projects/p/topics/t\",\"historyId\":\"123\"}\n")
+	if err := os.WriteFile(legacyPath, payload, 0o600); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+
+	store, err := loadGmailWatchStore("user+sales@example.com")
+	if err != nil {
+		t.Fatalf("load legacy state: %v", err)
+	}
+	if store.path != newPath {
+		t.Fatalf("loaded store path = %q, want %q", store.path, newPath)
+	}
+	if store.Get().HistoryID != "123" {
+		t.Fatalf("loaded history ID = %q, want 123", store.Get().HistoryID)
+	}
+	migrated, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("read migrated state: %v", err)
+	}
+	if string(migrated) != string(payload) {
+		t.Fatalf("migration changed state contents:\n got: %s\nwant: %s", migrated, payload)
+	}
+	if _, err := os.Stat(legacyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy state still exists after migration: %v", err)
+	}
+}
+
+func TestLoadGmailWatchStore_RejectsCollidingLegacyStateForAnotherAccount(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	requestedPath, err := gmailWatchStatePath("user+sales@example.com")
+	if err != nil {
+		t.Fatalf("requested state path: %v", err)
+	}
+	legacyPath := filepath.Join(filepath.Dir(requestedPath), "user_sales_example_com.json")
+	payload := []byte("{\"account\":\"user_sales@example.com\",\"historyId\":\"456\"}\n")
+	if err := os.WriteFile(legacyPath, payload, 0o600); err != nil {
+		t.Fatalf("write colliding legacy state: %v", err)
+	}
+
+	if _, err := loadGmailWatchStore("user+sales@example.com"); err == nil {
+		t.Fatal("colliding legacy state was accepted for another account")
+	}
+	if _, err := os.Stat(requestedPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("colliding legacy state was migrated to requested path: %v", err)
+	}
+	if got, err := os.ReadFile(legacyPath); err != nil || string(got) != string(payload) {
+		t.Fatalf("colliding legacy state changed: data=%q err=%v", got, err)
+	}
+}
 
 func TestIsStaleHistoryID(t *testing.T) {
 	stale, err := isStaleHistoryID("5", "4")

--- a/internal/cmd/gmail_watch_state_more_test.go
+++ b/internal/cmd/gmail_watch_state_more_test.go
@@ -37,9 +37,9 @@ func TestGmailWatchStatePath_CollisionFreeForNormalizedAccounts(t *testing.T) {
 func TestLoadGmailWatchStore_MigratesMatchingLegacyState(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	newPath, err := gmailWatchStatePath("user+sales@example.com")
-	if err != nil {
-		t.Fatalf("new state path: %v", err)
+	newPath, pathErr := gmailWatchStatePath("user+sales@example.com")
+	if pathErr != nil {
+		t.Fatalf("new state path: %v", pathErr)
 	}
 	legacyPath := filepath.Join(filepath.Dir(newPath), "user_sales_example_com.json")
 	payload := []byte("{\"account\":\" User+Sales@Example.COM \",\"topic\":\"projects/p/topics/t\",\"historyId\":\"123\"}\n")
@@ -72,9 +72,9 @@ func TestLoadGmailWatchStore_MigratesMatchingLegacyState(t *testing.T) {
 func TestLoadGmailWatchStore_RejectsCollidingLegacyStateForAnotherAccount(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	requestedPath, err := gmailWatchStatePath("user+sales@example.com")
-	if err != nil {
-		t.Fatalf("requested state path: %v", err)
+	requestedPath, pathErr := gmailWatchStatePath("user+sales@example.com")
+	if pathErr != nil {
+		t.Fatalf("requested state path: %v", pathErr)
 	}
 	legacyPath := filepath.Join(filepath.Dir(requestedPath), "user_sales_example_com.json")
 	payload := []byte("{\"account\":\"user_sales@example.com\",\"historyId\":\"456\"}\n")


### PR DESCRIPTION
## Summary
- derive Gmail watch state filenames from the normalized account SHA-256
- safely migrate matching legacy state while rejecting mismatched or invalid files
- clear both current and legacy state paths when stopping a watch

## Testing
- `/home/jeremy-johnson/.local/go/bin/go test ./internal/cmd -run 'Test(Execute_GmailWatch_MoreCommands|GmailWatchStatePath|LoadGmailWatchStore|GmailWatchStore_StateHelpers)' -count=1`
- `make ci`

Closes #97
