### PR TITLE
feat(cli): add exact command-path allowlisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- CLI: add `--enable-command-paths` / `GOG_ENABLE_COMMAND_PATHS` for exact command-path allowlisting alongside top-level `--enable-commands`. (#153)
+
 - Search Console: add `--start-row` to `search-console query` for zero-based Search Analytics result windows. (#98)
 - Tag Manager: add workspace trigger and variable create/delete/get/revert/update commands plus built-in-variable management. (#12, #45, #46, #47)
 - Tag Manager: add composable workspace version creation and container-version publishing commands. (#11)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Fast, script-friendly CLI for Gmail, Calendar, Chat, Classroom, Drive, Docs, Sli
 - **Groups** - list groups you belong to, view group members (Google Workspace)
 - **Local time** - quick local/UTC time display for scripts and agents
 - **Multiple accounts** - manage multiple Google accounts simultaneously (with aliases)
-- **Command allowlist** - restrict top-level commands for sandboxed/agent runs
+- **Command allowlist** - restrict top-level services and/or exact command paths for sandboxed/agent runs
 - **Secure credential storage** using OS keyring or encrypted on-disk keyring (configurable)
 - **Auto-refreshing tokens** - authenticate once, use indefinitely
 - **Least-privilege auth** - `--readonly` and `--drive-scope` to request fewer scopes
@@ -418,6 +418,7 @@ gog keep get <noteId> --account you@yourdomain.com
 - `GOG_COLOR` - Color mode: `auto` (default), `always`, or `never`
 - `GOG_TIMEZONE` - Default output timezone for Calendar/Gmail (IANA name, `UTC`, or `local`)
 - `GOG_ENABLE_COMMANDS` - Comma-separated allowlist of top-level commands (e.g., `calendar,tasks`)
+- `GOG_ENABLE_COMMAND_PATHS` - Comma-separated allowlist of exact command paths (e.g., `gmail search,calendar events`)
 
 ### Config File (JSON5)
 
@@ -476,13 +477,34 @@ Aliases work anywhere you pass `--account` or `GOG_ACCOUNT` (reserved: `auto`, `
 
 ### Command Allowlist (Sandboxing)
 
+Two complementary invocation allowlists restrict which commands may run:
+
+- `--enable-commands` / `GOG_ENABLE_COMMANDS`: top-level services only (e.g. `gmail`, `calendar`)
+- `--enable-command-paths` / `GOG_ENABLE_COMMAND_PATHS`: exact parser-resolved command paths (e.g. `gmail search`, `gmail thread get`)
+
+Matching rules for exact paths:
+
+- Identity is the Kong-resolved command path: command segments only (flags and positional values are excluded)
+- Documented aliases resolve via the parser model (`mail search` == `gmail search`; invocation `gmail read <id>` has identity `gmail thread get`). Group aliases in the allowlist (e.g. `gmail read`) match the group path only and do not implicitly allow default child leaves
+- Parent paths do **not** allow children (`gmail thread` does not allow `gmail thread get`)
+- When both lists are set, a match in **either** list permits the command (OR)
+- When neither list is set, enablement is unrestricted
+- Persisted `policy` rules remain a separate subsequent gate (AND with enablement)
+
 ```bash
-# Only allow calendar + tasks commands for an agent
+# Only allow calendar + tasks commands for an agent (top-level)
 gog --enable-commands calendar,tasks calendar events --today
 
 # Same via env
 export GOG_ENABLE_COMMANDS=calendar,tasks
 gog tasks list <tasklistId>
+
+# Exact paths: allow Gmail search without other Gmail commands
+gog --enable-command-paths "gmail search" gmail search 'is:unread'
+export GOG_ENABLE_COMMAND_PATHS='gmail search,calendar events'
+
+# Compose: top-level calendar OR exact gmail search
+gog --enable-commands calendar --enable-command-paths "gmail search" gmail search 'is:unread'
 ```
  
 ## Security
@@ -1332,6 +1354,7 @@ All commands support these flags:
 
 - `--account <email|alias|auto>` - Account to use (overrides GOG_ACCOUNT)
 - `--enable-commands <csv>` - Allowlist top-level commands (e.g., `calendar,tasks`)
+- `--enable-command-paths <csv>` - Allowlist exact command paths (e.g., `gmail search,calendar events`)
 - `--json` - Output JSON to stdout (best for scripting)
 - `--plain` - Output stable, parseable text to stdout (TSV; no colors)
 - `--color <mode>` - Color mode: `auto`, `always`, or `never` (default: auto)

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ Two complementary invocation allowlists restrict which commands may run:
 Matching rules for exact paths:
 
 - Identity is the Kong-resolved command path: command segments only (flags and positional values are excluded)
-- Documented aliases resolve via the parser model (`mail search` == `gmail search`; invocation `gmail read <id>` has identity `gmail thread get`). Group aliases in the allowlist (e.g. `gmail read`) match the group path only and do not implicitly allow default child leaves
+- Documented aliases resolve via the parser model (`mail search` == `gmail search`; `gmail read` == `gmail thread get`); parent paths written by primary name do not implicitly allow default child leaves
 - Parent paths do **not** allow children (`gmail thread` does not allow `gmail thread get`)
 - When both lists are set, a match in **either** list permits the command (OR)
 - When neither list is set, enablement is unrestricted

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -134,6 +134,7 @@ Environment:
 - `GOG_KEYRING_BACKEND={auto|keychain|file}` (force backend; use `file` to avoid Keychain prompts and pair with `GOG_KEYRING_PASSWORD` for non-interactive)
 - `GOG_TIMEZONE=America/New_York` (default output timezone; IANA name or `UTC`; `local` forces local timezone)
 - `GOG_ENABLE_COMMANDS=calendar,tasks` (optional allowlist of top-level commands)
+- `GOG_ENABLE_COMMAND_PATHS=gmail search,calendar events` (optional allowlist of exact command paths; aliases canonicalize; parents do not allow children; ORs with top-level enablement; policies still apply after)
 - `config.json` can also set `keyring_backend` (JSON5; env vars take precedence)
 - `config.json` can also set `default_timezone` (IANA name or `UTC`)
 - `config.json` can also set `account_aliases` for `gog auth alias` (JSON5)

--- a/internal/cmd/enabled_commands.go
+++ b/internal/cmd/enabled_commands.go
@@ -74,9 +74,6 @@ func parseEnabledTopLevelCommands(value string) (map[string]bool, bool) {
 			continue
 		}
 		configured = true
-		if part != "*" && part != "all" {
-			part = normalizeCommandService(part)
-		}
 		out[part] = true
 	}
 	return out, configured
@@ -126,8 +123,8 @@ func canonicalizeEnabledPath(kctx *kong.Context, segments []string) string {
 }
 
 // resolveCommandPath walks the Kong command tree matching each segment by
-// primary name or alias, following default commands when a path ends on a
-// non-leaf that has a default. Returns the canonical primary-name path.
+// primary name or alias. It returns the canonical primary-name path written by
+// the user; an exact-path entry for a parent does not follow its default child.
 func resolveCommandPath(root *kong.Node, segments []string) ([]string, bool) {
 	if root == nil || len(segments) == 0 {
 		return nil, false
@@ -142,10 +139,8 @@ func resolveCommandPath(root *kong.Node, segments []string) ([]string, bool) {
 		path = append(path, child.Name)
 		node = child
 	}
-	// Follow default leaf commands so entries like "gmail thread" that end on
-	// a group with a default do not silently become parent-only identities
-	// unless the user truly stopped there. We intentionally stop at the path
-	// as written: exact matching means "gmail thread" stays "gmail thread".
+	// Exact matching intentionally stops at the written parent, so
+	// "gmail thread" stays "gmail thread" rather than its default leaf.
 	return path, true
 }
 
@@ -174,5 +169,5 @@ func topAllowsCommand(allow map[string]bool, top string) bool {
 	if allow["*"] || allow["all"] {
 		return true
 	}
-	return allow[normalizeCommandService(top)]
+	return allow[top]
 }

--- a/internal/cmd/enabled_commands.go
+++ b/internal/cmd/enabled_commands.go
@@ -79,12 +79,6 @@ func parseEnabledTopLevelCommands(value string) (map[string]bool, bool) {
 	return out, configured
 }
 
-// parseEnabledCommands remains for tests and callers that only need the map.
-func parseEnabledCommands(value string) map[string]bool {
-	allow, _ := parseEnabledTopLevelCommands(value)
-	return allow
-}
-
 // parseEnabledCommandPaths builds the exact-path allow set.
 // When a Kong context is available, each entry is walked through the command
 // model so documented aliases collapse to the same canonical path identity.
@@ -124,29 +118,31 @@ func canonicalizeEnabledPath(kctx *kong.Context, segments []string) string {
 
 // resolveCommandPath walks the Kong command tree matching each segment by
 // primary name or alias. It returns the canonical primary-name path written by
-// the user; an exact-path entry for a parent does not follow its default child.
+// the user; a final alias that selects a default command includes that leaf.
+// An exact-path entry written with a parent primary name does not follow it.
 func resolveCommandPath(root *kong.Node, segments []string) ([]string, bool) {
 	if root == nil || len(segments) == 0 {
 		return nil, false
 	}
 	node := root
-	path := make([]string, 0, len(segments))
-	for _, segment := range segments {
-		child := findCommandChild(node, segment)
+	path := make([]string, 0, len(segments)+1)
+	for i, segment := range segments {
+		child, isAlias := findCommandChild(node, segment)
 		if child == nil {
 			return nil, false
 		}
 		path = append(path, child.Name)
 		node = child
+		if i == len(segments)-1 && isAlias && node.DefaultCmd != nil {
+			path = append(path, node.DefaultCmd.Name)
+		}
 	}
-	// Exact matching intentionally stops at the written parent, so
-	// "gmail thread" stays "gmail thread" rather than its default leaf.
 	return path, true
 }
 
-func findCommandChild(node *kong.Node, segment string) *kong.Node {
+func findCommandChild(node *kong.Node, segment string) (*kong.Node, bool) {
 	if node == nil {
-		return nil
+		return nil, false
 	}
 	segment = strings.ToLower(strings.TrimSpace(segment))
 	for _, child := range node.Children {
@@ -154,15 +150,15 @@ func findCommandChild(node *kong.Node, segment string) *kong.Node {
 			continue
 		}
 		if strings.EqualFold(child.Name, segment) {
-			return child
+			return child, false
 		}
 		for _, alias := range child.Aliases {
 			if strings.EqualFold(alias, segment) {
-				return child
+				return child, true
 			}
 		}
 	}
-	return nil
+	return nil, false
 }
 
 func topAllowsCommand(allow map[string]bool, top string) bool {

--- a/internal/cmd/enabled_commands.go
+++ b/internal/cmd/enabled_commands.go
@@ -6,37 +6,173 @@ import (
 	"github.com/alecthomas/kong"
 )
 
-func enforceEnabledCommands(kctx *kong.Context, enabled string) error {
-	enabled = strings.TrimSpace(enabled)
-	if enabled == "" {
+// enforceEnabledCommands applies invocation-scoped enablement.
+//
+// Composition:
+//   - unrestricted when neither top-level nor exact-path input is configured
+//   - a match in either list permits the command (OR)
+//   - parent exact paths do not implicitly allow descendants
+//   - persisted policies remain a separate subsequent gate
+func enforceEnabledCommands(kctx *kong.Context, enabledTop string, enabledPaths string) error {
+	topAllow, topConfigured := parseEnabledTopLevelCommands(enabledTop)
+	pathAllow, pathConfigured := parseEnabledCommandPaths(kctx, enabledPaths)
+	if !topConfigured && !pathConfigured {
 		return nil
 	}
-	allow := parseEnabledCommands(enabled)
-	if len(allow) == 0 {
+
+	path := commandPath(kctx)
+	if len(path) == 0 {
 		return nil
 	}
-	if allow["*"] || allow["all"] {
+
+	if topConfigured && topAllowsCommand(topAllow, path[0]) {
 		return nil
 	}
-	cmd := strings.Fields(kctx.Command())
-	if len(cmd) == 0 {
+	if pathConfigured && pathAllow[strings.Join(path, " ")] {
 		return nil
 	}
-	top := strings.ToLower(cmd[0])
-	if !allow[top] {
-		return usagef("command %q is not enabled (set --enable-commands to allow it)", top)
+
+	display := strings.Join(path, " ")
+	if pathConfigured && !topConfigured {
+		return usagef("command %q is not enabled (set --enable-command-paths to allow it)", display)
 	}
-	return nil
+	if topConfigured && !pathConfigured {
+		return usagef("command %q is not enabled (set --enable-commands to allow it)", path[0])
+	}
+	return usagef("command %q is not enabled (set --enable-commands or --enable-command-paths to allow it)", display)
 }
 
-func parseEnabledCommands(value string) map[string]bool {
+// commandPath returns the parser-resolved canonical command identity:
+// command segments only (no flags, no positional placeholders/values).
+// Kong already rewrites aliases to their primary command names.
+func commandPath(kctx *kong.Context) []string {
+	if kctx == nil {
+		return nil
+	}
+	rawParts := strings.Fields(strings.TrimSpace(kctx.Command()))
+	parts := make([]string, 0, len(rawParts))
+	for _, part := range rawParts {
+		part = strings.ToLower(strings.TrimSpace(part))
+		if part == "" {
+			continue
+		}
+		// Kong represents positional args as <name> placeholders in Command().
+		if strings.HasPrefix(part, "<") && strings.HasSuffix(part, ">") {
+			continue
+		}
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+func parseEnabledTopLevelCommands(value string) (map[string]bool, bool) {
 	out := map[string]bool{}
+	configured := false
 	for _, part := range strings.Split(value, ",") {
 		part = strings.TrimSpace(strings.ToLower(part))
 		if part == "" {
 			continue
 		}
+		configured = true
+		if part != "*" && part != "all" {
+			part = normalizeCommandService(part)
+		}
 		out[part] = true
 	}
-	return out
+	return out, configured
+}
+
+// parseEnabledCommands remains for tests and callers that only need the map.
+func parseEnabledCommands(value string) map[string]bool {
+	allow, _ := parseEnabledTopLevelCommands(value)
+	return allow
+}
+
+// parseEnabledCommandPaths builds the exact-path allow set.
+// When a Kong context is available, each entry is walked through the command
+// model so documented aliases collapse to the same canonical path identity.
+func parseEnabledCommandPaths(kctx *kong.Context, value string) (map[string]bool, bool) {
+	out := map[string]bool{}
+	configured := false
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		segments := strings.Fields(strings.ToLower(part))
+		if len(segments) == 0 {
+			continue
+		}
+		configured = true
+		out[canonicalizeEnabledPath(kctx, segments)] = true
+	}
+	return out, configured
+}
+
+func canonicalizeEnabledPath(kctx *kong.Context, segments []string) string {
+	if len(segments) == 0 {
+		return ""
+	}
+	if kctx != nil && kctx.Model != nil {
+		if path, ok := resolveCommandPath(kctx.Model.Node, segments); ok {
+			return strings.Join(path, " ")
+		}
+	}
+	// Fallback when the entry cannot be resolved against the model: still
+	// normalize the top-level service alias so mail/email/bq entries work.
+	segments = append([]string(nil), segments...)
+	segments[0] = normalizeCommandService(segments[0])
+	return strings.Join(segments, " ")
+}
+
+// resolveCommandPath walks the Kong command tree matching each segment by
+// primary name or alias, following default commands when a path ends on a
+// non-leaf that has a default. Returns the canonical primary-name path.
+func resolveCommandPath(root *kong.Node, segments []string) ([]string, bool) {
+	if root == nil || len(segments) == 0 {
+		return nil, false
+	}
+	node := root
+	path := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		child := findCommandChild(node, segment)
+		if child == nil {
+			return nil, false
+		}
+		path = append(path, child.Name)
+		node = child
+	}
+	// Follow default leaf commands so entries like "gmail thread" that end on
+	// a group with a default do not silently become parent-only identities
+	// unless the user truly stopped there. We intentionally stop at the path
+	// as written: exact matching means "gmail thread" stays "gmail thread".
+	return path, true
+}
+
+func findCommandChild(node *kong.Node, segment string) *kong.Node {
+	if node == nil {
+		return nil
+	}
+	segment = strings.ToLower(strings.TrimSpace(segment))
+	for _, child := range node.Children {
+		if child == nil || child.Type != kong.CommandNode {
+			continue
+		}
+		if strings.EqualFold(child.Name, segment) {
+			return child
+		}
+		for _, alias := range child.Aliases {
+			if strings.EqualFold(alias, segment) {
+				return child
+			}
+		}
+	}
+	return nil
+}
+
+func topAllowsCommand(allow map[string]bool, top string) bool {
+	if allow["*"] || allow["all"] {
+		return true
+	}
+	return allow[normalizeCommandService(top)]
 }

--- a/internal/cmd/enabled_commands_test.go
+++ b/internal/cmd/enabled_commands_test.go
@@ -76,8 +76,8 @@ func TestEnforceEnabledCommands_ExactPathAllowAndSiblingDenial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse search: %v", err)
 	}
-	if err := enforceEnabledCommands(search, "", "gmail search"); err != nil {
-		t.Fatalf("expected gmail search allow: %v", err)
+	if enforceErr := enforceEnabledCommands(search, "", "gmail search"); enforceErr != nil {
+		t.Fatalf("expected gmail search allow: %v", enforceErr)
 	}
 
 	send, err := parser.Parse([]string{"gmail", "send", "--to", "a@b.com", "--subject", "s", "--body", "b"})
@@ -101,12 +101,12 @@ func TestEnforceEnabledCommands_NestedPathsExactOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse get: %v", err)
 	}
-	if err := enforceEnabledCommands(get, "", "gmail thread get"); err != nil {
-		t.Fatalf("expected nested path allow: %v", err)
+	if enforceErr := enforceEnabledCommands(get, "", "gmail thread get"); enforceErr != nil {
+		t.Fatalf("expected nested path allow: %v", enforceErr)
 	}
 
 	// Parent path must not implicitly allow the leaf.
-	if err := enforceEnabledCommands(get, "", "gmail thread"); err == nil {
+	if enforceErr := enforceEnabledCommands(get, "", "gmail thread"); enforceErr == nil {
 		t.Fatalf("expected parent path not to allow nested leaf")
 	}
 
@@ -130,16 +130,16 @@ func TestEnforceEnabledCommands_AliasAllowlistEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	if err := enforceEnabledCommands(kctx, "", "mail search"); err != nil {
-		t.Fatalf("expected alias allowlist entry to match canonical path: %v", err)
+	if enforceErr := enforceEnabledCommands(kctx, "", "mail search"); enforceErr != nil {
+		t.Fatalf("expected alias allowlist entry to match canonical path: %v", enforceErr)
 	}
 
 	aliasInvoke, err := parser.Parse([]string{"mail", "search", "is:unread"})
 	if err != nil {
 		t.Fatalf("Parse alias invoke: %v", err)
 	}
-	if err := enforceEnabledCommands(aliasInvoke, "", "gmail search"); err != nil {
-		t.Fatalf("expected alias invocation to match canonical allowlist: %v", err)
+	if enforceErr := enforceEnabledCommands(aliasInvoke, "", "gmail search"); enforceErr != nil {
+		t.Fatalf("expected alias invocation to match canonical allowlist: %v", enforceErr)
 	}
 
 	// Nested command alias must not bypass a leaf restriction.
@@ -161,34 +161,37 @@ func TestEnforceEnabledCommands_AliasAllowlistEntries(t *testing.T) {
 	}
 }
 
-func TestEnforceEnabledCommands_LegacyTopLevelCompatibility(t *testing.T) {
+func TestEnforceEnabledCommands_LegacyTopLevelMatchesHistoricalExactNames(t *testing.T) {
 	parser, _, err := newParser("test")
 	if err != nil {
 		t.Fatalf("newParser: %v", err)
 	}
 
-	cal, err := parser.Parse([]string{"calendar", "colors"})
-	if err != nil {
-		t.Fatalf("Parse calendar: %v", err)
-	}
-	if err := enforceEnabledCommands(cal, "calendar,tasks", ""); err != nil {
-		t.Fatalf("expected legacy top-level allow: %v", err)
-	}
-
-	tasks, err := parser.Parse([]string{"tasks", "lists"})
-	if err != nil {
-		t.Fatalf("Parse tasks: %v", err)
-	}
-	if err := enforceEnabledCommands(tasks, "calendar,tasks", ""); err != nil {
-		t.Fatalf("expected legacy top-level allow for tasks: %v", err)
+	tests := []struct {
+		name        string
+		args        []string
+		enabled     string
+		wantAllowed bool
+	}{
+		{name: "canonical calendar", args: []string{"calendar", "colors"}, enabled: "calendar", wantAllowed: true},
+		{name: "canonical gmail", args: []string{"gmail", "search", "is:unread"}, enabled: "gmail", wantAllowed: true},
+		{name: "mail alias entry remains inert", args: []string{"mail", "search", "is:unread"}, enabled: "mail", wantAllowed: false},
+		{name: "email alias entry remains inert", args: []string{"email", "search", "is:unread"}, enabled: "email", wantAllowed: false},
+		{name: "bq alias entry remains inert", args: []string{"bq", "datasets", "--project", "test-project"}, enabled: "bq", wantAllowed: false},
+		{name: "gsc alias entry remains inert", args: []string{"gsc", "sites", "list"}, enabled: "gsc", wantAllowed: false},
 	}
 
-	gmail, err := parser.Parse([]string{"gmail", "search", "is:unread"})
-	if err != nil {
-		t.Fatalf("Parse gmail: %v", err)
-	}
-	if err := enforceEnabledCommands(gmail, "calendar,tasks", ""); err == nil {
-		t.Fatalf("expected legacy top-level denial for gmail")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kctx, parseErr := parser.Parse(tt.args)
+			if parseErr != nil {
+				t.Fatalf("Parse(%v): %v", tt.args, parseErr)
+			}
+			gotAllowed := enforceEnabledCommands(kctx, tt.enabled, "") == nil
+			if gotAllowed != tt.wantAllowed {
+				t.Fatalf("legacy --enable-commands=%q with %v allowed=%t, want %t", tt.enabled, tt.args, gotAllowed, tt.wantAllowed)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/enabled_commands_test.go
+++ b/internal/cmd/enabled_commands_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/steipete/gogcli/internal/config"
 )
 
-func TestParseEnabledCommands(t *testing.T) {
-	allow := parseEnabledCommands("calendar, tasks ,Gmail")
-	if !allow["calendar"] || !allow["tasks"] || !allow["gmail"] {
+func TestParseEnabledTopLevelCommands(t *testing.T) {
+	allow, configured := parseEnabledTopLevelCommands("calendar, tasks ,Gmail")
+	if !configured || !allow["calendar"] || !allow["tasks"] || !allow["gmail"] {
 		t.Fatalf("unexpected allow map: %#v", allow)
 	}
 }
@@ -155,9 +155,9 @@ func TestEnforceEnabledCommands_AliasAllowlistEntries(t *testing.T) {
 	if err := enforceEnabledCommands(read, "", "gmail thread get"); err != nil {
 		t.Fatalf("expected nested alias invocation to share canonical allow identity: %v", err)
 	}
-	// Allowlisting the group alias alone is still a parent path, not the leaf.
-	if err := enforceEnabledCommands(read, "", "gmail read"); err == nil {
-		t.Fatalf("expected group alias allowlist entry not to allow the default leaf")
+	// An alias that selects the default command canonicalizes to its leaf.
+	if err := enforceEnabledCommands(read, "", "gmail read"); err != nil {
+		t.Fatalf("expected alias allowlist entry to match default leaf: %v", err)
 	}
 }
 

--- a/internal/cmd/enabled_commands_test.go
+++ b/internal/cmd/enabled_commands_test.go
@@ -1,10 +1,314 @@
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/config"
+)
 
 func TestParseEnabledCommands(t *testing.T) {
 	allow := parseEnabledCommands("calendar, tasks ,Gmail")
 	if !allow["calendar"] || !allow["tasks"] || !allow["gmail"] {
 		t.Fatalf("unexpected allow map: %#v", allow)
+	}
+}
+
+func TestCommandPath_ExcludesPositionalsAndUsesCanonicalNames(t *testing.T) {
+	parser, _, err := newParser("test")
+	if err != nil {
+		t.Fatalf("newParser: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "search drops query positional",
+			args: []string{"gmail", "search", "is:unread", "--max", "5"},
+			want: []string{"gmail", "search"},
+		},
+		{
+			name: "service alias canonicalizes",
+			args: []string{"mail", "search", "is:unread"},
+			want: []string{"gmail", "search"},
+		},
+		{
+			name: "nested default and alias resolve to full leaf path",
+			args: []string{"gmail", "read", "thread-1"},
+			want: []string{"gmail", "thread", "get"},
+		},
+		{
+			name: "explicit nested path",
+			args: []string{"gmail", "thread", "get", "thread-1"},
+			want: []string{"gmail", "thread", "get"},
+		},
+		{
+			name: "flags only command",
+			args: []string{"gmail", "send", "--to", "a@b.com", "--subject", "s", "--body", "b"},
+			want: []string{"gmail", "send"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kctx, err := parser.Parse(tt.args)
+			if err != nil {
+				t.Fatalf("Parse(%v): %v", tt.args, err)
+			}
+			got := commandPath(kctx)
+			if strings.Join(got, " ") != strings.Join(tt.want, " ") {
+				t.Fatalf("commandPath(%v)=%v want %v (command=%q)", tt.args, got, tt.want, kctx.Command())
+			}
+		})
+	}
+}
+
+func TestEnforceEnabledCommands_ExactPathAllowAndSiblingDenial(t *testing.T) {
+	parser, _, err := newParser("test")
+	if err != nil {
+		t.Fatalf("newParser: %v", err)
+	}
+
+	search, err := parser.Parse([]string{"gmail", "search", "is:unread"})
+	if err != nil {
+		t.Fatalf("Parse search: %v", err)
+	}
+	if err := enforceEnabledCommands(search, "", "gmail search"); err != nil {
+		t.Fatalf("expected gmail search allow: %v", err)
+	}
+
+	send, err := parser.Parse([]string{"gmail", "send", "--to", "a@b.com", "--subject", "s", "--body", "b"})
+	if err != nil {
+		t.Fatalf("Parse send: %v", err)
+	}
+	if err := enforceEnabledCommands(send, "", "gmail search"); err == nil {
+		t.Fatalf("expected sibling gmail send to be denied")
+	} else if !strings.Contains(err.Error(), "not enabled") {
+		t.Fatalf("unexpected deny error: %v", err)
+	}
+}
+
+func TestEnforceEnabledCommands_NestedPathsExactOnly(t *testing.T) {
+	parser, _, err := newParser("test")
+	if err != nil {
+		t.Fatalf("newParser: %v", err)
+	}
+
+	get, err := parser.Parse([]string{"gmail", "thread", "get", "thread-1"})
+	if err != nil {
+		t.Fatalf("Parse get: %v", err)
+	}
+	if err := enforceEnabledCommands(get, "", "gmail thread get"); err != nil {
+		t.Fatalf("expected nested path allow: %v", err)
+	}
+
+	// Parent path must not implicitly allow the leaf.
+	if err := enforceEnabledCommands(get, "", "gmail thread"); err == nil {
+		t.Fatalf("expected parent path not to allow nested leaf")
+	}
+
+	modify, err := parser.Parse([]string{"gmail", "thread", "modify", "thread-1", "--add", "INBOX"})
+	if err != nil {
+		t.Fatalf("Parse modify: %v", err)
+	}
+	if err := enforceEnabledCommands(modify, "", "gmail thread get"); err == nil {
+		t.Fatalf("expected sibling nested path denial")
+	}
+}
+
+func TestEnforceEnabledCommands_AliasAllowlistEntries(t *testing.T) {
+	parser, _, err := newParser("test")
+	if err != nil {
+		t.Fatalf("newParser: %v", err)
+	}
+
+	// Allowlist uses aliases; invocation uses canonical names (and the reverse).
+	kctx, err := parser.Parse([]string{"gmail", "search", "is:unread"})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if err := enforceEnabledCommands(kctx, "", "mail search"); err != nil {
+		t.Fatalf("expected alias allowlist entry to match canonical path: %v", err)
+	}
+
+	aliasInvoke, err := parser.Parse([]string{"mail", "search", "is:unread"})
+	if err != nil {
+		t.Fatalf("Parse alias invoke: %v", err)
+	}
+	if err := enforceEnabledCommands(aliasInvoke, "", "gmail search"); err != nil {
+		t.Fatalf("expected alias invocation to match canonical allowlist: %v", err)
+	}
+
+	// Nested command alias must not bypass a leaf restriction.
+	// `read` aliases the `thread` group; with a thread id Kong selects default `get`,
+	// so the canonical leaf identity is still "gmail thread get".
+	read, err := parser.Parse([]string{"gmail", "read", "thread-1"})
+	if err != nil {
+		t.Fatalf("Parse read: %v", err)
+	}
+	if err := enforceEnabledCommands(read, "", "gmail search"); err == nil {
+		t.Fatalf("expected alias invocation to remain restricted")
+	}
+	if err := enforceEnabledCommands(read, "", "gmail thread get"); err != nil {
+		t.Fatalf("expected nested alias invocation to share canonical allow identity: %v", err)
+	}
+	// Allowlisting the group alias alone is still a parent path, not the leaf.
+	if err := enforceEnabledCommands(read, "", "gmail read"); err == nil {
+		t.Fatalf("expected group alias allowlist entry not to allow the default leaf")
+	}
+}
+
+func TestEnforceEnabledCommands_LegacyTopLevelCompatibility(t *testing.T) {
+	parser, _, err := newParser("test")
+	if err != nil {
+		t.Fatalf("newParser: %v", err)
+	}
+
+	cal, err := parser.Parse([]string{"calendar", "colors"})
+	if err != nil {
+		t.Fatalf("Parse calendar: %v", err)
+	}
+	if err := enforceEnabledCommands(cal, "calendar,tasks", ""); err != nil {
+		t.Fatalf("expected legacy top-level allow: %v", err)
+	}
+
+	tasks, err := parser.Parse([]string{"tasks", "lists"})
+	if err != nil {
+		t.Fatalf("Parse tasks: %v", err)
+	}
+	if err := enforceEnabledCommands(tasks, "calendar,tasks", ""); err != nil {
+		t.Fatalf("expected legacy top-level allow for tasks: %v", err)
+	}
+
+	gmail, err := parser.Parse([]string{"gmail", "search", "is:unread"})
+	if err != nil {
+		t.Fatalf("Parse gmail: %v", err)
+	}
+	if err := enforceEnabledCommands(gmail, "calendar,tasks", ""); err == nil {
+		t.Fatalf("expected legacy top-level denial for gmail")
+	}
+}
+
+func TestEnforceEnabledCommands_ORCompositionBetweenAllowlists(t *testing.T) {
+	parser, _, err := newParser("test")
+	if err != nil {
+		t.Fatalf("newParser: %v", err)
+	}
+
+	cal, err := parser.Parse([]string{"calendar", "colors"})
+	if err != nil {
+		t.Fatalf("Parse calendar: %v", err)
+	}
+	search, err := parser.Parse([]string{"gmail", "search", "is:unread"})
+	if err != nil {
+		t.Fatalf("Parse search: %v", err)
+	}
+	send, err := parser.Parse([]string{"gmail", "send", "--to", "a@b.com", "--subject", "s", "--body", "b"})
+	if err != nil {
+		t.Fatalf("Parse send: %v", err)
+	}
+
+	if err := enforceEnabledCommands(cal, "calendar", "gmail search"); err != nil {
+		t.Fatalf("top-level side of OR failed: %v", err)
+	}
+	if err := enforceEnabledCommands(search, "calendar", "gmail search"); err != nil {
+		t.Fatalf("exact-path side of OR failed: %v", err)
+	}
+	if err := enforceEnabledCommands(send, "calendar", "gmail search"); err == nil {
+		t.Fatalf("expected command matching neither allowlist to be denied")
+	}
+}
+
+func TestEnforceEnabledCommands_UnrestrictedWhenNeitherSet(t *testing.T) {
+	parser, _, err := newParser("test")
+	if err != nil {
+		t.Fatalf("newParser: %v", err)
+	}
+	kctx, err := parser.Parse([]string{"gmail", "send", "--to", "a@b.com", "--subject", "s", "--body", "b"})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if err := enforceEnabledCommands(kctx, "", ""); err != nil {
+		t.Fatalf("expected unrestricted when neither allowlist is set: %v", err)
+	}
+	if err := enforceEnabledCommands(kctx, "  ", " , "); err != nil {
+		t.Fatalf("expected unrestricted for empty-ish allowlists: %v", err)
+	}
+	if err := enforceEnabledCommands(kctx, "*", ""); err != nil {
+		t.Fatalf("expected * top-level to remain unrestricted: %v", err)
+	}
+	if err := enforceEnabledCommands(kctx, "all", ""); err != nil {
+		t.Fatalf("expected all top-level to remain unrestricted: %v", err)
+	}
+}
+
+func TestEnforceEnabledCommands_AndCompositionWithPersistedPolicy(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	err := config.WriteConfig(config.File{
+		Policies: []config.Policy{{
+			Name:    "no-send",
+			Account: "user@example.com",
+			Deny:    []string{"gmail:send"},
+			Reason:  "send blocked by policy",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	// Path allowlist permits send, but persisted policy must still deny.
+	errText := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := Execute([]string{
+				"--enable-command-paths", "gmail send",
+				"--account", "user@example.com",
+				"gmail", "send",
+				"--to", "x@y.com",
+				"--subject", "hello",
+				"--body", "body",
+			}); err == nil {
+				t.Fatalf("expected policy denial after path allow")
+			}
+		})
+	})
+	if !strings.Contains(errText, `policy "no-send" denied gmail:send`) {
+		t.Fatalf("missing policy denial: %q", errText)
+	}
+	if strings.Contains(errText, "not enabled") {
+		t.Fatalf("path allowlist should have passed before policy: %q", errText)
+	}
+
+	// Sibling still fails at the enablement gate before policy.
+	errText = captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := Execute([]string{
+				"--enable-command-paths", "gmail search",
+				"--account", "user@example.com",
+				"gmail", "send",
+				"--to", "x@y.com",
+				"--subject", "hello",
+				"--body", "body",
+			}); err == nil {
+				t.Fatalf("expected enablement denial for sibling")
+			}
+		})
+	})
+	if !strings.Contains(errText, "not enabled") {
+		t.Fatalf("expected enablement denial, got: %q", errText)
+	}
+}
+
+func TestEnableCommandPaths_ExecuteSurface(t *testing.T) {
+	err := Execute([]string{"--enable-command-paths", "gmail search", "tasks", "lists"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "not enabled") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/cmd/policy_enforcement.go
+++ b/internal/cmd/policy_enforcement.go
@@ -159,17 +159,7 @@ func policySpecificity(policy config.Policy) int {
 }
 
 func commandActionID(kctx *kong.Context) string {
-	if kctx == nil {
-		return ""
-	}
-	rawParts := strings.Fields(strings.ToLower(strings.TrimSpace(kctx.Command())))
-	parts := make([]string, 0, len(rawParts))
-	for _, part := range rawParts {
-		if strings.HasPrefix(part, "<") && strings.HasSuffix(part, ">") {
-			continue
-		}
-		parts = append(parts, part)
-	}
+	parts := commandPath(kctx)
 	if len(parts) < 2 {
 		return ""
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -35,16 +35,17 @@ var rootHelpDescription = helpDescription
 var maybeNotifyUpdate = selfupdate.MaybeNotify
 
 type RootFlags struct {
-	Color          string `help:"Color output: auto|always|never" default:"${color}"`
-	Account        string `help:"Account email for API commands (gmail/calendar/chat/classroom/drive/docs/slides/contacts/tasks/people/sheets)"`
-	Client         string `help:"OAuth client name (selects stored credentials + token bucket)" default:"${client}"`
-	EnableCommands string `help:"Comma-separated list of enabled top-level commands (restricts CLI)" default:"${enabled_commands}"`
-	JSON           bool   `help:"Output JSON to stdout (best for scripting)" default:"${json}"`
-	Plain          bool   `help:"Output stable, parseable text to stdout (TSV; no colors)" default:"${plain}"`
-	Version        bool   `help:"Print version and exit"`
-	Force          bool   `help:"Skip confirmations for destructive commands"`
-	NoInput        bool   `help:"Never prompt; fail instead (useful for CI)"`
-	Verbose        bool   `help:"Enable verbose logging"`
+	Color              string `help:"Color output: auto|always|never" default:"${color}"`
+	Account            string `help:"Account email for API commands (gmail/calendar/chat/classroom/drive/docs/slides/contacts/tasks/people/sheets)"`
+	Client             string `help:"OAuth client name (selects stored credentials + token bucket)" default:"${client}"`
+	EnableCommands     string `help:"Comma-separated list of enabled top-level commands (restricts CLI)" default:"${enabled_commands}"`
+	EnableCommandPaths string `help:"Comma-separated list of enabled exact command paths (e.g. 'gmail search,calendar events'; restricts CLI)" default:"${enabled_command_paths}"`
+	JSON               bool   `help:"Output JSON to stdout (best for scripting)" default:"${json}"`
+	Plain              bool   `help:"Output stable, parseable text to stdout (TSV; no colors)" default:"${plain}"`
+	Version            bool   `help:"Print version and exit"`
+	Force              bool   `help:"Skip confirmations for destructive commands"`
+	NoInput            bool   `help:"Never prompt; fail instead (useful for CI)"`
+	Verbose            bool   `help:"Enable verbose logging"`
 }
 
 type CLI struct {
@@ -118,7 +119,7 @@ func Execute(args []string) (err error) {
 		return parsedErr
 	}
 
-	if err = enforceEnabledCommands(kctx, cli.EnableCommands); err != nil {
+	if err = enforceEnabledCommands(kctx, cli.EnableCommands, cli.EnableCommandPaths); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, errfmt.Format(err))
 		return err
 	}
@@ -230,14 +231,15 @@ func boolString(v bool) string {
 func newParser(description string) (*kong.Kong, *CLI, error) {
 	envMode := outfmt.FromEnv()
 	vars := kong.Vars{
-		"auth_services":    googleauth.UserServiceCSV(),
-		"color":            envOr("GOG_COLOR", "auto"),
-		"calendar_weekday": envOr("GOG_CALENDAR_WEEKDAY", "false"),
-		"client":           envOr("GOG_CLIENT", ""),
-		"enabled_commands": envOr("GOG_ENABLE_COMMANDS", ""),
-		"json":             boolString(envMode.JSON),
-		"plain":            boolString(envMode.Plain),
-		"version":          VersionString(),
+		"auth_services":         googleauth.UserServiceCSV(),
+		"color":                 envOr("GOG_COLOR", "auto"),
+		"calendar_weekday":      envOr("GOG_CALENDAR_WEEKDAY", "false"),
+		"client":                envOr("GOG_CLIENT", ""),
+		"enabled_commands":      envOr("GOG_ENABLE_COMMANDS", ""),
+		"enabled_command_paths": envOr("GOG_ENABLE_COMMAND_PATHS", ""),
+		"json":                  boolString(envMode.JSON),
+		"plain":                 boolString(envMode.Plain),
+		"version":               VersionString(),
 	}
 
 	cli := &CLI{}

--- a/specs/CLI_DESIGN_SYSTEM.md
+++ b/specs/CLI_DESIGN_SYSTEM.md
@@ -52,7 +52,8 @@ Every command inherits these. Do NOT re-declare them on individual commands.
 | `--force` | bool | false | — | Skip destructive confirmations |
 | `--no-input` | bool | false | — | Never prompt, fail instead |
 | `--verbose` | bool | false | — | Enable debug logging |
-| `--enable-commands` | string | — | `GOG_ENABLE_COMMANDS` | Restrict available commands |
+| `--enable-commands` | string | — | `GOG_ENABLE_COMMANDS` | Restrict available top-level commands |
+| `--enable-command-paths` | string | — | `GOG_ENABLE_COMMAND_PATHS` | Restrict available exact command paths |
 
 ## Output Contract
 


### PR DESCRIPTION
## Summary

- add invocation-scoped exact command-path allowlisting via `--enable-command-paths` and `GOG_ENABLE_COMMAND_PATHS`
- canonicalize documented aliases while keeping parent paths fail-closed and preserving legacy `--enable-commands` behavior
- compose exact and top-level invocation allowlists with existing persisted policy enforcement
- document the new control and add focused coverage for matching, aliases, positional arguments, compatibility, and policy composition

## Testing

- `go test ./internal/cmd -run 'Test(ParseEnabledTopLevelCommands|CommandPath|EnforceEnabledCommands|EnableCommandPaths)' -count=1`
- `go test ./... -count=1`
- `make ci`
- `git diff --check origin/main...HEAD`

## Review

- Sol QC identified and verified authorization-compatibility and lint issues
- Terra applied corrections and reran the full gate
- final Standards review: 0 findings
- final Spec review: 0 findings
- rebased against `origin/main`: clean, no conflicts

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)