### PR TITLE
feat(auth): diagnose auth health in one command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Auth: add `gog auth doctor` for unified read-only diagnostics of config, keyring, OAuth client credentials, stored identities, and refresh-token usability. (#157)
 - Search Console: add `--start-row` to `search-console query` for zero-based Search Analytics result windows. (#98)
 - Tag Manager: add workspace trigger and variable create/delete/get/revert/update commands plus built-in-variable management. (#12, #45, #46, #47)
 - Tag Manager: add composable workspace version creation and container-version publishing commands. (#11)

--- a/README.md
+++ b/README.md
@@ -161,6 +161,13 @@ Show current auth state/services for the active account:
 gog auth status
 ```
 
+Run a read-only auth health check (config, keyring, credentials, accounts, token usability):
+
+```bash
+gog auth doctor
+gog --json auth doctor
+```
+
 ### Multiple OAuth clients
 
 Use `--client` (or `GOG_CLIENT`) to select a named OAuth client:
@@ -536,6 +543,7 @@ gog auth service-account unset <email>             # Remove service account
 gog auth keep <email> --key <path>                 # Legacy alias (Keep)
 gog auth keyring [backend]            # Show/set keyring backend (auto|keychain|file)
 gog auth status                       # Show current auth state/services
+gog auth doctor                       # Read-only auth/keyring/token health check
 gog auth services                     # List available services and OAuth scopes
 gog auth list                         # List stored accounts
 gog auth list --check                 # Validate stored refresh tokens

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -59,6 +59,7 @@ type AuthCmd struct {
 	List        AuthListCmd           `cmd:"" name:"list" help:"List stored accounts"`
 	Aliases     AuthAliasCmd          `cmd:"" name:"alias" help:"Manage account aliases"`
 	Status      AuthStatusCmd         `cmd:"" name:"status" help:"Show auth configuration and keyring backend"`
+	Doctor      AuthDoctorCmd         `cmd:"" name:"doctor" help:"Diagnose auth, keyring, and token health (read-only)"`
 	Keyring     AuthKeyringCmd        `cmd:"" name:"keyring" help:"Configure keyring backend"`
 	Remove      AuthRemoveCmd         `cmd:"" name:"remove" help:"Remove a stored refresh token"`
 	Tokens      AuthTokensCmd         `cmd:"" name:"tokens" help:"Manage stored refresh tokens"`

--- a/internal/cmd/auth_cmd_test.go
+++ b/internal/cmd/auth_cmd_test.go
@@ -97,6 +97,18 @@ func (s *memSecretsStore) ListTokens() ([]secrets.Token, error) {
 	return out, nil
 }
 
+func (s *memSecretsStore) InspectTokens() ([]secrets.TokenInspection, error) {
+	tokens, err := s.ListTokens()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]secrets.TokenInspection, 0, len(tokens))
+	for _, token := range tokens {
+		out = append(out, secrets.TokenInspection{Client: token.Client, Email: token.Email, Token: token})
+	}
+	return out, nil
+}
+
 func (s *memSecretsStore) GetDefaultAccount(client string) (string, error) {
 	if client == "" {
 		client = config.DefaultClientName

--- a/internal/cmd/auth_doctor.go
+++ b/internal/cmd/auth_doctor.go
@@ -1,0 +1,731 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+var openSecretsInspector = secrets.OpenReadOnlyDefault
+
+const (
+	doctorStatusOK   = "ok"
+	doctorStatusWarn = "warn"
+	doctorStatusFail = "fail"
+	doctorStatusSkip = "skip"
+
+	doctorCheckConfig      = "config"
+	doctorCheckKeyring     = "keyring"
+	doctorCheckCredentials = "credentials"
+	doctorCheckAccounts    = "accounts"
+
+	keyringPasswordEnv = "GOG_KEYRING_PASSWORD" //nolint:gosec // env var name, not a credential
+)
+
+// AuthDoctorCmd runs a read-only auth health check.
+type AuthDoctorCmd struct {
+	Timeout time.Duration `name:"timeout" help:"Per-token check timeout" default:"15s"`
+}
+
+type doctorCheck struct {
+	ID       string `json:"id"`
+	Status   string `json:"status"`
+	Summary  string `json:"summary"`
+	Detail   string `json:"detail,omitempty"`
+	Recovery string `json:"recovery,omitempty"`
+}
+
+type doctorReport struct {
+	Status  string        `json:"status"`
+	Healthy bool          `json:"healthy"`
+	Checks  []doctorCheck `json:"checks"`
+}
+
+func (c *AuthDoctorCmd) Run(ctx context.Context) error {
+	report := runAuthDoctor(ctx, c.Timeout)
+	if err := writeAuthDoctorReport(ctx, report); err != nil {
+		return err
+	}
+	if !report.Healthy {
+		return &ExitError{Code: 1, Err: errors.New("auth doctor found problems")}
+	}
+	return nil
+}
+
+func runAuthDoctor(ctx context.Context, timeout time.Duration) doctorReport {
+	checks := make([]doctorCheck, 0, 8)
+	redactSecrets := make([]string, 0, 8)
+
+	checks = append(checks, checkDoctorConfig())
+
+	backendInfo, backendErr := secrets.ResolveKeyringBackendInfo()
+	keyringCheck, inspector, keyringOpenErr := checkDoctorKeyring(backendInfo, backendErr)
+	checks = append(checks, keyringCheck)
+
+	var inspections []secrets.TokenInspection
+	var listTokensErr error
+	if inspector != nil {
+		inspections, listTokensErr = inspector.InspectTokens()
+		for _, inspection := range inspections {
+			if inspection.Err != nil {
+				continue
+			}
+			if token := strings.TrimSpace(inspection.Token.RefreshToken); token != "" {
+				redactSecrets = append(redactSecrets, token)
+			}
+		}
+	}
+
+	credCheck, usableCreds, clientSecrets := checkDoctorCredentials(oauthTokenClients(inspections))
+	checks = append(checks, credCheck)
+	redactSecrets = append(redactSecrets, clientSecrets...)
+
+	// Service-account files are independent of keyring access.
+	saEmails, listSAErr := config.ListServiceAccountEmails()
+
+	accountsCheck := checkDoctorAccounts(inspector != nil, keyringOpenErr, inspections, listTokensErr, saEmails, listSAErr)
+	checks = append(checks, accountsCheck)
+
+	tokenChecks := checkDoctorTokens(ctx, timeout, inspector != nil, keyringOpenErr, inspections, listTokensErr, saEmails, listSAErr, usableCreds, redactSecrets)
+	checks = append(checks, tokenChecks...)
+
+	return finalizeDoctorReport(checks)
+}
+
+func checkDoctorConfig() doctorCheck {
+	path, err := config.ConfigPath()
+	if err != nil {
+		return doctorCheck{
+			ID:       doctorCheckConfig,
+			Status:   doctorStatusFail,
+			Summary:  "could not resolve config path",
+			Detail:   err.Error(),
+			Recovery: "Ensure home/config directories are writable, then re-run gog auth doctor.",
+		}
+	}
+
+	exists, err := config.ConfigExists()
+	if err != nil {
+		return doctorCheck{
+			ID:       doctorCheckConfig,
+			Status:   doctorStatusFail,
+			Summary:  "config is not readable",
+			Detail:   fmt.Sprintf("path=%s; %s", path, err.Error()),
+			Recovery: fmt.Sprintf("Fix permissions on %s or remove a corrupt config file.", path),
+		}
+	}
+	if !exists {
+		return doctorCheck{
+			ID:      doctorCheckConfig,
+			Status:  doctorStatusOK,
+			Summary: "config file not present; defaults will be used",
+			Detail:  fmt.Sprintf("path=%s", path),
+		}
+	}
+
+	if _, err := config.ReadConfig(); err != nil {
+		return doctorCheck{
+			ID:       doctorCheckConfig,
+			Status:   doctorStatusFail,
+			Summary:  "config exists but could not be parsed",
+			Detail:   fmt.Sprintf("path=%s; %s", path, err.Error()),
+			Recovery: fmt.Sprintf("Fix or remove the corrupt config at %s.", path),
+		}
+	}
+
+	return doctorCheck{
+		ID:      doctorCheckConfig,
+		Status:  doctorStatusOK,
+		Summary: "config readable",
+		Detail:  fmt.Sprintf("path=%s exists=true", path),
+	}
+}
+
+func checkDoctorKeyring(backendInfo secrets.KeyringBackendInfo, backendErr error) (doctorCheck, secrets.TokenInspector, error) {
+	if backendErr != nil {
+		return doctorCheck{
+			ID:       doctorCheckKeyring,
+			Status:   doctorStatusFail,
+			Summary:  "could not resolve keyring backend",
+			Detail:   backendErr.Error(),
+			Recovery: "Check config.json keyring_backend and GOG_KEYRING_BACKEND (auto|keychain|file).",
+		}, nil, backendErr
+	}
+
+	detail := fmt.Sprintf("backend=%s source=%s", backendInfo.Value, backendInfo.Source)
+	inspector, openErr := openSecretsInspector()
+	if openErr != nil {
+		if secrets.IsKeyringStorageMissing(openErr) {
+			return doctorCheck{
+				ID:      doctorCheckKeyring,
+				Status:  doctorStatusSkip,
+				Summary: "no OAuth keyring storage present",
+				Detail:  detail,
+			}, nil, nil
+		}
+
+		return doctorCheck{
+			ID:       doctorCheckKeyring,
+			Status:   doctorStatusFail,
+			Summary:  "keyring is not accessible",
+			Detail:   joinDoctorDetail(detail, openErr.Error()),
+			Recovery: keyringRecoveryHint(backendInfo, openErr),
+		}, nil, openErr
+	}
+
+	// Soft warning for headless file-backend setups without a configured password.
+	if backendInfo.Value == strFile {
+		if strings.TrimSpace(os.Getenv(keyringPasswordEnv)) == "" && !term.IsTerminal(int(os.Stdin.Fd())) {
+			return doctorCheck{
+				ID:       doctorCheckKeyring,
+				Status:   doctorStatusWarn,
+				Summary:  "file keyring accessible, but non-interactive use needs a password",
+				Detail:   detail,
+				Recovery: fmt.Sprintf("Set %s for non-interactive/file keyring use.", keyringPasswordEnv),
+			}, inspector, nil
+		}
+	}
+
+	return doctorCheck{
+		ID:      doctorCheckKeyring,
+		Status:  doctorStatusOK,
+		Summary: "keyring accessible",
+		Detail:  detail,
+	}, inspector, nil
+}
+
+func keyringRecoveryHint(info secrets.KeyringBackendInfo, openErr error) string {
+	msg := openErr.Error()
+	switch {
+	case secrets.IsKeychainLockedError(msg):
+		return "Unlock the macOS login keychain (security unlock-keychain), then re-run gog auth doctor."
+	case strings.Contains(msg, keyringPasswordEnv) || strings.Contains(msg, "no TTY"):
+		return fmt.Sprintf("Set GOG_KEYRING_BACKEND=file and %s=<password> for headless/file keyring use.", keyringPasswordEnv)
+	case strings.Contains(msg, "timed out") || strings.Contains(strings.ToLower(msg), "dbus"):
+		return fmt.Sprintf("Secret Service may be unavailable. Set GOG_KEYRING_BACKEND=file and %s=<password>.", keyringPasswordEnv)
+	case info.Value == "keychain":
+		return "Ensure OS keychain access is allowed, or switch with: gog auth keyring file"
+	default:
+		return fmt.Sprintf("Check keyring backend (%s). For headless environments: gog auth keyring file and set %s.", info.Value, keyringPasswordEnv)
+	}
+}
+
+func oauthTokenClients(inspections []secrets.TokenInspection) []string {
+	clients := make(map[string]struct{}, len(inspections))
+	for _, inspection := range inspections {
+		if normalizeEmail(inspection.Email) == "" {
+			continue
+		}
+		client := strings.TrimSpace(inspection.Client)
+		if client == "" {
+			client = config.DefaultClientName
+		}
+		clients[client] = struct{}{}
+	}
+
+	out := make([]string, 0, len(clients))
+	for client := range clients {
+		out = append(out, client)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func checkDoctorCredentials(requiredClients []string) (doctorCheck, []config.ClientCredentialsInfo, []string) {
+	storedCreds, listErr := config.ListClientCredentials()
+	if listErr != nil {
+		return doctorCheck{
+			ID:       doctorCheckCredentials,
+			Status:   doctorStatusFail,
+			Summary:  "could not list OAuth client credentials",
+			Detail:   listErr.Error(),
+			Recovery: "Ensure the gog config directory is readable, then re-run gog auth doctor.",
+		}, nil, nil
+	}
+
+	candidates := make(map[string]config.ClientCredentialsInfo, len(storedCreds)+len(requiredClients))
+	for _, info := range storedCreds {
+		candidates[info.Client] = info
+	}
+	for _, client := range requiredClients {
+		if _, ok := candidates[client]; ok {
+			continue
+		}
+		path, _ := config.ClientCredentialsPathFor(client)
+		candidates[client] = config.ClientCredentialsInfo{
+			Client:  client,
+			Path:    path,
+			Default: client == config.DefaultClientName,
+		}
+	}
+
+	if len(candidates) == 0 {
+		return doctorCheck{
+			ID:      doctorCheckCredentials,
+			Status:  doctorStatusSkip,
+			Summary: "no OAuth client credentials stored or required",
+			Detail:  "stored=0 required=0",
+		}, nil, nil
+	}
+
+	clients := make([]string, 0, len(candidates))
+	for client := range candidates {
+		clients = append(clients, client)
+	}
+	sort.Strings(clients)
+
+	usable := make([]config.ClientCredentialsInfo, 0, len(clients))
+	usableClients := make([]string, 0, len(clients))
+	failures := make([]string, 0)
+	secretValues := make([]string, 0, len(clients)*2)
+	for _, client := range clients {
+		stored, err := config.ReadClientCredentialsFor(client)
+		if err != nil {
+			failures = append(failures, client)
+			continue
+		}
+
+		usable = append(usable, candidates[client])
+		usableClients = append(usableClients, client)
+		secretValues = append(secretValues, stored.ClientSecret, stored.ClientID)
+	}
+
+	if len(failures) > 0 {
+		recovery := "Replace each unusable credential set with: gog --client <client> auth credentials <credentials.json>"
+		if len(failures) == 1 && failures[0] == config.DefaultClientName {
+			recovery = "Download a Desktop OAuth client JSON from Google Cloud Console, then run: gog auth credentials <credentials.json>"
+		}
+		return doctorCheck{
+			ID:       doctorCheckCredentials,
+			Status:   doctorStatusFail,
+			Summary:  fmt.Sprintf("%d of %d OAuth client credential set(s) usable", len(usable), len(clients)),
+			Detail:   joinDoctorDetail("usable_clients="+strings.Join(usableClients, ","), "unusable_clients="+strings.Join(failures, ",")),
+			Recovery: recovery,
+		}, usable, secretValues
+	}
+
+	return doctorCheck{
+		ID:      doctorCheckCredentials,
+		Status:  doctorStatusOK,
+		Summary: fmt.Sprintf("%d OAuth client credential set(s) available", len(usable)),
+		Detail:  fmt.Sprintf("clients=%s", strings.Join(usableClients, ",")),
+	}, usable, secretValues
+}
+
+func checkDoctorAccounts(
+	keyringOpen bool,
+	keyringErr error,
+	inspections []secrets.TokenInspection,
+	listTokensErr error,
+	saEmails []string,
+	listSAErr error,
+) doctorCheck {
+	if listSAErr != nil {
+		return doctorCheck{
+			ID:       doctorCheckAccounts,
+			Status:   doctorStatusFail,
+			Summary:  "could not list service-account identities",
+			Detail:   listSAErr.Error(),
+			Recovery: "Ensure the gog config directory is readable.",
+		}
+	}
+
+	saSet := make(map[string]struct{}, len(saEmails))
+	for _, email := range saEmails {
+		if email = normalizeEmail(email); email != "" {
+			saSet[email] = struct{}{}
+		}
+	}
+
+	if !keyringOpen {
+		if keyringErr == nil {
+			if len(saSet) == 0 {
+				return doctorCheck{
+					ID:       doctorCheckAccounts,
+					Status:   doctorStatusFail,
+					Summary:  "no stored accounts",
+					Detail:   "oauth=0 service_account=0",
+					Recovery: "Authorize an account with gog auth add <email>, or configure a Workspace service account with gog auth service-account set <email> --key <path>.",
+				}
+			}
+
+			return doctorCheck{
+				ID:      doctorCheckAccounts,
+				Status:  doctorStatusOK,
+				Summary: fmt.Sprintf("%d service-account identity(s) stored", len(saSet)),
+				Detail:  fmt.Sprintf("total=%d oauth_only=0 service_account_only=%d both=0", len(saSet), len(saSet)),
+			}
+		}
+
+		return doctorCheck{
+			ID:       doctorCheckAccounts,
+			Status:   doctorStatusSkip,
+			Summary:  fmt.Sprintf("OAuth account listing skipped; %d service-account identity(s) found", len(saSet)),
+			Detail:   joinDoctorDetail(errString(keyringErr), fmt.Sprintf("service_account=%d", len(saSet))),
+			Recovery: "Restore keyring access, then re-run gog auth doctor.",
+		}
+	}
+	if listTokensErr != nil {
+		return doctorCheck{
+			ID:       doctorCheckAccounts,
+			Status:   doctorStatusFail,
+			Summary:  fmt.Sprintf("could not list stored OAuth tokens; %d service-account identity(s) found", len(saSet)),
+			Detail:   joinDoctorDetail(listTokensErr.Error(), fmt.Sprintf("service_account=%d", len(saSet))),
+			Recovery: "Restore keyring access or re-import tokens with gog auth tokens import.",
+		}
+	}
+
+	oauthEmails := make(map[string]struct{}, len(inspections))
+	for _, inspection := range inspections {
+		if email := normalizeEmail(inspection.Email); email != "" {
+			oauthEmails[email] = struct{}{}
+		}
+	}
+
+	all := make(map[string]struct{}, len(oauthEmails)+len(saSet))
+	for email := range oauthEmails {
+		all[email] = struct{}{}
+	}
+	for email := range saSet {
+		all[email] = struct{}{}
+	}
+
+	if len(all) == 0 {
+		return doctorCheck{
+			ID:       doctorCheckAccounts,
+			Status:   doctorStatusFail,
+			Summary:  "no stored accounts",
+			Detail:   "oauth=0 service_account=0",
+			Recovery: "Authorize an account with gog auth add <email>, or configure a Workspace service account with gog auth service-account set <email> --key <path>.",
+		}
+	}
+
+	oauthOnly, saOnly, both := 0, 0, 0
+	for email := range all {
+		_, hasOAuth := oauthEmails[email]
+		_, hasSA := saSet[email]
+		switch {
+		case hasOAuth && hasSA:
+			both++
+		case hasOAuth:
+			oauthOnly++
+		case hasSA:
+			saOnly++
+		}
+	}
+
+	return doctorCheck{
+		ID:      doctorCheckAccounts,
+		Status:  doctorStatusOK,
+		Summary: fmt.Sprintf("%d account(s) stored", len(all)),
+		Detail:  fmt.Sprintf("total=%d oauth_only=%d service_account_only=%d both=%d", len(all), oauthOnly, saOnly, both),
+	}
+}
+
+func checkDoctorTokens(
+	ctx context.Context,
+	timeout time.Duration,
+	keyringOpen bool,
+	keyringErr error,
+	inspections []secrets.TokenInspection,
+	listTokensErr error,
+	saEmails []string,
+	listSAErr error,
+	creds []config.ClientCredentialsInfo,
+	redactSecrets []string,
+) []doctorCheck {
+	saSet := make(map[string]struct{}, len(saEmails))
+	if listSAErr == nil {
+		for _, email := range saEmails {
+			if email = normalizeEmail(email); email != "" {
+				saSet[email] = struct{}{}
+			}
+		}
+	}
+
+	if !keyringOpen {
+		oauthCheck := doctorCheck{
+			ID:      "tokens",
+			Status:  doctorStatusSkip,
+			Summary: "no OAuth keyring storage present",
+		}
+		if keyringErr != nil {
+			oauthCheck.Summary = "skipped OAuth token checks because keyring is inaccessible"
+			oauthCheck.Detail = errString(keyringErr)
+			oauthCheck.Recovery = "Restore keyring access, then re-run gog auth doctor."
+		}
+
+		out := make([]doctorCheck, 0, 1+len(saSet))
+		out = append(out, oauthCheck)
+		for email := range saSet {
+			out = append(out, serviceAccountTokenCheck(email))
+		}
+		sort.Slice(out[1:], func(i, j int) bool { return out[i+1].ID < out[j+1].ID })
+		return out
+	}
+	if listTokensErr != nil {
+		out := make([]doctorCheck, 0, 1+len(saSet))
+		out = append(out, doctorCheck{
+			ID:      "tokens",
+			Status:  doctorStatusSkip,
+			Summary: "skipped OAuth token checks because tokens could not be listed",
+			Detail:  listTokensErr.Error(),
+		})
+		for email := range saSet {
+			out = append(out, serviceAccountTokenCheck(email))
+		}
+		sort.Slice(out[1:], func(i, j int) bool { return out[i+1].ID < out[j+1].ID })
+		return out
+	}
+
+	credClients := make(map[string]struct{}, len(creds))
+	for _, info := range creds {
+		credClients[info.Client] = struct{}{}
+	}
+
+	// Stable order: service-account-only identities first by email, then OAuth tokens by email/client.
+	type identity struct {
+		email      string
+		client     string
+		inspection *secrets.TokenInspection
+		saOnly     bool
+	}
+	idents := make([]identity, 0, len(inspections)+len(saSet))
+	oauthEmails := make(map[string]struct{}, len(inspections))
+	for i := range inspections {
+		inspection := &inspections[i]
+		email := normalizeEmail(inspection.Email)
+		if email == "" {
+			continue
+		}
+		client := strings.TrimSpace(inspection.Client)
+		if client == "" {
+			client = config.DefaultClientName
+		}
+		oauthEmails[email] = struct{}{}
+		idents = append(idents, identity{email: email, client: client, inspection: inspection})
+	}
+	for email := range saSet {
+		if _, ok := oauthEmails[email]; !ok {
+			idents = append(idents, identity{email: email, saOnly: true})
+		}
+	}
+	sort.Slice(idents, func(i, j int) bool {
+		if idents[i].email != idents[j].email {
+			return idents[i].email < idents[j].email
+		}
+		if idents[i].saOnly != idents[j].saOnly {
+			return idents[i].saOnly
+		}
+		return idents[i].client < idents[j].client
+	})
+
+	if len(idents) == 0 {
+		return []doctorCheck{{
+			ID:      "tokens",
+			Status:  doctorStatusSkip,
+			Summary: "no accounts available for token checks",
+		}}
+	}
+
+	out := make([]doctorCheck, 0, len(idents))
+	for _, id := range idents {
+		if id.saOnly {
+			out = append(out, serviceAccountTokenCheck(id.email))
+			continue
+		}
+
+		checkID := doctorTokenCheckID(id.email, id.client)
+		detail := fmt.Sprintf("email=%s client=%s auth=oauth", id.email, id.client)
+		if _, ok := saSet[id.email]; ok {
+			detail = fmt.Sprintf("email=%s client=%s auth=oauth+service_account", id.email, id.client)
+		}
+
+		if id.inspection.Err != nil {
+			out = append(out, doctorCheck{
+				ID:       checkID,
+				Status:   doctorStatusFail,
+				Summary:  "stored OAuth token could not be read",
+				Detail:   joinDoctorDetail(detail, "token_data=unreadable"),
+				Recovery: fmt.Sprintf("Re-authorize the account: gog auth add %s --force-consent", id.email),
+			})
+			continue
+		}
+
+		if _, ok := credClients[id.client]; !ok {
+			path, _ := config.ClientCredentialsPathFor(id.client)
+			out = append(out, doctorCheck{
+				ID:       checkID,
+				Status:   doctorStatusFail,
+				Summary:  "OAuth client credentials unavailable for token client",
+				Detail:   joinDoctorDetail(detail, fmt.Sprintf("credentials_path=%s", path)),
+				Recovery: fmt.Sprintf("Store usable credentials for client %q: gog --client %s auth credentials <credentials.json>", id.client, id.client),
+			})
+			continue
+		}
+
+		tok := id.inspection.Token
+		if strings.TrimSpace(tok.RefreshToken) == "" {
+			out = append(out, doctorCheck{
+				ID:       checkID,
+				Status:   doctorStatusFail,
+				Summary:  "stored OAuth token is missing a refresh token",
+				Detail:   detail,
+				Recovery: fmt.Sprintf("Re-authorize: gog auth add %s --force-consent", id.email),
+			})
+			continue
+		}
+
+		if err := checkRefreshToken(ctx, id.client, tok.RefreshToken, tok.Scopes, timeout); err != nil {
+			out = append(out, doctorCheck{
+				ID:       checkID,
+				Status:   doctorStatusFail,
+				Summary:  "OAuth refresh token is not usable",
+				Detail:   joinDoctorDetail(detail, redactDoctorText(err.Error(), redactSecrets...)),
+				Recovery: fmt.Sprintf("Re-authorize the account: gog auth add %s --force-consent", id.email),
+			})
+			continue
+		}
+
+		out = append(out, doctorCheck{
+			ID:      checkID,
+			Status:  doctorStatusOK,
+			Summary: "OAuth refresh token is usable",
+			Detail:  detail,
+		})
+	}
+	return out
+}
+
+func doctorTokenCheckID(email, client string) string {
+	if client == config.DefaultClientName {
+		return "token:" + email
+	}
+	return "token:" + email + ":" + client
+}
+
+func serviceAccountTokenCheck(email string) doctorCheck {
+	return doctorCheck{
+		ID:      "token:" + email,
+		Status:  doctorStatusSkip,
+		Summary: "service-account identity; OAuth refresh-token check not applicable",
+		Detail:  "auth=service_account",
+	}
+}
+
+func finalizeDoctorReport(checks []doctorCheck) doctorReport {
+	status := doctorStatusOK
+	healthy := true
+	for _, c := range checks {
+		switch c.Status {
+		case doctorStatusFail:
+			status = doctorStatusFail
+			healthy = false
+		case doctorStatusWarn:
+			if status == doctorStatusOK {
+				status = doctorStatusWarn
+			}
+		}
+	}
+	return doctorReport{
+		Status:  status,
+		Healthy: healthy,
+		Checks:  checks,
+	}
+}
+
+func writeAuthDoctorReport(ctx context.Context, report doctorReport) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, report)
+	}
+
+	u := ui.FromContext(ctx)
+	if u == nil {
+		return nil
+	}
+
+	if outfmt.IsPlain(ctx) {
+		// --plain keeps a stable four-column check schema for scripts.
+		u.Out().Printf("status\t%s", report.Status)
+		u.Out().Printf("healthy\t%t", report.Healthy)
+		for _, c := range report.Checks {
+			u.Out().Printf("check\t%s\t%s\t%s\t%s",
+				sanitizePlainField(c.ID),
+				sanitizePlainField(c.Status),
+				sanitizePlainField(c.Summary),
+				sanitizePlainField(c.Detail),
+			)
+		}
+	} else {
+		u.Out().Printf("Auth doctor: %s", strings.ToUpper(report.Status))
+		for _, c := range report.Checks {
+			u.Out().Printf("[%s] %s: %s", strings.ToUpper(c.Status), c.ID, c.Summary)
+			if c.Detail != "" {
+				u.Out().Printf("  %s", c.Detail)
+			}
+		}
+	}
+
+	var tips []string
+	for _, c := range report.Checks {
+		if c.Recovery == "" {
+			continue
+		}
+		if c.Status == doctorStatusFail || c.Status == doctorStatusWarn {
+			tips = append(tips, fmt.Sprintf("%s: %s", c.ID, c.Recovery))
+		}
+	}
+	if len(tips) > 0 {
+		u.Err().Println("Recovery hints:")
+		for _, tip := range tips {
+			u.Err().Printf("- %s", tip)
+		}
+	}
+	return nil
+}
+
+func joinDoctorDetail(parts ...string) string {
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return strings.Join(out, "; ")
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func redactDoctorText(s string, secretValues ...string) string {
+	out := s
+	// Longest first to avoid partial overlaps leaving remnants.
+	sort.SliceStable(secretValues, func(i, j int) bool { return len(secretValues[i]) > len(secretValues[j]) })
+	for _, secret := range secretValues {
+		secret = strings.TrimSpace(secret)
+		if secret == "" {
+			continue
+		}
+		if strings.Contains(out, secret) {
+			out = strings.ReplaceAll(out, secret, "[redacted]")
+		}
+	}
+	return out
+}

--- a/internal/cmd/auth_doctor.go
+++ b/internal/cmd/auth_doctor.go
@@ -647,7 +647,7 @@ func finalizeDoctorReport(checks []doctorCheck) doctorReport {
 
 func writeAuthDoctorReport(ctx context.Context, report doctorReport) error {
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, report)
+		return outfmt.WriteJSON(ctx, os.Stdout, report)
 	}
 
 	u := ui.FromContext(ctx)

--- a/internal/cmd/auth_doctor_test.go
+++ b/internal/cmd/auth_doctor_test.go
@@ -1,0 +1,703 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func setupDoctorEnv(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	t.Setenv("GOG_KEYRING_BACKEND", "file")
+	t.Setenv("GOG_KEYRING_PASSWORD", "test-password")
+}
+
+func writeDoctorCredentials(t *testing.T) {
+	t.Helper()
+	if err := config.WriteClientCredentials(config.ClientCredentials{
+		ClientID:     "client-id",
+		ClientSecret: "super-secret-value",
+	}); err != nil {
+		t.Fatalf("WriteClientCredentials: %v", err)
+	}
+}
+
+func withDoctorSeams(t *testing.T, inspector secrets.TokenInspector, check func(context.Context, string, string, []string, time.Duration) error) {
+	t.Helper()
+	origOpen := openSecretsInspector
+	origCheck := checkRefreshToken
+	t.Cleanup(func() {
+		openSecretsInspector = origOpen
+		checkRefreshToken = origCheck
+	})
+	openSecretsInspector = func() (secrets.TokenInspector, error) {
+		if inspector == nil {
+			return nil, errors.New("keyring unavailable: simulated")
+		}
+		return inspector, nil
+	}
+	if check == nil {
+		check = func(context.Context, string, string, []string, time.Duration) error { return nil }
+	}
+	checkRefreshToken = check
+}
+
+func doctorUIContext(t *testing.T, mode outfmt.Mode) context.Context {
+	t.Helper()
+	u, err := ui.New(ui.Options{Stdout: os.Stdout, Stderr: os.Stderr, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	return outfmt.WithMode(ui.WithUI(context.Background(), u), mode)
+}
+
+func parseDoctorJSON(t *testing.T, raw string) doctorReport {
+	t.Helper()
+	var report doctorReport
+	if err := json.Unmarshal([]byte(raw), &report); err != nil {
+		t.Fatalf("decode doctor JSON: %v\nout=%q", err, raw)
+	}
+	return report
+}
+
+func checkByID(t *testing.T, report doctorReport, id string) doctorCheck {
+	t.Helper()
+	for _, c := range report.Checks {
+		if c.ID == id {
+			return c
+		}
+	}
+	t.Fatalf("check %q not found in %#v", id, report.Checks)
+	return doctorCheck{}
+}
+
+func TestAuthDoctor_Healthy_JSON(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+
+	store := newMemSecretsStore()
+	if err := store.SetToken(config.DefaultClientName, "a@b.com", secrets.Token{
+		Services:     []string{"gmail"},
+		Scopes:       []string{"s1"},
+		RefreshToken: "rt-good",
+	}); err != nil {
+		t.Fatalf("SetToken: %v", err)
+	}
+	withDoctorSeams(t, store, func(_ context.Context, client, refresh string, _ []string, _ time.Duration) error {
+		if client != config.DefaultClientName || refresh != "rt-good" {
+			return errors.New("unexpected token args")
+		}
+		return nil
+	})
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			runErr = (&AuthDoctorCmd{}).Run(ctx)
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("expected success, got %v", runErr)
+	}
+	if ExitCode(runErr) != 0 {
+		t.Fatalf("expected exit 0, got %d", ExitCode(runErr))
+	}
+
+	report := parseDoctorJSON(t, out)
+	if !report.Healthy || report.Status != doctorStatusOK {
+		t.Fatalf("expected healthy ok report, got %#v", report)
+	}
+	if checkByID(t, report, doctorCheckConfig).Status != doctorStatusOK {
+		t.Fatalf("config check: %#v", checkByID(t, report, doctorCheckConfig))
+	}
+	if checkByID(t, report, doctorCheckKeyring).Status != doctorStatusOK {
+		t.Fatalf("keyring check: %#v", checkByID(t, report, doctorCheckKeyring))
+	}
+	if checkByID(t, report, doctorCheckCredentials).Status != doctorStatusOK {
+		t.Fatalf("credentials check: %#v", checkByID(t, report, doctorCheckCredentials))
+	}
+	if checkByID(t, report, doctorCheckAccounts).Status != doctorStatusOK {
+		t.Fatalf("accounts check: %#v", checkByID(t, report, doctorCheckAccounts))
+	}
+	tok := checkByID(t, report, "token:a@b.com")
+	if tok.Status != doctorStatusOK {
+		t.Fatalf("token check: %#v", tok)
+	}
+	if strings.Contains(out, "super-secret-value") || strings.Contains(out, "rt-good") {
+		t.Fatalf("secrets leaked in JSON output: %q", out)
+	}
+}
+
+func TestAuthDoctor_MissingCredentials(t *testing.T) {
+	setupDoctorEnv(t)
+	store := newMemSecretsStore()
+	_ = store.SetToken(config.DefaultClientName, "a@b.com", secrets.Token{RefreshToken: "rt"})
+	withDoctorSeams(t, store, nil)
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			runErr = (&AuthDoctorCmd{}).Run(ctx)
+		})
+	})
+	if ExitCode(runErr) == 0 {
+		t.Fatalf("expected non-zero exit, err=%v out=%q", runErr, out)
+	}
+	report := parseDoctorJSON(t, out)
+	if report.Healthy || report.Status != doctorStatusFail {
+		t.Fatalf("expected unhealthy fail, got %#v", report)
+	}
+	cred := checkByID(t, report, doctorCheckCredentials)
+	if cred.Status != doctorStatusFail || !strings.Contains(cred.Recovery, "gog auth credentials") {
+		t.Fatalf("unexpected credentials check: %#v", cred)
+	}
+}
+
+func TestAuthDoctor_InaccessibleKeyring(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+	withDoctorSeams(t, nil, nil)
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			runErr = (&AuthDoctorCmd{}).Run(ctx)
+		})
+	})
+	if ExitCode(runErr) == 0 {
+		t.Fatalf("expected non-zero exit, err=%v", runErr)
+	}
+	report := parseDoctorJSON(t, out)
+	if report.Healthy {
+		t.Fatalf("expected unhealthy: %#v", report)
+	}
+	if checkByID(t, report, doctorCheckKeyring).Status != doctorStatusFail {
+		t.Fatalf("keyring: %#v", checkByID(t, report, doctorCheckKeyring))
+	}
+	if checkByID(t, report, doctorCheckAccounts).Status != doctorStatusSkip {
+		t.Fatalf("accounts should skip: %#v", checkByID(t, report, doctorCheckAccounts))
+	}
+	if checkByID(t, report, "tokens").Status != doctorStatusSkip {
+		t.Fatalf("tokens should skip: %#v", checkByID(t, report, "tokens"))
+	}
+	// Independent checks still ran.
+	if checkByID(t, report, doctorCheckConfig).Status != doctorStatusOK {
+		t.Fatalf("config should still run: %#v", checkByID(t, report, doctorCheckConfig))
+	}
+	if checkByID(t, report, doctorCheckCredentials).Status != doctorStatusOK {
+		t.Fatalf("stored credentials should still be inspected: %#v", checkByID(t, report, doctorCheckCredentials))
+	}
+}
+
+func TestAuthDoctor_NoAccounts(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+	withDoctorSeams(t, newMemSecretsStore(), nil)
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			runErr = (&AuthDoctorCmd{}).Run(ctx)
+		})
+	})
+	if ExitCode(runErr) == 0 {
+		t.Fatalf("expected non-zero exit, err=%v out=%q", runErr, out)
+	}
+	report := parseDoctorJSON(t, out)
+	acc := checkByID(t, report, doctorCheckAccounts)
+	if acc.Status != doctorStatusFail || !strings.Contains(acc.Recovery, "gog auth add") {
+		t.Fatalf("unexpected accounts check: %#v", acc)
+	}
+}
+
+func TestAuthDoctor_InvalidToken(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+	store := newMemSecretsStore()
+	_ = store.SetToken(config.DefaultClientName, "a@b.com", secrets.Token{RefreshToken: "rt-bad"})
+	withDoctorSeams(t, store, func(context.Context, string, string, []string, time.Duration) error {
+		return errors.New("refresh access token: invalid_grant")
+	})
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			runErr = (&AuthDoctorCmd{}).Run(ctx)
+		})
+	})
+	if ExitCode(runErr) == 0 {
+		t.Fatalf("expected non-zero exit, err=%v", runErr)
+	}
+	report := parseDoctorJSON(t, out)
+	tok := checkByID(t, report, "token:a@b.com")
+	if tok.Status != doctorStatusFail || !strings.Contains(tok.Recovery, "gog auth add a@b.com") {
+		t.Fatalf("unexpected token check: %#v", tok)
+	}
+}
+
+func TestAuthDoctor_ServiceAccountOnly(t *testing.T) {
+	setupDoctorEnv(t)
+	withDoctorSeams(t, newMemSecretsStore(), nil)
+
+	email := "sa-user@example.com"
+	keyPath := filepath.Join(t.TempDir(), "sa.json")
+	if err := os.WriteFile(keyPath, []byte(`{"type":"service_account","client_email":"svc@example.com","private_key":"x"}`), 0o600); err != nil {
+		t.Fatalf("write sa key: %v", err)
+	}
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"auth", "service-account", "set", email, "--key", keyPath}); err != nil {
+				t.Fatalf("service-account set: %v", err)
+			}
+		})
+	})
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			runErr = (&AuthDoctorCmd{}).Run(ctx)
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("expected success for SA-only, got %v out=%q", runErr, out)
+	}
+	report := parseDoctorJSON(t, out)
+	if !report.Healthy {
+		t.Fatalf("expected healthy SA-only report: %#v", report)
+	}
+	if credentials := checkByID(t, report, doctorCheckCredentials); credentials.Status != doctorStatusSkip {
+		t.Fatalf("service-account-only setup should not require OAuth credentials: %#v", credentials)
+	}
+	tok := checkByID(t, report, "token:"+normalizeEmail(email))
+	if tok.Status != doctorStatusSkip || !strings.Contains(tok.Summary, "not applicable") {
+		t.Fatalf("expected SA token skip, got %#v", tok)
+	}
+	if strings.Contains(strings.ToLower(tok.Summary), "usable") {
+		t.Fatalf("SA identity must not look OAuth-validated: %#v", tok)
+	}
+}
+
+func TestAuthDoctor_MultiAccountPartialFailure(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+	store := newMemSecretsStore()
+	_ = store.SetToken(config.DefaultClientName, "good@example.com", secrets.Token{RefreshToken: "rt-good"})
+	_ = store.SetToken(config.DefaultClientName, "bad@example.com", secrets.Token{RefreshToken: "rt-bad"})
+	withDoctorSeams(t, store, func(_ context.Context, _ string, refresh string, _ []string, _ time.Duration) error {
+		if refresh == "rt-bad" {
+			return errors.New("refresh access token: revoked")
+		}
+		return nil
+	})
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			runErr = (&AuthDoctorCmd{}).Run(ctx)
+		})
+	})
+	if ExitCode(runErr) == 0 {
+		t.Fatalf("expected non-zero exit, err=%v", runErr)
+	}
+	report := parseDoctorJSON(t, out)
+	if checkByID(t, report, "token:good@example.com").Status != doctorStatusOK {
+		t.Fatalf("good token missing/failed: %#v", report.Checks)
+	}
+	if checkByID(t, report, "token:bad@example.com").Status != doctorStatusFail {
+		t.Fatalf("bad token missing/failed: %#v", report.Checks)
+	}
+}
+
+func TestAuthDoctor_PlainAndHumanOutput(t *testing.T) {
+	setupDoctorEnv(t)
+	// An OAuth token without credentials fails with recovery guidance.
+	store := newMemSecretsStore()
+	_ = store.SetToken(config.DefaultClientName, "a@b.com", secrets.Token{RefreshToken: "rt"})
+	withDoctorSeams(t, store, nil)
+
+	// Plain: parseable stdout; recovery guidance stays on stderr.
+	var plainOut, plainErrOut bytes.Buffer
+	plainUI, err := ui.New(ui.Options{Stdout: &plainOut, Stderr: &plainErrOut, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New plain: %v", err)
+	}
+	plainCtx := outfmt.WithMode(ui.WithUI(context.Background(), plainUI), outfmt.Mode{Plain: true})
+	plainErr := (&AuthDoctorCmd{}).Run(plainCtx)
+	if ExitCode(plainErr) == 0 {
+		t.Fatalf("expected non-zero plain exit")
+	}
+	if !strings.Contains(plainOut.String(), "status\tfail") || !strings.Contains(plainOut.String(), "healthy\tfalse") {
+		t.Fatalf("plain missing status rows: %q", plainOut.String())
+	}
+	if !strings.Contains(plainOut.String(), "check\tcredentials\tfail\t") {
+		t.Fatalf("plain missing credentials check: %q", plainOut.String())
+	}
+	if strings.Contains(plainOut.String(), "gog auth credentials") {
+		t.Fatalf("plain stdout must not include recovery guidance: %q", plainOut.String())
+	}
+	if !strings.Contains(plainErrOut.String(), "Recovery hints:") || !strings.Contains(plainErrOut.String(), "gog auth credentials") {
+		t.Fatalf("plain recovery guidance should be on stderr: %q", plainErrOut.String())
+	}
+
+	// Human: stdout is readable rather than the stable --plain TSV.
+	var humanOut, humanErrOut bytes.Buffer
+	humanUI, err := ui.New(ui.Options{Stdout: &humanOut, Stderr: &humanErrOut, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New human: %v", err)
+	}
+	humanCtx := outfmt.WithMode(ui.WithUI(context.Background(), humanUI), outfmt.Mode{})
+	humanErr := (&AuthDoctorCmd{}).Run(humanCtx)
+	if ExitCode(humanErr) == 0 {
+		t.Fatalf("expected non-zero human exit")
+	}
+	if !strings.Contains(humanOut.String(), "Auth doctor: FAIL") || !strings.Contains(humanOut.String(), "[FAIL] credentials:") {
+		t.Fatalf("human stdout should summarize checks: %q", humanOut.String())
+	}
+	if strings.Contains(humanOut.String(), "status\tfail") {
+		t.Fatalf("human stdout should differ from --plain TSV: %q", humanOut.String())
+	}
+	if !strings.Contains(humanErrOut.String(), "Recovery hints:") || !strings.Contains(humanErrOut.String(), "gog auth credentials") {
+		t.Fatalf("expected recovery hints on stderr: %q", humanErrOut.String())
+	}
+}
+
+func TestAuthDoctor_RedactsSecretsInTokenErrors(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+	store := newMemSecretsStore()
+	secretRT := "rt-should-not-leak-12345"
+	_ = store.SetToken(config.DefaultClientName, "a@b.com", secrets.Token{RefreshToken: secretRT})
+	withDoctorSeams(t, store, func(context.Context, string, string, []string, time.Duration) error {
+		return errors.New("refresh failed using token " + secretRT + " and secret super-secret-value")
+	})
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			runErr = (&AuthDoctorCmd{}).Run(ctx)
+		})
+	})
+	if ExitCode(runErr) == 0 {
+		t.Fatalf("expected failure")
+	}
+	if strings.Contains(out, secretRT) || strings.Contains(out, "super-secret-value") {
+		t.Fatalf("secret material leaked: %q", out)
+	}
+	report := parseDoctorJSON(t, out)
+	detail := checkByID(t, report, "token:a@b.com").Detail
+	if !strings.Contains(detail, "[redacted]") {
+		t.Fatalf("expected redacted detail, got %q", detail)
+	}
+}
+
+func TestAuthDoctor_WarningOnlyExitsZero(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+	// Force file backend via env (already set) and clear password + non-TTY stdin simulation
+	// by relying on checkDoctorKeyring warning path: backend file, no password env, non-terminal stdin.
+	t.Setenv("GOG_KEYRING_PASSWORD", "")
+
+	store := newMemSecretsStore()
+	_ = store.SetToken(config.DefaultClientName, "a@b.com", secrets.Token{RefreshToken: "rt"})
+	withDoctorSeams(t, store, nil)
+
+	// Ensure stdin is not a terminal by pointing to a pipe-backed file.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	_ = w.Close()
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			runErr = (&AuthDoctorCmd{}).Run(ctx)
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("warning-only should exit successfully, got %v out=%q", runErr, out)
+	}
+	report := parseDoctorJSON(t, out)
+	if !report.Healthy || report.Status != doctorStatusWarn {
+		t.Fatalf("expected healthy warn report, got %#v", report)
+	}
+	if checkByID(t, report, doctorCheckKeyring).Status != doctorStatusWarn {
+		t.Fatalf("expected keyring warn: %#v", checkByID(t, report, doctorCheckKeyring))
+	}
+}
+
+func TestAuthDoctor_PartiallyConfiguredContinues(t *testing.T) {
+	setupDoctorEnv(t)
+	// Empty accounts fail, while unused OAuth credentials are not required.
+	withDoctorSeams(t, newMemSecretsStore(), nil)
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			runErr = (&AuthDoctorCmd{}).Run(ctx)
+		})
+	})
+	if ExitCode(runErr) == 0 {
+		t.Fatalf("expected unhealthy")
+	}
+	report := parseDoctorJSON(t, out)
+	for _, id := range []string{doctorCheckConfig, doctorCheckKeyring, doctorCheckCredentials, doctorCheckAccounts} {
+		if checkByID(t, report, id).ID == "" {
+			t.Fatalf("missing check %s", id)
+		}
+	}
+	if checkByID(t, report, doctorCheckCredentials).Status != doctorStatusSkip {
+		t.Fatalf("credentials should skip without OAuth tokens")
+	}
+	if checkByID(t, report, doctorCheckAccounts).Status != doctorStatusFail {
+		t.Fatalf("accounts should fail")
+	}
+}
+
+func TestAuthDoctor_ExecuteWiring(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+	store := newMemSecretsStore()
+	_ = store.SetToken(config.DefaultClientName, "a@b.com", secrets.Token{RefreshToken: "rt"})
+	withDoctorSeams(t, store, nil)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "auth", "doctor"}); err != nil {
+				t.Fatalf("Execute auth doctor: %v", err)
+			}
+		})
+	})
+	report := parseDoctorJSON(t, out)
+	if !report.Healthy {
+		t.Fatalf("expected healthy via Execute: %#v", report)
+	}
+}
+
+type doctorTokenInspector struct {
+	inspections []secrets.TokenInspection
+	err         error
+}
+
+func (s doctorTokenInspector) InspectTokens() ([]secrets.TokenInspection, error) {
+	return s.inspections, s.err
+}
+
+func TestAuthDoctor_CorruptCredentialSetFailsWithoutLeakingValues(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+
+	path, err := config.ClientCredentialsPathFor("work")
+	if err != nil {
+		t.Fatalf("credentials path: %v", err)
+	}
+	const corruptValue = `{"client_id":"not-for-output","client_secret":"not-for-output"`
+	if err := os.WriteFile(path, []byte(corruptValue), 0o600); err != nil {
+		t.Fatalf("write corrupt credentials: %v", err)
+	}
+	withDoctorSeams(t, doctorTokenInspector{inspections: []secrets.TokenInspection{{
+		Client: "work",
+		Email:  "work@example.com",
+		Token:  secrets.Token{RefreshToken: "rt-work"},
+	}}}, nil)
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() { runErr = (&AuthDoctorCmd{}).Run(ctx) })
+	})
+	if ExitCode(runErr) == 0 {
+		t.Fatalf("expected corrupt credentials to fail")
+	}
+	report := parseDoctorJSON(t, out)
+	credentials := checkByID(t, report, doctorCheckCredentials)
+	if credentials.Status != doctorStatusFail || !strings.Contains(credentials.Detail, "unusable_clients=work") {
+		t.Fatalf("expected per-client credential failure, got %#v", credentials)
+	}
+	if strings.Contains(out, "not-for-output") {
+		t.Fatalf("credential material leaked: %q", out)
+	}
+}
+
+func TestAuthDoctor_ServiceAccountsStillListedWhenKeyringFails(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+
+	email := "sa-user@example.com"
+	keyPath := filepath.Join(t.TempDir(), "sa.json")
+	if err := os.WriteFile(keyPath, []byte(`{"type":"service_account","client_email":"svc@example.com","private_key":"x"}`), 0o600); err != nil {
+		t.Fatalf("write service account key: %v", err)
+	}
+	if _, _, err := storeServiceAccountKey(email, keyPath); err != nil {
+		t.Fatalf("store service account: %v", err)
+	}
+	withDoctorSeams(t, nil, nil)
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() { runErr = (&AuthDoctorCmd{}).Run(ctx) })
+	})
+	if ExitCode(runErr) == 0 {
+		t.Fatalf("expected inaccessible keyring to fail")
+	}
+	report := parseDoctorJSON(t, out)
+	accounts := checkByID(t, report, doctorCheckAccounts)
+	if accounts.Status != doctorStatusSkip || !strings.Contains(accounts.Summary, "1 service-account") {
+		t.Fatalf("service account discovery should survive keyring failure: %#v", accounts)
+	}
+	if token := checkByID(t, report, "token:"+email); token.Status != doctorStatusSkip || !strings.Contains(token.Summary, "not applicable") {
+		t.Fatalf("service account token check: %#v", token)
+	}
+}
+
+func TestAuthDoctor_CorruptTokenDoesNotSuppressOtherTokensOrLeakDecodeData(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+	const sensitiveMarker = "refresh-token-should-not-appear"
+	malformedStoredJSON := `{"refresh_token":"` + sensitiveMarker + `"`
+	var ignored map[string]any
+	decodeErr := json.Unmarshal([]byte(malformedStoredJSON), &ignored)
+	if decodeErr == nil {
+		t.Fatal("expected malformed stored JSON to fail decoding")
+	}
+	inspector := doctorTokenInspector{inspections: []secrets.TokenInspection{
+		{Client: config.DefaultClientName, Email: "good@example.com", Token: secrets.Token{RefreshToken: "rt-good"}},
+		{
+			Client: "work",
+			Email:  "bad@example.com",
+			Token:  secrets.Token{RefreshToken: sensitiveMarker},
+			Err:    fmt.Errorf("decode stored token %s: %w", malformedStoredJSON, decodeErr),
+		},
+	}}
+	withDoctorSeams(t, inspector, nil)
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() { runErr = (&AuthDoctorCmd{}).Run(ctx) })
+	})
+	if ExitCode(runErr) == 0 {
+		t.Fatalf("expected corrupt token to fail")
+	}
+	if strings.Contains(out, sensitiveMarker) || strings.Contains(out, malformedStoredJSON) {
+		t.Fatalf("corrupt token data leaked: %q", out)
+	}
+
+	report := parseDoctorJSON(t, out)
+	if checkByID(t, report, "token:good@example.com").Status != doctorStatusOK {
+		t.Fatalf("good token missing from report: %#v", report.Checks)
+	}
+	bad := checkByID(t, report, "token:bad@example.com:work")
+	if bad.Status != doctorStatusFail || !strings.Contains(bad.Summary, "could not be read") {
+		t.Fatalf("corrupt token should have its own failure: %#v", bad)
+	}
+	if !strings.Contains(bad.Detail, "token_data=unreadable") || strings.Contains(bad.Detail, "decode stored token") {
+		t.Fatalf("corrupt token should use a safe classified error: %#v", bad)
+	}
+}
+
+func TestAuthDoctor_ServiceAccountOnlyWithoutKeyringStorageIsHealthy(t *testing.T) {
+	setupDoctorEnv(t)
+
+	email := "sa-only@example.com"
+	keyPath := filepath.Join(t.TempDir(), "sa.json")
+	if err := os.WriteFile(keyPath, []byte(`{"type":"service_account","client_email":"svc@example.com","private_key":"x"}`), 0o600); err != nil {
+		t.Fatalf("write service account key: %v", err)
+	}
+	if _, _, err := storeServiceAccountKey(email, keyPath); err != nil {
+		t.Fatalf("store service account: %v", err)
+	}
+
+	ctx := doctorUIContext(t, outfmt.Mode{JSON: true})
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() { runErr = (&AuthDoctorCmd{}).Run(ctx) })
+	})
+	if runErr != nil {
+		t.Fatalf("service-account-only setup should be healthy: %v\nout=%s", runErr, out)
+	}
+
+	report := parseDoctorJSON(t, out)
+	if keyring := checkByID(t, report, doctorCheckKeyring); keyring.Status != doctorStatusSkip {
+		t.Fatalf("absent OAuth keyring should skip: %#v", keyring)
+	}
+	if accounts := checkByID(t, report, doctorCheckAccounts); accounts.Status != doctorStatusOK {
+		t.Fatalf("service-account identity should be healthy: %#v", accounts)
+	}
+	if token := checkByID(t, report, "token:"+email); token.Status != doctorStatusSkip {
+		t.Fatalf("service-account token check should be not applicable: %#v", token)
+	}
+}
+
+func TestAuthDoctor_TokenListFailureStillReportsServiceAccounts(t *testing.T) {
+	setupDoctorEnv(t)
+
+	email := "sa-user@example.com"
+	keyPath := filepath.Join(t.TempDir(), "sa.json")
+	if err := os.WriteFile(keyPath, []byte(`{"type":"service_account","client_email":"svc@example.com","private_key":"x"}`), 0o600); err != nil {
+		t.Fatalf("write service account key: %v", err)
+	}
+	if _, _, err := storeServiceAccountKey(email, keyPath); err != nil {
+		t.Fatalf("store service account: %v", err)
+	}
+	withDoctorSeams(t, doctorTokenInspector{err: errors.New("list failed")}, nil)
+
+	report := runAuthDoctor(doctorUIContext(t, outfmt.Mode{JSON: true}), time.Second)
+	accounts := checkByID(t, report, doctorCheckAccounts)
+	if accounts.Status != doctorStatusFail || !strings.Contains(accounts.Summary, "1 service-account") {
+		t.Fatalf("account failure should retain service-account count: %#v", accounts)
+	}
+	if token := checkByID(t, report, "token:"+email); token.Status != doctorStatusSkip {
+		t.Fatalf("service-account token check should survive OAuth list failure: %#v", token)
+	}
+}
+
+func TestAuthDoctor_TokenCheckIDsIncludeNonDefaultClient(t *testing.T) {
+	setupDoctorEnv(t)
+	writeDoctorCredentials(t)
+	if err := config.WriteClientCredentialsFor("work", config.ClientCredentials{ClientID: "work-id", ClientSecret: "work-secret"}); err != nil {
+		t.Fatalf("write work credentials: %v", err)
+	}
+	store := newMemSecretsStore()
+	_ = store.SetToken(config.DefaultClientName, "same@example.com", secrets.Token{RefreshToken: "rt-default"})
+	_ = store.SetToken("work", "same@example.com", secrets.Token{RefreshToken: "rt-work"})
+	withDoctorSeams(t, store, nil)
+
+	report := runAuthDoctor(doctorUIContext(t, outfmt.Mode{JSON: true}), time.Second)
+	if checkByID(t, report, "token:same@example.com").Status != doctorStatusOK {
+		t.Fatalf("default-client token check missing: %#v", report.Checks)
+	}
+	if checkByID(t, report, "token:same@example.com:work").Status != doctorStatusOK {
+		t.Fatalf("work-client token check missing: %#v", report.Checks)
+	}
+}

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -25,6 +25,18 @@ type Store interface {
 	SetDefaultAccount(client string, email string) error
 }
 
+// TokenInspector exposes read-only token diagnostics without triggering legacy-token migration.
+type TokenInspector interface {
+	InspectTokens() ([]TokenInspection, error)
+}
+
+type TokenInspection struct {
+	Client string
+	Email  string
+	Token  Token
+	Err    error
+}
+
 type KeyringStore struct {
 	ring keyring.Keyring
 }
@@ -50,6 +62,7 @@ var (
 	errNoTTY                 = errors.New("no TTY available for keyring file backend password prompt")
 	errInvalidKeyringBackend = errors.New("invalid keyring backend")
 	errKeyringTimeout        = errors.New("keyring connection timed out")
+	errReadOnlyFileKeyring   = errors.New("file keyring directory does not exist; refusing to create it during read-only inspection")
 	openKeyringFunc          = openKeyring
 	keyringOpenFunc          = keyring.Open
 )
@@ -158,14 +171,24 @@ func shouldUseKeyringTimeout(goos string, backendInfo KeyringBackendInfo, dbusAd
 }
 
 func openKeyring() (keyring.Keyring, error) {
-	// On Linux/WSL/containers, OS keychains (secret-service/kwallet) may be unavailable.
-	// In that case github.com/99designs/keyring falls back to the "file" backend,
-	// which *requires* both a directory and a password prompt function.
 	keyringDir, err := config.EnsureKeyringDir()
 	if err != nil {
 		return nil, fmt.Errorf("ensure keyring dir: %w", err)
 	}
 
+	return openKeyringAt(keyringDir, false)
+}
+
+func openKeyringReadOnly() (keyring.Keyring, error) {
+	keyringDir, err := config.KeyringDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve keyring dir: %w", err)
+	}
+
+	return openKeyringAt(keyringDir, true)
+}
+
+func openKeyringAt(keyringDir string, readOnly bool) (keyring.Keyring, error) {
 	backendInfo, err := ResolveKeyringBackendInfo()
 	if err != nil {
 		return nil, err
@@ -182,6 +205,19 @@ func openKeyring() (keyring.Keyring, error) {
 	// trying to connect (common on headless systems like Raspberry Pi).
 	if shouldForceFileBackend(runtime.GOOS, backendInfo, dbusAddr) {
 		backends = []keyring.BackendType{keyring.FileBackend}
+	}
+
+	if readOnly {
+		if _, statErr := os.Stat(keyringDir); statErr != nil {
+			if !os.IsNotExist(statErr) {
+				return nil, fmt.Errorf("stat keyring dir: %w", statErr)
+			}
+
+			backends = withoutFileBackend(backends)
+			if len(backends) == 0 {
+				return nil, errReadOnlyFileKeyring
+			}
+		}
 	}
 
 	cfg := keyring.Config{
@@ -211,6 +247,21 @@ func openKeyring() (keyring.Keyring, error) {
 	}
 
 	return ring, nil
+}
+
+func withoutFileBackend(backends []keyring.BackendType) []keyring.BackendType {
+	if backends == nil {
+		backends = keyring.AvailableBackends()
+	}
+
+	out := make([]keyring.BackendType, 0, len(backends))
+	for _, backend := range backends {
+		if backend != keyring.FileBackend {
+			out = append(out, backend)
+		}
+	}
+
+	return out
 }
 
 type keyringResult struct {
@@ -249,6 +300,20 @@ func openKeyringWithTimeout(cfg keyring.Config, timeout time.Duration) (keyring.
 
 func OpenDefault() (Store, error) {
 	ring, err := openKeyringFunc()
+	if err != nil {
+		return nil, err
+	}
+
+	return &KeyringStore{ring: ring}, nil
+}
+
+func IsKeyringStorageMissing(err error) bool {
+	return errors.Is(err, errReadOnlyFileKeyring)
+}
+
+// OpenReadOnlyDefault opens a token inspector that will not create keyring storage.
+func OpenReadOnlyDefault() (TokenInspector, error) {
+	ring, err := openKeyringReadOnly()
 	if err != nil {
 		return nil, err
 	}
@@ -427,6 +492,80 @@ func (s *KeyringStore) DeleteToken(client string, email string) error {
 	}
 
 	return nil
+}
+
+func (s *KeyringStore) InspectTokens() ([]TokenInspection, error) {
+	keys, err := s.Keys()
+	if err != nil {
+		return nil, fmt.Errorf("list tokens: %w", err)
+	}
+
+	out := make([]TokenInspection, 0)
+	seen := make(map[string]struct{})
+
+	for _, key := range keys {
+		client, email, ok := ParseTokenKey(key)
+		if !ok {
+			continue
+		}
+
+		identity := client + "\n" + email
+		if _, ok := seen[identity]; ok {
+			continue
+		}
+		seen[identity] = struct{}{}
+
+		inspection := TokenInspection{Client: client, Email: email}
+
+		token, err := s.getTokenReadOnly(client, email)
+		if err != nil {
+			inspection.Err = fmt.Errorf("read token: %w", err)
+		} else {
+			inspection.Token = token
+		}
+
+		out = append(out, inspection)
+	}
+
+	return out, nil
+}
+
+func (s *KeyringStore) getTokenReadOnly(client string, email string) (Token, error) {
+	email = normalize(email)
+	if email == "" {
+		return Token{}, errMissingEmail
+	}
+
+	normalizedClient, err := normalizeClient(client)
+	if err != nil {
+		return Token{}, err
+	}
+
+	item, err := s.ring.Get(tokenKey(normalizedClient, email))
+	if err != nil {
+		if normalizedClient != config.DefaultClientName {
+			return Token{}, fmt.Errorf("read token: %w", err)
+		}
+
+		item, err = s.ring.Get(legacyTokenKey(email))
+		if err != nil {
+			return Token{}, fmt.Errorf("read legacy token: %w", err)
+		}
+	}
+
+	var st storedToken
+	if err := json.Unmarshal(item.Data, &st); err != nil {
+		return Token{}, fmt.Errorf("decode token: %w", err)
+	}
+
+	return Token{
+		Client:       normalizedClient,
+		Email:        email,
+		Services:     st.Services,
+		Scopes:       st.Scopes,
+		CreatedAt:    st.CreatedAt,
+		RefreshToken: st.RefreshToken,
+	}, nil
 }
 
 func (s *KeyringStore) ListTokens() ([]Token, error) {

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -267,6 +268,77 @@ func TestOpenKeyring_NoDBus_ForcesFileBackend(t *testing.T) {
 
 	if store == nil {
 		t.Fatal("expected non-nil store")
+	}
+}
+
+func TestOpenReadOnlyDefault_DoesNotCreateFileKeyringDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	t.Setenv("GOG_KEYRING_BACKEND", "file")
+	t.Setenv("GOG_KEYRING_PASSWORD", "testpw")
+
+	keyringDir, err := config.KeyringDir()
+	if err != nil {
+		t.Fatalf("KeyringDir: %v", err)
+	}
+
+	if _, err := OpenReadOnlyDefault(); err == nil {
+		t.Fatal("expected missing file keyring directory to be reported")
+	}
+
+	if _, err := os.Stat(keyringDir); !os.IsNotExist(err) {
+		t.Fatalf("read-only open created keyring dir %q: %v", keyringDir, err)
+	}
+}
+
+func TestKeyringStoreInspectTokens_IsReadOnlyAndContinues(t *testing.T) {
+	ring := keyring.NewArrayKeyring(nil)
+	store := &KeyringStore{ring: ring}
+
+	payload, marshalErr := json.Marshal(storedToken{RefreshToken: "good-refresh-token"})
+	if marshalErr != nil {
+		t.Fatalf("encode token: %v", marshalErr)
+	}
+
+	if err := ring.Set(keyring.Item{Key: legacyTokenKey("legacy@example.com"), Data: payload}); err != nil {
+		t.Fatalf("store legacy token: %v", err)
+	}
+
+	if err := ring.Set(keyring.Item{Key: tokenKey("work", "corrupt@example.com"), Data: []byte("not json")}); err != nil {
+		t.Fatalf("store corrupt token: %v", err)
+	}
+
+	inspections, err := store.InspectTokens()
+	if err != nil {
+		t.Fatalf("InspectTokens: %v", err)
+	}
+
+	if len(inspections) != 2 {
+		t.Fatalf("expected two inspections, got %#v", inspections)
+	}
+
+	var legacy, corrupt TokenInspection
+
+	for _, inspection := range inspections {
+		switch inspection.Email {
+		case "legacy@example.com":
+			legacy = inspection
+		case "corrupt@example.com":
+			corrupt = inspection
+		}
+	}
+
+	if legacy.Err != nil || legacy.Token.RefreshToken != "good-refresh-token" {
+		t.Fatalf("legacy token inspection: %#v", legacy)
+	}
+
+	if corrupt.Err == nil {
+		t.Fatalf("corrupt token should have an inspection error: %#v", corrupt)
+	}
+
+	if _, err := ring.Get(tokenKey(config.DefaultClientName, "legacy@example.com")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("read-only inspection migrated legacy token: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `gog auth doctor` for a unified read-only health report covering config, keyring state, OAuth credentials, stored identities, and refresh-token usability
- provide distinct human, stable plain TSV, and JSON output with per-check statuses, safe recovery guidance, and nonzero exit status for actionable failures
- add a non-migrating token inspection path so diagnostics neither create keyring storage nor rewrite legacy tokens, while isolating corrupt entries and service-account checks
- preserve multi-client identity semantics and redact credential material from all diagnostic details

## Testing

- `go test ./internal/cmd ./internal/secrets -count=1`
- `make ci`
- Grok implementation, Sol review/QC, Terra correction passes, and final blocking review with no findings

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
