### PR TITLE
feat(cli): expose machine-readable command schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- CLI: add `gog schema` for deterministic, versioned JSON discovery of commands, flags, exit codes, and effective automation safeguards. (#152)
 - Search Console: add `--start-row` to `search-console query` for zero-based Search Analytics result windows. (#98)
 - Tag Manager: add workspace trigger and variable create/delete/get/revert/update commands plus built-in-variable management. (#12, #45, #46, #47)
 - Tag Manager: add composable workspace version creation and container-version publishing commands. (#11)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Help:
 - `gog --help` shows top-level command groups.
 - Drill down with `gog <group> --help` (and deeper subcommands).
 - For the full expanded command list: `GOG_HELP=full gog --help`.
+- For machine-readable discovery: `gog schema` emits one deterministic, versioned JSON document describing visible commands, aliases, arguments, flags, global flags, exit-code classes, and effective automation/policy state.
+- `gog schema` is read-only and remains available under `--enable-commands` restrictions; it does not authenticate, call Google APIs, prompt, check for updates, write configuration, or expose stored credentials and secret environment values.
 - Make shortcut: `make gog -- --help` (or `make gog -- gmail --help`).
 - `make gog-help` shows CLI help (note: `make gog --help` is Make’s own help; use `--`).
 

--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -27,7 +27,7 @@ type CalendarCreateCmd struct {
 	ColorId               string   `name:"event-color" help:"Event color ID (1-11). Use 'gog calendar colors' to see available colors."`
 	Visibility            string   `name:"visibility" help:"Event visibility: default, public, private, confidential"`
 	Transparency          string   `name:"transparency" help:"Show as busy (opaque) or free (transparent). Aliases: busy, free"`
-	SendUpdates           string   `name:"send-updates" help:"Notification mode: all, externalOnly, none (default: all)"`
+	SendUpdates           string   `name:"send-updates" help:"Notification mode: all, externalOnly, none (default: all)" default:"all"`
 	GuestsCanInviteOthers *bool    `name:"guests-can-invite" help:"Allow guests to invite others"`
 	GuestsCanModify       *bool    `name:"guests-can-modify" help:"Allow guests to modify event"`
 	GuestsCanSeeOthers    *bool    `name:"guests-can-see-others" help:"Allow guests to see other guests"`

--- a/internal/cmd/calendar_events_edit.go
+++ b/internal/cmd/calendar_events_edit.go
@@ -268,7 +268,7 @@ func (c *CalendarEventsInstancesCmd) Run(ctx context.Context, flags *RootFlags) 
 type CalendarEventsQuickAddCmd struct {
 	CalendarID string `arg:"" name:"calendarId" help:"Calendar ID (default: primary)"`
 	Text       string `arg:"" name:"text" help:"Event description (e.g., 'Meeting tomorrow at 3pm')"`
-	SendUpdate string `name:"send-updates" help:"Notification mode: all, externalOnly, none (default: all)"`
+	SendUpdate string `name:"send-updates" help:"Notification mode: all, externalOnly, none (default: all)" default:"all"`
 }
 
 func (c *CalendarEventsQuickAddCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -320,7 +320,7 @@ type CalendarEventsMoveCmd struct {
 	SourceCalendarID      string `arg:"" name:"sourceCalendarId" help:"Source calendar ID (default: primary)"`
 	EventID               string `arg:"" name:"eventId" help:"Event ID"`
 	DestinationCalendarID string `arg:"" name:"destinationCalendarId" help:"Destination calendar ID"`
-	SendUpdate            string `name:"send-updates" help:"Notification mode: all, externalOnly, none (default: all)"`
+	SendUpdate            string `name:"send-updates" help:"Notification mode: all, externalOnly, none (default: all)" default:"all"`
 }
 
 func (c *CalendarEventsMoveCmd) Run(ctx context.Context, flags *RootFlags) error {

--- a/internal/cmd/calendar_focus_time.go
+++ b/internal/cmd/calendar_focus_time.go
@@ -77,7 +77,7 @@ func validateAutoDeclineMode(s string) (string, error) {
 	switch s {
 	case "", "none":
 		return "declineNone", nil
-	case "all":
+	case scopeAll:
 		return "declineAllConflictingInvitations", nil
 	case "new":
 		return "declineOnlyNewConflictingInvitations", nil

--- a/internal/cmd/calendar_focus_time.go
+++ b/internal/cmd/calendar_focus_time.go
@@ -77,7 +77,7 @@ func validateAutoDeclineMode(s string) (string, error) {
 	switch s {
 	case "", "none":
 		return "declineNone", nil
-	case scopeAll:
+	case "all":
 		return "declineAllConflictingInvitations", nil
 	case "new":
 		return "declineOnlyNewConflictingInvitations", nil

--- a/internal/cmd/enabled_commands.go
+++ b/internal/cmd/enabled_commands.go
@@ -23,7 +23,7 @@ func enforceEnabledCommands(kctx *kong.Context, enabled string) error {
 		return nil
 	}
 	top := strings.ToLower(cmd[0])
-	if top == "schema" {
+	if isSchemaCommand(kctx.Command()) {
 		return nil
 	}
 	if !allow[top] {

--- a/internal/cmd/enabled_commands.go
+++ b/internal/cmd/enabled_commands.go
@@ -23,6 +23,9 @@ func enforceEnabledCommands(kctx *kong.Context, enabled string) error {
 		return nil
 	}
 	top := strings.ToLower(cmd[0])
+	if top == "schema" {
+		return nil
+	}
 	if !allow[top] {
 		return usagef("command %q is not enabled (set --enable-commands to allow it)", top)
 	}

--- a/internal/cmd/policy_enforcement.go
+++ b/internal/cmd/policy_enforcement.go
@@ -93,22 +93,7 @@ func hasPolicyForService(policies []config.Policy, service string) bool {
 }
 
 func evaluatePolicies(policies []config.Policy, action string, account string, client string) policyDecision {
-	var candidates []config.Policy
-	bestSpecificity := -1
-	for _, policy := range policies {
-		if !policyApplies(policy, account, client) {
-			continue
-		}
-		specificity := policySpecificity(policy)
-		if specificity > bestSpecificity {
-			bestSpecificity = specificity
-			candidates = []config.Policy{policy}
-			continue
-		}
-		if specificity == bestSpecificity {
-			candidates = append(candidates, policy)
-		}
-	}
+	candidates := mostSpecificApplicablePolicies(policies, account, client)
 	if len(candidates) == 0 {
 		return policyDecision{}
 	}
@@ -135,6 +120,26 @@ func evaluatePolicies(policies []config.Policy, action string, account string, c
 	}
 
 	return policyDecision{}
+}
+
+func mostSpecificApplicablePolicies(policies []config.Policy, account string, client string) []config.Policy {
+	var candidates []config.Policy
+	bestSpecificity := -1
+	for _, policy := range policies {
+		if !policyApplies(policy, account, client) {
+			continue
+		}
+		specificity := policySpecificity(policy)
+		if specificity > bestSpecificity {
+			bestSpecificity = specificity
+			candidates = []config.Policy{policy}
+			continue
+		}
+		if specificity == bestSpecificity {
+			candidates = append(candidates, policy)
+		}
+	}
+	return candidates
 }
 
 func policyApplies(policy config.Policy, account string, client string) bool {

--- a/internal/cmd/policy_enforcement.go
+++ b/internal/cmd/policy_enforcement.go
@@ -33,6 +33,10 @@ type policyDecision struct {
 }
 
 func enforceCommandPolicies(kctx *kong.Context, flags *RootFlags) error {
+	if isSchemaCommand(kctx.Command()) {
+		return nil
+	}
+
 	cfg, err := config.ReadConfig()
 	if err != nil {
 		return fmt.Errorf("read config: %w", err)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -75,6 +75,7 @@ type CLI struct {
 	Policy          PolicyCmd             `cmd:"" help:"Manage command safety policies"`
 	Update          UpdateCmd             `cmd:"" help:"Update gog binary and companion Google skills"`
 	Skills          SkillsCmd             `cmd:"" help:"Manage companion Google skill pack (pack skills only)"`
+	Schema          SchemaCmd             `cmd:"" help:"Print machine-readable CLI schema as JSON"`
 	VersionCmd      VersionCmd            `cmd:"" name:"version" help:"Print version"`
 	Completion      CompletionCmd         `cmd:"" help:"Generate shell completion scripts"`
 	Complete        CompletionInternalCmd `cmd:"" name:"__complete" hidden:"" help:"Internal completion helper"`
@@ -163,9 +164,9 @@ func Execute(args []string) (err error) {
 	kctx.Bind(&cli.RootFlags)
 
 	// Throttled non-fatal update notice for humans and agents (stderr only).
-	// Shell completion must stay fast/deterministic: never touch update cache
-	// or the release service for completion-script generation or __complete.
-	if !isCompletionCommand(kctx.Command()) {
+	// Local discovery and shell completion must stay deterministic: never touch
+	// the update cache or release service for schema, completion, or __complete.
+	if !skipsUpdateCheck(kctx.Command()) {
 		if notice := maybeNotifyUpdate(ctx, &selfupdate.Client{
 			Repo:  strings.TrimSpace(os.Getenv("GOG_UPDATE_REPO")),
 			Token: envOr("GITHUB_TOKEN", envOr("GH_TOKEN", "")),
@@ -205,15 +206,14 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
-// isCompletionCommand reports whether the parsed kong command is shell-completion
-// related and must bypass background update checks.
-func isCompletionCommand(command string) bool {
+// skipsUpdateCheck reports whether a command must remain local and deterministic.
+func skipsUpdateCheck(command string) bool {
 	parts := strings.Fields(command)
 	if len(parts) == 0 {
 		return false
 	}
 	switch parts[0] {
-	case "completion", "__complete":
+	case "completion", "__complete", "schema":
 		return true
 	default:
 		return false

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -36,7 +36,7 @@ var maybeNotifyUpdate = selfupdate.MaybeNotify
 
 type RootFlags struct {
 	Color          string `help:"Color output: auto|always|never" default:"${color}"`
-	Account        string `help:"Account email for API commands (gmail/calendar/chat/classroom/drive/docs/slides/contacts/tasks/people/sheets)"`
+	Account        string `help:"Account email for API commands (gmail/calendar/chat/classroom/drive/docs/slides/contacts/tasks/people/sheets)" schema-default-env:"GOG_ACCOUNT"`
 	Client         string `help:"OAuth client name (selects stored credentials + token bucket)" default:"${client}"`
 	EnableCommands string `help:"Comma-separated list of enabled top-level commands (restricts CLI)" default:"${enabled_commands}"`
 	JSON           bool   `help:"Output JSON to stdout (best for scripting)" default:"${json}"`
@@ -204,6 +204,11 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func isSchemaCommand(command string) bool {
+	parts := strings.Fields(command)
+	return len(parts) > 0 && parts[0] == "schema"
 }
 
 // skipsUpdateCheck reports whether a command must remain local and deterministic.

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -269,6 +269,11 @@ func schemaDefault(value *kong.Value) string {
 	if value.HasDefault {
 		return value.Default
 	}
+	if value.Tag != nil {
+		if envName := value.Tag.Get("schema-default-env"); envName != "" {
+			return strings.TrimSpace(os.Getenv(envName))
+		}
+	}
 	if !value.Target.IsValid() {
 		return ""
 	}

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -1,0 +1,302 @@
+package cmd
+
+import (
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+const schemaVersion = "1"
+
+type SchemaCmd struct{}
+
+type schemaDocument struct {
+	SchemaVersion string           `json:"schema_version"`
+	Commands      []schemaCommand  `json:"commands"`
+	GlobalFlags   []schemaValue    `json:"global_flags"`
+	ExitCodes     []schemaExitCode `json:"exit_codes"`
+	Automation    schemaAutomation `json:"automation"`
+}
+
+type schemaExitCode struct {
+	Code        int    `json:"code"`
+	Class       string `json:"class"`
+	Description string `json:"description"`
+}
+
+type schemaAutomation struct {
+	JSON            bool               `json:"json"`
+	Plain           bool               `json:"plain"`
+	NoInput         bool               `json:"no_input"`
+	Force           bool               `json:"force"`
+	AccountInput    string             `json:"account_input"`
+	ClientInput     string             `json:"client_input"`
+	Account         string             `json:"account"`
+	Client          string             `json:"client"`
+	EnabledCommands schemaEnabledState `json:"enabled_commands"`
+	Policy          schemaPolicyState  `json:"policy"`
+}
+
+type schemaEnabledState struct {
+	Input      string   `json:"input"`
+	Restricted bool     `json:"restricted"`
+	Allowed    []string `json:"allowed"`
+}
+
+type schemaPolicyState struct {
+	Status           string               `json:"status"`
+	UnresolvedReason string               `json:"unresolved_reason,omitempty"`
+	Effects          []schemaPolicyEffect `json:"effects"`
+}
+
+type schemaPolicyEffect struct {
+	Name   string   `json:"name"`
+	Allow  []string `json:"allow"`
+	Deny   []string `json:"deny"`
+	Reason string   `json:"reason,omitempty"`
+}
+
+type schemaCommand struct {
+	Path      string        `json:"path"`
+	Aliases   []string      `json:"aliases"`
+	Help      string        `json:"help"`
+	Arguments []schemaValue `json:"arguments"`
+	Flags     []schemaValue `json:"flags"`
+}
+
+type schemaValue struct {
+	Name       string   `json:"name"`
+	Aliases    []string `json:"aliases"`
+	Type       string   `json:"type"`
+	Required   bool     `json:"required"`
+	Repeatable bool     `json:"repeatable"`
+	Default    string   `json:"default"`
+	Help       string   `json:"help"`
+}
+
+func (c *SchemaCmd) Run(flags *RootFlags) error {
+	parser, _, err := newParser(baseDescription())
+	if err != nil {
+		return err
+	}
+	document := buildSchemaDocument(parser.Model.Node, flags)
+	return outfmt.WriteJSON(os.Stdout, document)
+}
+
+func buildSchemaDocument(root *kong.Node, flags *RootFlags) schemaDocument {
+	document := schemaDocument{
+		SchemaVersion: schemaVersion,
+		GlobalFlags:   schemaFlags(root.Flags),
+		ExitCodes: []schemaExitCode{
+			{Code: 0, Class: "success", Description: "Command completed successfully"},
+			{Code: 1, Class: "runtime", Description: "Command failed during execution"},
+			{Code: 2, Class: "usage", Description: "Arguments or flags could not be parsed or validated"},
+		},
+		Automation: buildSchemaAutomation(flags),
+	}
+	appendSchemaCommands(root, &document.Commands)
+	sort.Slice(document.Commands, func(i, j int) bool {
+		return document.Commands[i].Path < document.Commands[j].Path
+	})
+	return document
+}
+
+func buildSchemaAutomation(flags *RootFlags) schemaAutomation {
+	if flags == nil {
+		flags = &RootFlags{}
+	}
+	account := strings.TrimSpace(flags.Account)
+	if account == "" {
+		account = strings.TrimSpace(os.Getenv("GOG_ACCOUNT"))
+	}
+	client := strings.TrimSpace(flags.Client)
+
+	cfg, readErr := config.ReadConfig()
+	resolvedAccount, resolvedClient, resolutionErr := resolveSchemaSelection(cfg, account, client, readErr)
+	return schemaAutomation{
+		JSON:            flags.JSON,
+		Plain:           flags.Plain,
+		NoInput:         flags.NoInput,
+		Force:           flags.Force,
+		AccountInput:    account,
+		ClientInput:     client,
+		Account:         resolvedAccount,
+		Client:          resolvedClient,
+		EnabledCommands: buildSchemaEnabledState(flags.EnableCommands),
+		Policy:          buildSchemaPolicyState(cfg.Policies, resolvedAccount, resolvedClient, readErr, resolutionErr),
+	}
+}
+
+func resolveSchemaSelection(cfg config.File, accountInput string, clientInput string, readErr error) (string, string, string) {
+	if readErr != nil {
+		return "", "", "configuration could not be read"
+	}
+	account := strings.TrimSpace(accountInput)
+	if account == "" || shouldAutoSelectAccount(account) {
+		return "", "", "account selection required"
+	}
+	if !strings.Contains(account, "@") {
+		resolved, ok := cfg.AccountAliases[config.NormalizeAccountAlias(account)]
+		if !ok || strings.TrimSpace(resolved) == "" {
+			return "", "", "account alias could not be resolved"
+		}
+		account = strings.TrimSpace(resolved)
+	}
+	client, err := config.ResolveClientForAccount(cfg, account, clientInput)
+	if err != nil {
+		return account, "", "client selection could not be resolved"
+	}
+	return account, client, ""
+}
+
+func buildSchemaEnabledState(input string) schemaEnabledState {
+	input = strings.TrimSpace(input)
+	allowedSet := parseEnabledCommands(input)
+	if input == "" || len(allowedSet) == 0 || allowedSet["*"] || allowedSet["all"] {
+		return schemaEnabledState{Input: input, Allowed: []string{}}
+	}
+	allowed := make([]string, 0, len(allowedSet))
+	for command := range allowedSet {
+		allowed = append(allowed, command)
+	}
+	sort.Strings(allowed)
+	return schemaEnabledState{Input: input, Restricted: true, Allowed: allowed}
+}
+
+func buildSchemaPolicyState(policies []config.Policy, account string, client string, readErr error, resolutionErr string) schemaPolicyState {
+	if readErr != nil {
+		return schemaPolicyState{Status: "unresolved", UnresolvedReason: "configuration could not be read", Effects: []schemaPolicyEffect{}}
+	}
+	if len(policies) == 0 {
+		return schemaPolicyState{Status: "not_configured", Effects: []schemaPolicyEffect{}}
+	}
+	if resolutionErr != "" {
+		return schemaPolicyState{Status: "unresolved", UnresolvedReason: resolutionErr, Effects: []schemaPolicyEffect{}}
+	}
+
+	applicable := mostSpecificApplicablePolicies(policies, account, client)
+	effects := make([]schemaPolicyEffect, 0, len(applicable))
+	for _, policy := range applicable {
+		effects = append(effects, schemaPolicyEffect{
+			Name:   policy.Name,
+			Allow:  sortedStrings(policy.Allow),
+			Deny:   sortedStrings(policy.Deny),
+			Reason: policy.Reason,
+		})
+	}
+	sort.Slice(effects, func(i, j int) bool {
+		return effects[i].Name < effects[j].Name
+	})
+	return schemaPolicyState{Status: "resolved", Effects: effects}
+}
+
+func appendSchemaCommands(node *kong.Node, commands *[]schemaCommand) {
+	for _, child := range node.Children {
+		if child.Hidden {
+			continue
+		}
+		if child.Type == kong.CommandNode {
+			*commands = append(*commands, schemaCommand{
+				Path:      canonicalCommandPath(child),
+				Aliases:   sortedStrings(child.Aliases),
+				Help:      child.Help,
+				Arguments: schemaArguments(child.Positional),
+				Flags:     schemaFlags(child.Flags),
+			})
+		}
+		appendSchemaCommands(child, commands)
+	}
+}
+
+func canonicalCommandPath(node *kong.Node) string {
+	parts := make([]string, 0, node.Depth()+1)
+	for current := node; current != nil && current.Type != kong.ApplicationNode; current = current.Parent {
+		if current.Type == kong.CommandNode {
+			parts = append(parts, current.Name)
+		}
+	}
+	for left, right := 0, len(parts)-1; left < right; left, right = left+1, right-1 {
+		parts[left], parts[right] = parts[right], parts[left]
+	}
+	return strings.Join(parts, " ")
+}
+
+func schemaArguments(arguments []*kong.Positional) []schemaValue {
+	values := make([]schemaValue, 0, len(arguments))
+	for _, argument := range arguments {
+		values = append(values, schemaValueFromValue(argument, nil))
+	}
+	return values
+}
+
+func schemaFlags(flags []*kong.Flag) []schemaValue {
+	values := make([]schemaValue, 0, len(flags))
+	for _, flag := range flags {
+		if flag.Hidden {
+			continue
+		}
+		aliases := append([]string(nil), flag.Aliases...)
+		if flag.Short != 0 {
+			aliases = append(aliases, string(flag.Short))
+		}
+		values = append(values, schemaValueFromValue(flag.Value, aliases))
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return values[i].Name < values[j].Name
+	})
+	return values
+}
+
+func schemaValueFromValue(value *kong.Value, aliases []string) schemaValue {
+	return schemaValue{
+		Name:       value.Name,
+		Aliases:    sortedStrings(aliases),
+		Type:       schemaValueType(value.Target),
+		Required:   value.Required,
+		Repeatable: value.IsCumulative(),
+		Default:    schemaDefault(value),
+		Help:       value.Help,
+	}
+}
+
+func schemaDefault(value *kong.Value) string {
+	if value.HasDefault {
+		return value.Default
+	}
+	if !value.Target.IsValid() {
+		return ""
+	}
+	switch value.Target.Kind() {
+	case reflect.Bool:
+		return boolFalse
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64:
+		return "0"
+	case reflect.Slice, reflect.Array:
+		return "[]"
+	case reflect.Map:
+		return "{}"
+	default:
+		return ""
+	}
+}
+
+func schemaValueType(value reflect.Value) string {
+	if !value.IsValid() {
+		return "unknown"
+	}
+	return value.Type().String()
+}
+
+func sortedStrings(values []string) []string {
+	out := append([]string{}, values...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -44,9 +44,10 @@ type schemaAutomation struct {
 }
 
 type schemaEnabledState struct {
-	Input      string   `json:"input"`
-	Restricted bool     `json:"restricted"`
-	Allowed    []string `json:"allowed"`
+	Input        string   `json:"input"`
+	Restricted   bool     `json:"restricted"`
+	Allowed      []string `json:"allowed"`
+	Unrecognized []string `json:"unrecognized"`
 }
 
 type schemaPolicyState struct {
@@ -98,7 +99,7 @@ func buildSchemaDocument(root *kong.Node, flags *RootFlags) schemaDocument {
 			{Code: 1, Class: "runtime", Description: "Command failed during execution"},
 			{Code: 2, Class: "usage", Description: "Arguments or flags could not be parsed or validated"},
 		},
-		Automation: buildSchemaAutomation(flags),
+		Automation: buildSchemaAutomation(root, flags),
 	}
 	appendSchemaCommands(root, &document.Commands)
 	sort.Slice(document.Commands, func(i, j int) bool {
@@ -107,7 +108,7 @@ func buildSchemaDocument(root *kong.Node, flags *RootFlags) schemaDocument {
 	return document
 }
 
-func buildSchemaAutomation(flags *RootFlags) schemaAutomation {
+func buildSchemaAutomation(root *kong.Node, flags *RootFlags) schemaAutomation {
 	if flags == nil {
 		flags = &RootFlags{}
 	}
@@ -128,7 +129,7 @@ func buildSchemaAutomation(flags *RootFlags) schemaAutomation {
 		ClientInput:     client,
 		Account:         resolvedAccount,
 		Client:          resolvedClient,
-		EnabledCommands: buildSchemaEnabledState(flags.EnableCommands),
+		EnabledCommands: buildSchemaEnabledState(flags.EnableCommands, visibleTopLevelCommands(root)),
 		Policy:          buildSchemaPolicyState(cfg.Policies, resolvedAccount, resolvedClient, readErr, resolutionErr),
 	}
 }
@@ -155,18 +156,34 @@ func resolveSchemaSelection(cfg config.File, accountInput string, clientInput st
 	return account, client, ""
 }
 
-func buildSchemaEnabledState(input string) schemaEnabledState {
+func buildSchemaEnabledState(input string, known map[string]bool) schemaEnabledState {
 	input = strings.TrimSpace(input)
 	allowedSet := parseEnabledCommands(input)
 	if input == "" || len(allowedSet) == 0 || allowedSet["*"] || allowedSet["all"] {
-		return schemaEnabledState{Input: input, Allowed: []string{}}
+		return schemaEnabledState{Input: input, Allowed: []string{}, Unrecognized: []string{}}
 	}
 	allowed := make([]string, 0, len(allowedSet))
+	unrecognized := make([]string, 0, len(allowedSet))
 	for command := range allowedSet {
-		allowed = append(allowed, command)
+		if known[command] {
+			allowed = append(allowed, command)
+		} else {
+			unrecognized = append(unrecognized, command)
+		}
 	}
 	sort.Strings(allowed)
-	return schemaEnabledState{Input: input, Restricted: true, Allowed: allowed}
+	sort.Strings(unrecognized)
+	return schemaEnabledState{Input: input, Restricted: true, Allowed: allowed, Unrecognized: unrecognized}
+}
+
+func visibleTopLevelCommands(root *kong.Node) map[string]bool {
+	commands := map[string]bool{}
+	for _, child := range root.Children {
+		if child.Type == kong.CommandNode && !child.Hidden {
+			commands[strings.ToLower(child.Name)] = true
+		}
+	}
+	return commands
 }
 
 func buildSchemaPolicyState(policies []config.Policy, account string, client string, readErr error, resolutionErr string) schemaPolicyState {

--- a/internal/cmd/schema_test.go
+++ b/internal/cmd/schema_test.go
@@ -43,8 +43,10 @@ type decodedSchemaAutomation struct {
 }
 
 type decodedEnabledState struct {
-	Restricted bool     `json:"restricted"`
-	Allowed    []string `json:"allowed"`
+	Input        string   `json:"input"`
+	Restricted   bool     `json:"restricted"`
+	Allowed      []string `json:"allowed"`
+	Unrecognized []string `json:"unrecognized"`
 }
 
 type decodedPolicyState struct {
@@ -193,10 +195,12 @@ func TestExecuteSchemaIncludesKongCommandArgumentAndFlagMetadata(t *testing.T) {
 	if force.Default != "false" {
 		t.Fatalf("global force default = %q, want false", force.Default)
 	}
-	calendarCreate := findSchemaCommand(t, document.Commands, "calendar create")
-	sendUpdates := findSchemaValue(t, calendarCreate.Flags, "send-updates")
-	if sendUpdates.Default != "all" {
-		t.Fatalf("calendar create send-updates default = %q, want all", sendUpdates.Default)
+	for _, path := range []string{"calendar create", "calendar events-move", "calendar events-quick-add"} {
+		command := findSchemaCommand(t, document.Commands, path)
+		sendUpdates := findSchemaValue(t, command.Flags, "send-updates")
+		if sendUpdates.Default != scopeAll {
+			t.Fatalf("%s send-updates default = %q, want %q", path, sendUpdates.Default, scopeAll)
+		}
 	}
 
 	seen := make(map[string]bool, len(document.Commands))
@@ -226,11 +230,33 @@ func TestExecuteSchemaIncludesKongCommandArgumentAndFlagMetadata(t *testing.T) {
 			t.Fatalf("visible Kong command %q missing from schema", path)
 		}
 	}
-	if _, err := parser.Parse([]string{"calendar", "create", "primary"}); err != nil {
-		t.Fatalf("parse calendar create defaults: %v", err)
+	if _, parseErr := parser.Parse([]string{"calendar", "create", "primary"}); parseErr != nil {
+		t.Fatalf("parse calendar create defaults: %v", parseErr)
 	}
 	if cli.Calendar.Create.SendUpdates != scopeAll {
 		t.Fatalf("calendar create runtime send-updates default = %q, want %q", cli.Calendar.Create.SendUpdates, scopeAll)
+	}
+
+	parser, cli, err = newParser(baseDescription())
+	if err != nil {
+		t.Fatalf("new parser: %v", err)
+	}
+	if _, parseErr := parser.Parse([]string{"calendar", "events-quick-add", "primary", "meeting"}); parseErr != nil {
+		t.Fatalf("parse calendar events-quick-add defaults: %v", parseErr)
+	}
+	if cli.Calendar.EventsQuickAdd.SendUpdate != scopeAll {
+		t.Fatalf("calendar events-quick-add runtime send-updates default = %q, want %q", cli.Calendar.EventsQuickAdd.SendUpdate, scopeAll)
+	}
+
+	parser, cli, err = newParser(baseDescription())
+	if err != nil {
+		t.Fatalf("new parser: %v", err)
+	}
+	if _, parseErr := parser.Parse([]string{"calendar", "events-move", "primary", "event", "destination"}); parseErr != nil {
+		t.Fatalf("parse calendar events-move defaults: %v", parseErr)
+	}
+	if cli.Calendar.EventsMove.SendUpdate != scopeAll {
+		t.Fatalf("calendar events-move runtime send-updates default = %q, want %q", cli.Calendar.EventsMove.SendUpdate, scopeAll)
 	}
 }
 
@@ -324,6 +350,23 @@ func TestExecuteSchemaReportsExitCodesAndEffectiveAutomationState(t *testing.T) 
 	}
 }
 
+func TestExecuteSchemaReportsCanonicalAndUnrecognizedEnabledCommands(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	canonical, _ := executeSchema(t, "--enable-commands", "gmail", "schema")
+	if strings.Join(canonical.Automation.EnabledCommands.Allowed, ",") != "gmail" || len(canonical.Automation.EnabledCommands.Unrecognized) != 0 {
+		t.Fatalf("canonical enabled-command state = %+v", canonical.Automation.EnabledCommands)
+	}
+
+	alias, _ := executeSchema(t, "--enable-commands", "mail", "schema")
+	if len(alias.Automation.EnabledCommands.Allowed) != 0 || strings.Join(alias.Automation.EnabledCommands.Unrecognized, ",") != "mail" {
+		t.Fatalf("alias enabled-command state = %+v", alias.Automation.EnabledCommands)
+	}
+	if alias.Automation.EnabledCommands.Input != "mail" || !alias.Automation.EnabledCommands.Restricted {
+		t.Fatalf("alias enabled-command input/restriction = %+v", alias.Automation.EnabledCommands)
+	}
+}
+
 func TestExecuteSchemaReportsPolicyEffectsOrUnresolvedContext(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("GOG_SKIP_UPDATE_CHECK", "1")
@@ -396,12 +439,29 @@ func TestExecuteSchemaIsDeterministicAndExcludesSecretValues(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "schema-secret-token-152")
 	t.Setenv("GH_TOKEN", "schema-secret-fallback-token-152")
 
+	configMarkers := []string{
+		"schema-config-backend-marker-152",
+		"schema-config-timezone-marker-152",
+		"schema-config-alias-marker-152",
+		"schema-config-account-client-marker-152",
+		"schema-config-domain-marker-152",
+	}
+	if err := config.WriteConfig(config.File{
+		KeyringBackend:  configMarkers[0],
+		DefaultTimezone: configMarkers[1],
+		AccountAliases:  map[string]string{configMarkers[2]: "marker@example.com"},
+		AccountClients:  map[string]string{"marker@example.com": configMarkers[3]},
+		ClientDomains:   map[string]string{configMarkers[4]: "example.com"},
+	}); err != nil {
+		t.Fatalf("write marker config: %v", err)
+	}
+
 	_, first := executeSchema(t, "schema")
 	_, second := executeSchema(t, "schema")
 	if first != second {
 		t.Fatalf("schema output changed between identical invocations")
 	}
-	for _, secret := range []string{"schema-secret-password-152", "schema-secret-token-152", "schema-secret-fallback-token-152"} {
+	for _, secret := range append([]string{"schema-secret-password-152", "schema-secret-token-152", "schema-secret-fallback-token-152"}, configMarkers...) {
 		if strings.Contains(first, secret) {
 			t.Fatalf("schema output contains secret value %q", secret)
 		}
@@ -412,8 +472,16 @@ func TestSchemaV1ContractFingerprint(t *testing.T) {
 	normalizeSchemaEnvironment(t)
 
 	_, output := executeSchema(t, "schema")
-	got := fmt.Sprintf("%x", sha256.Sum256([]byte(output)))
-	const want = "35bdf825496c042720ebdf294b49afe0a134d396ea61edf8f623606de4d86afb"
+	var document any
+	if err := json.Unmarshal([]byte(output), &document); err != nil {
+		t.Fatalf("decode complete schema contract: %v", err)
+	}
+	canonical, err := json.Marshal(document)
+	if err != nil {
+		t.Fatalf("marshal canonical schema: %v", err)
+	}
+	got := fmt.Sprintf("%x", sha256.Sum256(canonical))
+	const want = "b55b0f31c26dc4ac3983e1b9e53f0bd52a62c3b7a014c83b13e43516b3ac6930"
 	if got != want {
 		t.Fatalf("schema v1 contract fingerprint = %s, want %s; review the contract change and schema version", got, want)
 	}

--- a/internal/cmd/schema_test.go
+++ b/internal/cmd/schema_test.go
@@ -1,0 +1,385 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/selfupdate"
+)
+
+type decodedSchema struct {
+	SchemaVersion string                  `json:"schema_version"`
+	Commands      []decodedSchemaCommand  `json:"commands"`
+	GlobalFlags   []decodedSchemaValue    `json:"global_flags"`
+	ExitCodes     []decodedSchemaExitCode `json:"exit_codes"`
+	Automation    decodedSchemaAutomation `json:"automation"`
+}
+
+type decodedSchemaExitCode struct {
+	Code  int    `json:"code"`
+	Class string `json:"class"`
+}
+
+type decodedSchemaAutomation struct {
+	JSON            bool                `json:"json"`
+	Plain           bool                `json:"plain"`
+	NoInput         bool                `json:"no_input"`
+	Force           bool                `json:"force"`
+	AccountInput    string              `json:"account_input"`
+	ClientInput     string              `json:"client_input"`
+	Account         string              `json:"account"`
+	Client          string              `json:"client"`
+	EnabledCommands decodedEnabledState `json:"enabled_commands"`
+	Policy          decodedPolicyState  `json:"policy"`
+}
+
+type decodedEnabledState struct {
+	Restricted bool     `json:"restricted"`
+	Allowed    []string `json:"allowed"`
+}
+
+type decodedPolicyState struct {
+	Status           string                `json:"status"`
+	UnresolvedReason string                `json:"unresolved_reason"`
+	Effects          []decodedPolicyEffect `json:"effects"`
+}
+
+type decodedPolicyEffect struct {
+	Name  string   `json:"name"`
+	Allow []string `json:"allow"`
+	Deny  []string `json:"deny"`
+}
+
+type decodedSchemaCommand struct {
+	Path      string               `json:"path"`
+	Aliases   []string             `json:"aliases"`
+	Help      string               `json:"help"`
+	Arguments []decodedSchemaValue `json:"arguments"`
+	Flags     []decodedSchemaValue `json:"flags"`
+}
+
+type decodedSchemaValue struct {
+	Name       string   `json:"name"`
+	Aliases    []string `json:"aliases"`
+	Type       string   `json:"type"`
+	Required   bool     `json:"required"`
+	Repeatable bool     `json:"repeatable"`
+	Default    string   `json:"default"`
+	Help       string   `json:"help"`
+}
+
+func TestExecuteSchemaEmitsVersionedJSONWithoutUpdateCheck(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	calls := 0
+	original := maybeNotifyUpdate
+	maybeNotifyUpdate = func(context.Context, *selfupdate.Client, string, time.Duration) string {
+		calls++
+		return "unexpected update notice"
+	}
+	t.Cleanup(func() { maybeNotifyUpdate = original })
+
+	var executeErr error
+	stderr := captureStderr(t, func() {
+		stdout := captureStdout(t, func() {
+			executeErr = Execute([]string{"schema"})
+		})
+		if executeErr != nil {
+			t.Fatalf("Execute(schema): %v", executeErr)
+		}
+
+		var document decodedSchema
+		if err := json.Unmarshal([]byte(stdout), &document); err != nil {
+			t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout)
+		}
+		if document.SchemaVersion != "1" {
+			t.Fatalf("schema_version = %q, want 1", document.SchemaVersion)
+		}
+	})
+
+	if calls != 0 {
+		t.Fatalf("update notifier calls = %d, want 0", calls)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestExecuteSchemaIncludesKongCommandArgumentAndFlagMetadata(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GOG_SKIP_UPDATE_CHECK", "1")
+
+	var executeErr error
+	stdout := captureStdout(t, func() {
+		executeErr = Execute([]string{"schema"})
+	})
+	if executeErr != nil {
+		t.Fatalf("Execute(schema): %v", executeErr)
+	}
+
+	var document decodedSchema
+	if err := json.Unmarshal([]byte(stdout), &document); err != nil {
+		t.Fatalf("decode schema: %v", err)
+	}
+
+	gmail := findSchemaCommand(t, document.Commands, "gmail")
+	if !schemaContainsString(gmail.Aliases, "mail") || !schemaContainsString(gmail.Aliases, "email") {
+		t.Fatalf("gmail aliases = %v, want mail and email", gmail.Aliases)
+	}
+
+	deleteGuardian := findSchemaCommand(t, document.Commands, "classroom guardians delete")
+	if !schemaContainsString(deleteGuardian.Aliases, "rm") {
+		t.Fatalf("classroom guardians delete aliases = %v, want rm", deleteGuardian.Aliases)
+	}
+
+	get := findSchemaCommand(t, document.Commands, "gmail get")
+	if len(get.Arguments) == 0 || get.Arguments[0].Name == "" || get.Arguments[0].Type == "" || get.Arguments[0].Help == "" {
+		t.Fatalf("gmail get arguments missing machine metadata: %+v", get.Arguments)
+	}
+	if len(get.Flags) == 0 {
+		t.Fatalf("gmail get flags are empty")
+	}
+	for _, flag := range get.Flags {
+		if flag.Name == "" || flag.Type == "" || flag.Help == "" {
+			t.Fatalf("gmail get flag missing machine metadata: %+v", flag)
+		}
+	}
+
+	account := findSchemaValue(t, document.GlobalFlags, "account")
+	if account.Type != "string" || account.Help == "" {
+		t.Fatalf("global account flag = %+v", account)
+	}
+	force := findSchemaValue(t, document.GlobalFlags, "force")
+	if force.Default != "false" {
+		t.Fatalf("global force default = %q, want false", force.Default)
+	}
+
+	seen := make(map[string]bool, len(document.Commands))
+	for i, command := range document.Commands {
+		if command.Path == "" || command.Help == "" {
+			t.Fatalf("command missing path/help: %+v", command)
+		}
+		if seen[command.Path] {
+			t.Fatalf("duplicate canonical command path %q", command.Path)
+		}
+		seen[command.Path] = true
+		if i > 0 && document.Commands[i-1].Path > command.Path {
+			t.Fatalf("commands are not deterministically sorted at %q", command.Path)
+		}
+	}
+
+	parser, _, err := newParser(baseDescription())
+	if err != nil {
+		t.Fatalf("new parser: %v", err)
+	}
+	wantPaths := visibleCanonicalCommandPaths(parser.Model.Node)
+	if len(seen) != len(wantPaths) {
+		t.Fatalf("emitted command count = %d, Kong visible command count = %d", len(seen), len(wantPaths))
+	}
+	for path := range wantPaths {
+		if !seen[path] {
+			t.Fatalf("visible Kong command %q missing from schema", path)
+		}
+	}
+}
+
+func TestExecuteSchemaUsesEffectiveEnvironmentDefaults(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GOG_SKIP_UPDATE_CHECK", "1")
+	t.Setenv("GOG_JSON", "1")
+	t.Setenv("GOG_CLIENT", "env-client")
+	t.Setenv("GOG_ACCOUNT", "env@example.com")
+
+	document, _ := executeSchema(t, "schema")
+	jsonFlag := findSchemaValue(t, document.GlobalFlags, "json")
+	if jsonFlag.Default != "true" {
+		t.Fatalf("global json default = %q, want true", jsonFlag.Default)
+	}
+	if !document.Automation.JSON || document.Automation.ClientInput != "env-client" || document.Automation.AccountInput != "env@example.com" {
+		t.Fatalf("environment automation defaults = %+v", document.Automation)
+	}
+}
+
+func visibleCanonicalCommandPaths(node *kong.Node) map[string]bool {
+	paths := map[string]bool{}
+	var walk func(*kong.Node)
+	walk = func(current *kong.Node) {
+		for _, child := range current.Children {
+			if child.Hidden {
+				continue
+			}
+			if child.Type == kong.CommandNode {
+				paths[canonicalCommandPath(child)] = true
+			}
+			walk(child)
+		}
+	}
+	walk(node)
+	return paths
+}
+
+func TestExecuteSchemaReportsExitCodesAndEffectiveAutomationState(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GOG_JSON", "1")
+	t.Setenv("GOG_ENABLE_COMMANDS", "calendar,gmail")
+	t.Setenv("GOG_SKIP_UPDATE_CHECK", "1")
+
+	document, _ := executeSchema(t, "--account", "agent@example.com", "--client", "work", "--no-input", "--force", "schema")
+
+	wantExitCodes := map[int]string{0: "success", 1: "runtime", 2: "usage"}
+	for _, exitCode := range document.ExitCodes {
+		delete(wantExitCodes, exitCode.Code)
+	}
+	if len(wantExitCodes) != 0 {
+		t.Fatalf("missing exit code classes: %v (got %+v)", wantExitCodes, document.ExitCodes)
+	}
+	if !document.Automation.JSON || document.Automation.Plain || !document.Automation.NoInput || !document.Automation.Force {
+		t.Fatalf("automation flags = %+v", document.Automation)
+	}
+	if document.Automation.AccountInput != "agent@example.com" || document.Automation.ClientInput != "work" {
+		t.Fatalf("automation selection inputs = %+v", document.Automation)
+	}
+	if !document.Automation.EnabledCommands.Restricted {
+		t.Fatalf("enabled-command restriction not reported: %+v", document.Automation.EnabledCommands)
+	}
+	if strings.Join(document.Automation.EnabledCommands.Allowed, ",") != "calendar,gmail" {
+		t.Fatalf("enabled commands = %v", document.Automation.EnabledCommands.Allowed)
+	}
+}
+
+func TestExecuteSchemaReportsPolicyEffectsOrUnresolvedContext(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GOG_SKIP_UPDATE_CHECK", "1")
+
+	cfg := config.File{Policies: []config.Policy{
+		{Name: "agent-mail", Account: "agent@example.com", Client: "work", Allow: []string{"gmail:read"}, Deny: []string{"gmail:send"}},
+	}}
+	if err := config.WriteConfig(cfg); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	path, err := config.ConfigPath()
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config before schema: %v", err)
+	}
+
+	unresolved, _ := executeSchema(t, "schema")
+	if unresolved.Automation.Policy.Status != "unresolved" || unresolved.Automation.Policy.UnresolvedReason == "" {
+		t.Fatalf("policy without context = %+v", unresolved.Automation.Policy)
+	}
+
+	resolved, _ := executeSchema(t, "--account", "agent@example.com", "--client", "work", "schema")
+	if resolved.Automation.Policy.Status != "resolved" || len(resolved.Automation.Policy.Effects) != 1 {
+		t.Fatalf("policy with context = %+v", resolved.Automation.Policy)
+	}
+	effect := resolved.Automation.Policy.Effects[0]
+	if effect.Name != "agent-mail" || strings.Join(effect.Allow, ",") != "gmail:read" || strings.Join(effect.Deny, ",") != "gmail:send" {
+		t.Fatalf("policy effect = %+v", effect)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config after schema: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("schema modified config file")
+	}
+}
+
+func TestExecuteSchemaResolvesAliasAndDefaultClientForPolicyEffects(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GOG_SKIP_UPDATE_CHECK", "1")
+
+	cfg := config.File{
+		AccountAliases: map[string]string{"team": "agent@example.com"},
+		Policies: []config.Policy{
+			{Name: "default-mail", Account: "agent@example.com", Client: "default", Deny: []string{"gmail:send"}},
+		},
+	}
+	if err := config.WriteConfig(cfg); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	document, _ := executeSchema(t, "--account", "team", "schema")
+	if document.Automation.AccountInput != "team" || document.Automation.Account != "agent@example.com" || document.Automation.Client != "default" {
+		t.Fatalf("resolved selection = %+v", document.Automation)
+	}
+	if document.Automation.Policy.Status != "resolved" || len(document.Automation.Policy.Effects) != 1 || document.Automation.Policy.Effects[0].Name != "default-mail" {
+		t.Fatalf("resolved alias/default policy = %+v", document.Automation.Policy)
+	}
+}
+
+func TestExecuteSchemaIsDeterministicAndExcludesSecretValues(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GOG_SKIP_UPDATE_CHECK", "1")
+	t.Setenv("GOG_KEYRING_PASSWORD", "schema-secret-password-152")
+	t.Setenv("GITHUB_TOKEN", "schema-secret-token-152")
+
+	_, first := executeSchema(t, "schema")
+	_, second := executeSchema(t, "schema")
+	if first != second {
+		t.Fatalf("schema output changed between identical invocations")
+	}
+	for _, secret := range []string{"schema-secret-password-152", "schema-secret-token-152"} {
+		if strings.Contains(first, secret) {
+			t.Fatalf("schema output contains secret value %q", secret)
+		}
+	}
+}
+
+func executeSchema(t *testing.T, args ...string) (decodedSchema, string) {
+	t.Helper()
+	var executeErr error
+	stdout := captureStdout(t, func() {
+		executeErr = Execute(args)
+	})
+	if executeErr != nil {
+		t.Fatalf("Execute(%v): %v", args, executeErr)
+	}
+	var document decodedSchema
+	if err := json.Unmarshal([]byte(stdout), &document); err != nil {
+		t.Fatalf("decode schema: %v", err)
+	}
+	return document, stdout
+}
+
+func findSchemaCommand(t *testing.T, commands []decodedSchemaCommand, path string) decodedSchemaCommand {
+	t.Helper()
+	for _, command := range commands {
+		if command.Path == path {
+			return command
+		}
+	}
+	t.Fatalf("schema command %q not found", path)
+	return decodedSchemaCommand{}
+}
+
+func findSchemaValue(t *testing.T, values []decodedSchemaValue, name string) decodedSchemaValue {
+	t.Helper()
+	for _, value := range values {
+		if value.Name == name {
+			return value
+		}
+	}
+	t.Fatalf("schema value %q not found", name)
+	return decodedSchemaValue{}
+}
+
+func schemaContainsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cmd/schema_test.go
+++ b/internal/cmd/schema_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -112,6 +114,37 @@ func TestExecuteSchemaEmitsVersionedJSONWithoutUpdateCheck(t *testing.T) {
 	}
 }
 
+func TestExecuteSchemaBypassesPolicyEnforcementForMalformedConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if _, err := config.EnsureDir(); err != nil {
+		t.Fatalf("ensure config dir: %v", err)
+	}
+	path, err := config.ConfigPath()
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{malformed"), 0o600); err != nil {
+		t.Fatalf("write malformed config: %v", err)
+	}
+
+	document, _ := executeSchema(t, "schema")
+	if document.Automation.Policy.Status != "unresolved" || document.Automation.Policy.UnresolvedReason != "configuration could not be read" {
+		t.Fatalf("policy state = %+v, want unresolved config read", document.Automation.Policy)
+	}
+
+	stderr := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := Execute([]string{"time", "now"}); err == nil {
+				t.Fatal("ordinary command succeeded with malformed config")
+			}
+		})
+	})
+	if !strings.Contains(stderr, "read config") {
+		t.Fatalf("ordinary command stderr = %q, want config read failure", stderr)
+	}
+}
+
 func TestExecuteSchemaIncludesKongCommandArgumentAndFlagMetadata(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("GOG_SKIP_UPDATE_CHECK", "1")
@@ -160,6 +193,11 @@ func TestExecuteSchemaIncludesKongCommandArgumentAndFlagMetadata(t *testing.T) {
 	if force.Default != "false" {
 		t.Fatalf("global force default = %q, want false", force.Default)
 	}
+	calendarCreate := findSchemaCommand(t, document.Commands, "calendar create")
+	sendUpdates := findSchemaValue(t, calendarCreate.Flags, "send-updates")
+	if sendUpdates.Default != "all" {
+		t.Fatalf("calendar create send-updates default = %q, want all", sendUpdates.Default)
+	}
 
 	seen := make(map[string]bool, len(document.Commands))
 	for i, command := range document.Commands {
@@ -175,7 +213,7 @@ func TestExecuteSchemaIncludesKongCommandArgumentAndFlagMetadata(t *testing.T) {
 		}
 	}
 
-	parser, _, err := newParser(baseDescription())
+	parser, cli, err := newParser(baseDescription())
 	if err != nil {
 		t.Fatalf("new parser: %v", err)
 	}
@@ -188,21 +226,53 @@ func TestExecuteSchemaIncludesKongCommandArgumentAndFlagMetadata(t *testing.T) {
 			t.Fatalf("visible Kong command %q missing from schema", path)
 		}
 	}
+	if _, err := parser.Parse([]string{"calendar", "create", "primary"}); err != nil {
+		t.Fatalf("parse calendar create defaults: %v", err)
+	}
+	if cli.Calendar.Create.SendUpdates != scopeAll {
+		t.Fatalf("calendar create runtime send-updates default = %q, want %q", cli.Calendar.Create.SendUpdates, scopeAll)
+	}
 }
 
 func TestExecuteSchemaUsesEffectiveEnvironmentDefaults(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("GOG_SKIP_UPDATE_CHECK", "1")
 	t.Setenv("GOG_JSON", "1")
+	t.Setenv("GOG_PLAIN", "")
+	t.Setenv("GOG_COLOR", "always")
 	t.Setenv("GOG_CLIENT", "env-client")
 	t.Setenv("GOG_ACCOUNT", "env@example.com")
+	t.Setenv("GOG_ENABLE_COMMANDS", "calendar,gmail")
 
 	document, _ := executeSchema(t, "schema")
-	jsonFlag := findSchemaValue(t, document.GlobalFlags, "json")
-	if jsonFlag.Default != "true" {
-		t.Fatalf("global json default = %q, want true", jsonFlag.Default)
+	wantDefaults := map[string]string{
+		"account":         "env@example.com",
+		"client":          "env-client",
+		"color":           "always",
+		"enable-commands": "calendar,gmail",
+		"json":            "true",
+		"plain":           "false",
+	}
+	for name, want := range wantDefaults {
+		if got := findSchemaValue(t, document.GlobalFlags, name).Default; got != want {
+			t.Fatalf("global %s default = %q, want %q", name, got, want)
+		}
 	}
 	if !document.Automation.JSON || document.Automation.ClientInput != "env-client" || document.Automation.AccountInput != "env@example.com" {
+		t.Fatalf("environment automation defaults = %+v", document.Automation)
+	}
+}
+
+func TestExecuteSchemaUsesEffectivePlainEnvironmentDefault(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GOG_JSON", "")
+	t.Setenv("GOG_PLAIN", "1")
+
+	document, _ := executeSchema(t, "schema")
+	if got := findSchemaValue(t, document.GlobalFlags, "plain").Default; got != "true" {
+		t.Fatalf("global plain default = %q, want true", got)
+	}
+	if !document.Automation.Plain || document.Automation.JSON {
 		t.Fatalf("environment automation defaults = %+v", document.Automation)
 	}
 }
@@ -324,16 +394,50 @@ func TestExecuteSchemaIsDeterministicAndExcludesSecretValues(t *testing.T) {
 	t.Setenv("GOG_SKIP_UPDATE_CHECK", "1")
 	t.Setenv("GOG_KEYRING_PASSWORD", "schema-secret-password-152")
 	t.Setenv("GITHUB_TOKEN", "schema-secret-token-152")
+	t.Setenv("GH_TOKEN", "schema-secret-fallback-token-152")
 
 	_, first := executeSchema(t, "schema")
 	_, second := executeSchema(t, "schema")
 	if first != second {
 		t.Fatalf("schema output changed between identical invocations")
 	}
-	for _, secret := range []string{"schema-secret-password-152", "schema-secret-token-152"} {
+	for _, secret := range []string{"schema-secret-password-152", "schema-secret-token-152", "schema-secret-fallback-token-152"} {
 		if strings.Contains(first, secret) {
 			t.Fatalf("schema output contains secret value %q", secret)
 		}
+	}
+}
+
+func TestSchemaV1ContractFingerprint(t *testing.T) {
+	normalizeSchemaEnvironment(t)
+
+	_, output := executeSchema(t, "schema")
+	got := fmt.Sprintf("%x", sha256.Sum256([]byte(output)))
+	const want = "35bdf825496c042720ebdf294b49afe0a134d396ea61edf8f623606de4d86afb"
+	if got != want {
+		t.Fatalf("schema v1 contract fingerprint = %s, want %s; review the contract change and schema version", got, want)
+	}
+}
+
+func normalizeSchemaEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	for _, key := range []string{
+		"GOG_ACCOUNT",
+		"GOG_CALENDAR_WEEKDAY",
+		"GOG_CLIENT",
+		"GOG_COLOR",
+		"GOG_ENABLE_COMMANDS",
+		"GOG_JSON",
+		"GOG_KEYRING_PASSWORD",
+		"GOG_PLAIN",
+		"GOG_SKIP_UPDATE_CHECK",
+		"GOG_UPDATE_REPO",
+		"GITHUB_TOKEN",
+		"GH_TOKEN",
+	} {
+		t.Setenv(key, "")
 	}
 }
 

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -80,11 +80,17 @@ func captureStdout(t *testing.T, fn func()) string {
 	}
 	os.Stdout = w
 
+	result := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		result <- b
+	}()
+
 	fn()
 
 	_ = w.Close()
 	os.Stdout = orig
-	b, _ := io.ReadAll(r)
+	b := <-result
 	_ = r.Close()
 	return string(b)
 }


### PR DESCRIPTION
## Summary
- add a versioned `gog schema` JSON document derived from the authoritative Kong command model
- report effective automation, enabled-command, policy, default, and exit-code metadata without auth, prompts, update checks, or secret access
- document the command and cover schema stability, restrictions, policy resolution, defaults, determinism, and secret exclusion

## Verification
- `go test ./internal/cmd -run 'Schema|EnabledCommands|CalendarEventsQuickAdd|CalendarEventsMove|CalendarCreate'`
- `make fmt`
- `make ci`

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)