### PR TITLE
feat(cli): add concise JSON output selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- CLI: add `--results-only` and `--select` for concise, projected JSON output. (#156)
 - Search Console: add `--start-row` to `search-console query` for zero-based Search Analytics result windows. (#98)
 - Tag Manager: add workspace trigger and variable create/delete/get/revert/update commands plus built-in-variable management. (#12, #45, #46, #47)
 - Tag Manager: add composable workspace version creation and container-version publishing commands. (#11)

--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ gog auth list
 - Default: human-friendly tables on stdout.
 - `--plain`: stable TSV on stdout (tabs preserved; best for piping to tools that expect `\t`).
 - `--json`: JSON on stdout (best for scripting).
+- `--results-only`: with `--json`, emit only the command's declared primary result instead of its response envelope.
+- `--select <paths>`: with `--json`, project comma-separated fields such as `id,name` or `sender.email`; dotted paths preserve nested shape and missing fields are omitted.
+- When combined, `--results-only` runs before `--select`.
 - Human-facing hints/progress go to stderr.
 - Colors are enabled only in rich TTY output and are disabled automatically for `--json` and `--plain`.
 
@@ -1201,15 +1204,17 @@ $ gog gmail messages search 'newer_than:7d' --max 1 --include-body --json
 }
 ```
 
-Data goes to stdout, errors and progress to stderr for clean piping:
+Data goes to stdout, errors and progress to stderr for clean piping. Built-in projection can replace common envelope-scraping `jq` usage:
 
 ```bash
-gog --json drive ls --max 5 | jq '.files[] | select(.mimeType=="application/pdf")'
+# Emit the file array without nextPageToken, then retain only selected fields.
+gog --json --results-only --select id,name,mimeType drive ls --max 5
+
+# Filtering expressions remain a jq use case.
+gog --json --results-only drive ls --max 5 | jq '.[] | select(.mimeType=="application/pdf")'
 ```
 
-Useful pattern:
-
-- `gog --json ... | jq .`
+`--select` projects objects or each object in an array. It is separate from command-specific options such as Calendar's `--fields`: `--fields` controls the Google API partial response, while `--select` shapes the JSON printed by `gog`; they can be combined.
 
 Calendar JSON convenience fields:
 
@@ -1333,6 +1338,8 @@ All commands support these flags:
 - `--account <email|alias|auto>` - Account to use (overrides GOG_ACCOUNT)
 - `--enable-commands <csv>` - Allowlist top-level commands (e.g., `calendar,tasks`)
 - `--json` - Output JSON to stdout (best for scripting)
+- `--results-only` - Output the command's declared primary result (requires `--json`)
+- `--select <paths>` - Project comma-separated dotted paths from JSON output (requires `--json`)
 - `--plain` - Output stable, parseable text to stdout (TSV; no colors)
 - `--color <mode>` - Color mode: `auto`, `always`, or `never` (default: auto)
 - `--force` - Skip confirmations for destructive commands

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -32,6 +32,8 @@ This replaces the existing separate CLIs (`gmcli`, `gccli`, `gdcli`) and the Pyt
 - Global flag:
   - `--color=auto|always|never` (default `auto`)
   - `--json` (JSON output to stdout)
+  - `--results-only` (emit the command's declared primary JSON result; requires `--json`)
+  - `--select <paths>` (project comma-separated dotted paths from JSON objects or arrays of objects; requires `--json`)
   - `--plain` (TSV output to stdout; stable/parseable; disables colors)
   - `--force` (skip confirmations for destructive commands)
   - `--no-input` (never prompt; fail instead)

--- a/internal/cmd/analytics.go
+++ b/internal/cmd/analytics.go
@@ -114,12 +114,12 @@ func (c *AnalyticsReportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"dimensionHeaders": resp.DimensionHeaders,
 			"metricHeaders":    resp.MetricHeaders,
 			"rows":             resp.Rows,
 			"rowCount":         resp.RowCount,
-		})
+		}, resp.Rows))
 	}
 
 	u := ui.FromContext(ctx)
@@ -211,12 +211,12 @@ func (c *AnalyticsRealtimeCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"dimensionHeaders": resp.DimensionHeaders,
 			"metricHeaders":    resp.MetricHeaders,
 			"rows":             resp.Rows,
 			"rowCount":         resp.RowCount,
-		})
+		}, resp.Rows))
 	}
 
 	u := ui.FromContext(ctx)
@@ -279,10 +279,10 @@ func (c *AnalyticsPropertiesCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"accountSummaries": resp.AccountSummaries,
 			"nextPageToken":    resp.NextPageToken,
-		})
+		}, resp.AccountSummaries))
 	}
 
 	u := ui.FromContext(ctx)
@@ -331,10 +331,10 @@ func (c *AnalyticsAccountsCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"accounts":      resp.Accounts,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Accounts))
 	}
 
 	u := ui.FromContext(ctx)
@@ -382,9 +382,9 @@ func (c *AnalyticsDimensionsCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"dimensions": resp.Dimensions,
-		})
+		}, resp.Dimensions))
 	}
 
 	u := ui.FromContext(ctx)
@@ -431,9 +431,9 @@ func (c *AnalyticsMetricsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"metrics": resp.Metrics,
-		})
+		}, resp.Metrics))
 	}
 
 	u := ui.FromContext(ctx)

--- a/internal/cmd/analytics_admin_access_bindings.go
+++ b/internal/cmd/analytics_admin_access_bindings.go
@@ -102,7 +102,7 @@ func (c *AAAccessBindingsListCmd) Run(ctx context.Context, flags *RootFlags) err
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"accessBindings": resp.AccessBindings, "nextPageToken": resp.NextPageToken})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"accessBindings": resp.AccessBindings, "nextPageToken": resp.NextPageToken}, resp.AccessBindings))
 	}
 	u := ui.FromContext(ctx)
 	if len(resp.AccessBindings) == 0 {
@@ -223,7 +223,7 @@ func (c *AAAccessBindingsDeleteCmd) Run(ctx context.Context, flags *RootFlags) e
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "name": name})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"deleted": true, "name": name}))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -238,7 +238,7 @@ func (c *AAAccessBindingsDeleteCmd) Run(ctx context.Context, flags *RootFlags) e
 
 func writeAnalyticsAccessBinding(ctx context.Context, action string, binding *analyticsadmin.GoogleAnalyticsAdminV1alphaAccessBinding) error {
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"accessBinding": binding})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"accessBinding": binding}, binding))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)

--- a/internal/cmd/analytics_admin_streams.go
+++ b/internal/cmd/analytics_admin_streams.go
@@ -86,7 +86,7 @@ func (c *AADataStreamsCreateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"dataStream": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"dataStream": resp}, resp))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -138,7 +138,7 @@ func (c *AADataStreamsDeleteCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "name": name})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"deleted": true, "name": name}))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -179,7 +179,7 @@ func (c *AADataStreamsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"dataStream": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"dataStream": resp}, resp))
 	}
 
 	w, flush := tableWriter(ctx)
@@ -228,10 +228,10 @@ func (c *AADataStreamsListCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"dataStreams":   resp.DataStreams,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.DataStreams))
 	}
 
 	u := ui.FromContext(ctx)
@@ -293,7 +293,7 @@ func (c *AADataStreamsPatchCmd) Run(ctx context.Context, flags *RootFlags, kctx 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"dataStream": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"dataStream": resp}, resp))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -351,7 +351,7 @@ func (c *AAMpSecretsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"measurementProtocolSecret": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"measurementProtocolSecret": resp}, resp))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -397,7 +397,7 @@ func (c *AAMpSecretsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "name": name})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"deleted": true, "name": name}))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -439,7 +439,7 @@ func (c *AAMpSecretsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"measurementProtocolSecret": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"measurementProtocolSecret": resp}, resp))
 	}
 
 	w, flush := tableWriter(ctx)
@@ -485,10 +485,10 @@ func (c *AAMpSecretsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"measurementProtocolSecrets": resp.MeasurementProtocolSecrets,
 			"nextPageToken":              resp.NextPageToken,
-		})
+		}, resp.MeasurementProtocolSecrets))
 	}
 
 	u := ui.FromContext(ctx)
@@ -547,7 +547,7 @@ func (c *AAMpSecretsPatchCmd) Run(ctx context.Context, flags *RootFlags, kctx *k
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"measurementProtocolSecret": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"measurementProtocolSecret": resp}, resp))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)

--- a/internal/cmd/analytics_audience.go
+++ b/internal/cmd/analytics_audience.go
@@ -73,13 +73,14 @@ func (c *AnalyticsAudienceExportsCreateCmd) Run(ctx context.Context, flags *Root
 	// The create method returns an Operation. When done, the response contains the AudienceExport.
 	// For now, we just return the operation metadata.
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
-			"operation": map[string]any{
-				"name":     resp.Name,
-				"done":     resp.Done,
-				"metadata": resp.Metadata,
-			},
-		})
+		operation := map[string]any{
+			"name":     resp.Name,
+			"done":     resp.Done,
+			"metadata": resp.Metadata,
+		}
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
+			"operation": operation,
+		}, operation))
 	}
 
 	w, flush := tableWriter(ctx)
@@ -124,7 +125,7 @@ func (c *AnalyticsAudienceExportsGetCmd) Run(ctx context.Context, flags *RootFla
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, resp)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(resp, resp))
 	}
 
 	w, flush := tableWriter(ctx)
@@ -188,10 +189,10 @@ func (c *AnalyticsAudienceExportsListCmd) Run(ctx context.Context, flags *RootFl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"audienceExports": resp.AudienceExports,
 			"nextPageToken":   resp.NextPageToken,
-		})
+		}, resp.AudienceExports))
 	}
 
 	u := ui.FromContext(ctx)
@@ -252,10 +253,10 @@ func (c *AnalyticsAudienceExportsQueryCmd) Run(ctx context.Context, flags *RootF
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"audienceExport": resp.AudienceExport,
 			"audienceRows":   resp.AudienceRows,
-		})
+		}, resp.AudienceRows))
 	}
 
 	u := ui.FromContext(ctx)

--- a/internal/cmd/analytics_reports.go
+++ b/internal/cmd/analytics_reports.go
@@ -104,14 +104,14 @@ func (c *AnalyticsPivotReportCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"pivotHeaders":     resp.PivotHeaders,
 			"dimensionHeaders": resp.DimensionHeaders,
 			"metricHeaders":    resp.MetricHeaders,
 			"rows":             resp.Rows,
 			"metadata":         resp.Metadata,
 			"propertyQuota":    resp.PropertyQuota,
-		})
+		}, resp.Rows))
 	}
 
 	u := ui.FromContext(ctx)
@@ -201,9 +201,9 @@ func (c *AnalyticsBatchReportsCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"reports": resp.Reports,
-		})
+		}, resp.Reports))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -333,9 +333,9 @@ func (c *AnalyticsBatchPivotReportsCmd) Run(ctx context.Context, flags *RootFlag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"pivotReports": resp.PivotReports,
-		})
+		}, resp.PivotReports))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -449,10 +449,10 @@ func (c *AnalyticsCheckCompatibilityCmd) Run(ctx context.Context, flags *RootFla
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"dimensionCompatibilities": resp.DimensionCompatibilities,
 			"metricCompatibilities":    resp.MetricCompatibilities,
-		})
+		}))
 	}
 
 	u := ui.FromContext(ctx)

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -123,11 +123,11 @@ func (c *AuthCredentialsSetCmd) Run(ctx context.Context) error {
 		}
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"saved":  true,
 			"path":   outPath,
 			"client": client,
-		})
+		}))
 	}
 	u.Out().Printf("path\t%s", outPath)
 	u.Out().Printf("client\t%s", client)
@@ -195,14 +195,14 @@ func (c *AuthCredentialsListCmd) Run(ctx context.Context) error {
 
 	if len(entries) == 0 {
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(os.Stdout, map[string]any{"clients": []entry{}})
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"clients": []entry{}}, []entry{}))
 		}
 		u.Err().Println("No OAuth client credentials stored")
 		return nil
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"clients": entries})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"clients": entries}, entries))
 	}
 
 	w, done := tableWriter(ctx)
@@ -244,13 +244,13 @@ func (c *AuthTokensListCmd) Run(ctx context.Context) error {
 
 	if len(filtered) == 0 {
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(os.Stdout, map[string]any{"keys": []string{}})
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"keys": []string{}}, []string{}))
 		}
 		u.Err().Println("No tokens stored")
 		return nil
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"keys": filtered})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"keys": filtered}, filtered))
 	}
 	for _, k := range filtered {
 		u.Out().Println(k)
@@ -285,11 +285,11 @@ func (c *AuthTokensDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted": true,
 			"email":   email,
 			"client":  client,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("email\t%s", email)
@@ -374,12 +374,12 @@ func (c *AuthTokensExportCmd) Run(ctx context.Context) error {
 
 	u.Err().Println("WARNING: exported file contains a refresh token (keep it safe and delete it when done)")
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"exported": true,
 			"email":    tok.Email,
 			"client":   client,
 			"path":     outPath,
-		})
+		}))
 	}
 	u.Out().Printf("exported\ttrue")
 	u.Out().Printf("email\t%s", tok.Email)
@@ -469,11 +469,11 @@ func (c *AuthTokensImportCmd) Run(ctx context.Context) error {
 
 	u.Err().Println("Imported refresh token into keyring")
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"imported": true,
 			"email":    ex.Email,
 			"client":   client,
-		})
+		}))
 	}
 	u.Out().Printf("imported\ttrue")
 	u.Out().Printf("email\t%s", ex.Email)
@@ -599,12 +599,12 @@ func (c *AuthAddCmd) Run(ctx context.Context) error {
 		}
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"stored":   true,
 			"email":    authorizedEmail,
 			"services": serviceNames,
 			"client":   client,
-		})
+		}))
 	}
 	u.Out().Printf("email\t%s", authorizedEmail)
 	u.Out().Printf("services\t%s", strings.Join(serviceNames, ","))
@@ -679,7 +679,7 @@ func (c *AuthStatusCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"config": map[string]any{
 				"path":   configPath,
 				"exists": configExists,
@@ -697,7 +697,7 @@ func (c *AuthStatusCmd) Run(ctx context.Context, flags *RootFlags) error {
 				"service_account_configured": serviceAccountConfigured,
 				"service_account_path":       serviceAccountPath,
 			},
-		})
+		}))
 	}
 	u.Out().Printf("config_path\t%s", configPath)
 	u.Out().Printf("config_exists\t%t", configExists)
@@ -854,7 +854,7 @@ func (c *AuthListCmd) Run(ctx context.Context) error {
 			}
 			out = append(out, it)
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"accounts": out})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"accounts": out}, out))
 	}
 	if len(entries) == 0 {
 		u.Err().Println("No tokens stored")
@@ -936,7 +936,7 @@ type AuthServicesCmd struct {
 func (c *AuthServicesCmd) Run(ctx context.Context) error {
 	infos := googleauth.ServicesInfo()
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"services": infos})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"services": infos}, infos))
 	}
 	if c.Markdown {
 		_, err := io.WriteString(os.Stdout, googleauth.ServicesMarkdown(infos))
@@ -987,11 +987,11 @@ func (c *AuthRemoveCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted": true,
 			"email":   email,
 			"client":  client,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("email\t%s", email)
@@ -1068,12 +1068,12 @@ func (c *AuthKeepCmd) Run(ctx context.Context) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"stored": true,
 			"email":  email,
 			"path":   destPath,
 			"paths":  []string{destPath, genericPath},
-		})
+		}))
 	}
 	u.Out().Printf("email\t%s", email)
 	u.Out().Printf("path\t%s", destPath)

--- a/internal/cmd/auth_alias.go
+++ b/internal/cmd/auth_alias.go
@@ -27,7 +27,7 @@ func (c *AuthAliasListCmd) Run(ctx context.Context) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"aliases": aliases})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"aliases": aliases}, aliases))
 	}
 	if len(aliases) == 0 {
 		u.Err().Println("No account aliases")
@@ -72,10 +72,10 @@ func (c *AuthAliasSetCmd) Run(ctx context.Context) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"alias": alias,
 			"email": strings.ToLower(email),
-		})
+		}))
 	}
 	u.Out().Printf("alias\t%s", alias)
 	u.Out().Printf("email\t%s", strings.ToLower(email))
@@ -100,10 +100,10 @@ func (c *AuthAliasUnsetCmd) Run(ctx context.Context) error {
 		return usage("alias not found")
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted": true,
 			"alias":   alias,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("alias\t%s", alias)

--- a/internal/cmd/auth_keyring.go
+++ b/internal/cmd/auth_keyring.go
@@ -41,11 +41,11 @@ func (c *AuthKeyringCmd) Run(ctx context.Context) error {
 		}
 
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(os.Stdout, map[string]any{
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 				"keyring_backend": info.Value,
 				"source":          info.Source,
 				"path":            path,
-			})
+			}))
 		}
 
 		if u == nil {
@@ -108,11 +108,11 @@ func (c *AuthKeyringCmd) Run(ctx context.Context) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"written":         true,
 			"path":            path,
 			"keyring_backend": backend,
-		})
+		}))
 	}
 
 	if u == nil {

--- a/internal/cmd/auth_service_account.go
+++ b/internal/cmd/auth_service_account.go
@@ -260,13 +260,13 @@ func (c *AuthServiceAccountSetCmd) Run(ctx context.Context) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"stored":       true,
 			"email":        email,
 			"path":         destPath,
 			"client_email": info.ClientEmail,
 			"client_id":    info.ClientID,
-		})
+		}))
 	}
 	u.Out().Printf("email\t%s", email)
 	u.Out().Printf("path\t%s", destPath)
@@ -309,11 +309,11 @@ func (c *AuthServiceAccountUnsetCmd) Run(ctx context.Context, flags *RootFlags) 
 	if err := os.Remove(path); err != nil {
 		if os.IsNotExist(err) {
 			if outfmt.IsJSON(ctx) {
-				return outfmt.WriteJSON(os.Stdout, map[string]any{
+				return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 					"deleted": false,
 					"email":   email,
 					"path":    path,
-				})
+				}))
 			}
 			u.Out().Printf("deleted\tfalse")
 			u.Out().Printf("email\t%s", email)
@@ -324,11 +324,11 @@ func (c *AuthServiceAccountUnsetCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted": true,
 			"email":   email,
 			"path":    path,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("email\t%s", email)
@@ -357,13 +357,13 @@ func (c *AuthServiceAccountStatusCmd) Run(ctx context.Context) error {
 	if err != nil {
 		if os.IsNotExist(err) {
 			if outfmt.IsJSON(ctx) {
-				return outfmt.WriteJSON(os.Stdout, map[string]any{
+				return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 					"email":   email,
 					"path":    path,
 					"exists":  false,
 					"stored":  false,
 					"message": "no service account configured",
-				})
+				}))
 			}
 			u.Out().Printf("email\t%s", email)
 			u.Out().Printf("path\t%s", path)
@@ -379,14 +379,14 @@ func (c *AuthServiceAccountStatusCmd) Run(ctx context.Context) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"email":        email,
 			"path":         path,
 			"exists":       true,
 			"stored":       true,
 			"client_email": info.ClientEmail,
 			"client_id":    info.ClientID,
-		})
+		}))
 	}
 	u.Out().Printf("email\t%s", email)
 	u.Out().Printf("path\t%s", path)

--- a/internal/cmd/bigquery.go
+++ b/internal/cmd/bigquery.go
@@ -69,11 +69,11 @@ func (c *BigqueryQueryCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"schema":    resp.Schema,
 			"rows":      resp.Rows,
 			"totalRows": resp.TotalRows,
-		})
+		}, resp.Rows))
 	}
 
 	if resp.Schema == nil || len(resp.Schema.Fields) == 0 {
@@ -147,10 +147,10 @@ func (c *BigqueryDatasetsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"datasets":      resp.Datasets,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Datasets))
 	}
 
 	if len(resp.Datasets) == 0 {
@@ -211,10 +211,10 @@ func (c *BigqueryTablesCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"tables":        resp.Tables,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Tables))
 	}
 
 	if len(resp.Tables) == 0 {
@@ -274,9 +274,9 @@ func (c *BigquerySchemaCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"schema": tbl.Schema,
-		})
+		}, tbl.Schema))
 	}
 
 	if tbl.Schema == nil || len(tbl.Schema.Fields) == 0 {
@@ -333,10 +333,10 @@ func (c *BigqueryJobsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"jobs":          resp.Jobs,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Jobs))
 	}
 
 	if len(resp.Jobs) == 0 {

--- a/internal/cmd/businessprofile.go
+++ b/internal/cmd/businessprofile.go
@@ -31,7 +31,7 @@ func writeBusinessProfileMutationReceipt(ctx context.Context, action, resource, 
 		if destination != "" {
 			payload["destination"] = destination
 		}
-		return outfmt.WriteJSON(os.Stdout, payload)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(payload))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -111,10 +111,10 @@ func (c *BusinessProfileLocationsCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"locations":     resp.Locations,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Locations))
 	}
 
 	if len(resp.Locations) == 0 {
@@ -166,7 +166,7 @@ func (c *BusinessProfileGetCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"location": loc})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"location": loc}, loc))
 	}
 
 	u.Out().Printf("name\t%s", loc.Name)

--- a/internal/cmd/businessprofile_accounts.go
+++ b/internal/cmd/businessprofile_accounts.go
@@ -56,7 +56,7 @@ func (c *BusinessProfileAccountsCreateCmd) Run(ctx context.Context, flags *RootF
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"account": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"account": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -105,7 +105,7 @@ func (c *BusinessProfileAccountsGetCmd) Run(ctx context.Context, flags *RootFlag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"account": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"account": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -180,7 +180,7 @@ func (c *BusinessProfileAccountsPatchCmd) Run(ctx context.Context, flags *RootFl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"account": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"account": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -219,10 +219,10 @@ func (c *BusinessProfileAccountsListCmd) Run(ctx context.Context, flags *RootFla
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"accounts":      resp.Accounts,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Accounts))
 	}
 
 	if len(resp.Accounts) == 0 {

--- a/internal/cmd/businessprofile_admins.go
+++ b/internal/cmd/businessprofile_admins.go
@@ -52,9 +52,9 @@ func (c *BusinessProfileAccountAdminsListCmd) Run(ctx context.Context, flags *Ro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"admins": resp.AccountAdmins,
-		})
+		}, resp.AccountAdmins))
 	}
 
 	if len(resp.AccountAdmins) == 0 {
@@ -114,7 +114,7 @@ func (c *BusinessProfileAccountAdminsCreateCmd) Run(ctx context.Context, flags *
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"admin": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"admin": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -205,7 +205,7 @@ func (c *BusinessProfileAccountAdminsPatchCmd) Run(ctx context.Context, flags *R
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"admin": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"admin": resp}, resp))
 	}
 
 	if resp.Name != "" {

--- a/internal/cmd/businessprofile_info_attributes.go
+++ b/internal/cmd/businessprofile_info_attributes.go
@@ -73,10 +73,10 @@ func (c *BusinessProfileInfoAttributesListCmd) Run(ctx context.Context, flags *R
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"attributeMetadata": resp.AttributeMetadata,
 			"nextPageToken":     resp.NextPageToken,
-		})
+		}, resp.AttributeMetadata))
 	}
 
 	if len(resp.AttributeMetadata) == 0 {
@@ -122,10 +122,10 @@ func (c *BusinessProfileInfoLocationAttrsGetCmd) Run(ctx context.Context, flags 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"name":       resp.Name,
 			"attributes": resp.Attributes,
-		})
+		}, resp.Attributes))
 	}
 
 	u.Out().Printf("name\t%s", resp.Name)
@@ -171,10 +171,10 @@ func (c *BusinessProfileInfoLocationAttrsGetGoogleUpdatedCmd) Run(ctx context.Co
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"name":       resp.Name,
 			"attributes": resp.Attributes,
-		})
+		}, resp.Attributes))
 	}
 
 	u := ui.FromContext(ctx)
@@ -250,10 +250,10 @@ func (c *BusinessProfileInfoLocationAttrsUpdateCmd) Run(ctx context.Context, fla
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"name":       resp.Name,
 			"attributes": resp.Attributes,
-		})
+		}, resp.Attributes))
 	}
 
 	u.Out().Printf("name\t%s", resp.Name)

--- a/internal/cmd/businessprofile_info_categories.go
+++ b/internal/cmd/businessprofile_info_categories.go
@@ -57,10 +57,10 @@ func (c *BusinessProfileInfoCategoriesListCmd) Run(ctx context.Context, flags *R
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"categories":    resp.Categories,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Categories))
 	}
 
 	if len(resp.Categories) == 0 {
@@ -113,9 +113,9 @@ func (c *BusinessProfileInfoCategoriesBatchGetCmd) Run(ctx context.Context, flag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"categories": resp.Categories,
-		})
+		}, resp.Categories))
 	}
 
 	if len(resp.Categories) == 0 {

--- a/internal/cmd/businessprofile_info_chains.go
+++ b/internal/cmd/businessprofile_info_chains.go
@@ -47,7 +47,7 @@ func (c *BusinessProfileInfoChainsGetCmd) Run(ctx context.Context, flags *RootFl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"chain": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"chain": resp}, resp))
 	}
 
 	u.Out().Printf("name\t%s", resp.Name)
@@ -92,9 +92,9 @@ func (c *BusinessProfileInfoChainsSearchCmd) Run(ctx context.Context, flags *Roo
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"chains": resp.Chains,
-		})
+		}, resp.Chains))
 	}
 
 	if len(resp.Chains) == 0 {

--- a/internal/cmd/businessprofile_info_locations.go
+++ b/internal/cmd/businessprofile_info_locations.go
@@ -50,9 +50,9 @@ func (c *BusinessProfileInfoGoogleLocationsCmd) Run(ctx context.Context, flags *
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"googleLocations": resp.GoogleLocations,
-		})
+		}, resp.GoogleLocations))
 	}
 
 	if len(resp.GoogleLocations) == 0 {
@@ -153,7 +153,7 @@ func (c *BusinessProfileInfoLocationsCreateCmd) Run(ctx context.Context, flags *
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"location": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"location": resp}, resp))
 	}
 
 	u.Out().Printf("name\t%s", resp.Name)
@@ -232,11 +232,11 @@ func (c *BusinessProfileInfoLocationsGetGoogleUpdatedCmd) Run(ctx context.Contex
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"location":    resp.Location,
 			"diffMask":    resp.DiffMask,
 			"pendingMask": resp.PendingMask,
-		})
+		}, resp.Location))
 	}
 
 	if resp.Location != nil {
@@ -334,7 +334,7 @@ func (c *BusinessProfileInfoLocationsPatchCmd) Run(ctx context.Context, flags *R
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"location": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"location": resp}, resp))
 	}
 
 	u.Out().Printf("name\t%s", resp.Name)

--- a/internal/cmd/businessprofile_invitations.go
+++ b/internal/cmd/businessprofile_invitations.go
@@ -56,9 +56,9 @@ func (c *BusinessProfileInvitationsListCmd) Run(ctx context.Context, flags *Root
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"invitations": resp.Invitations,
-		})
+		}, resp.Invitations))
 	}
 
 	if len(resp.Invitations) == 0 {

--- a/internal/cmd/businessprofile_location_admins.go
+++ b/internal/cmd/businessprofile_location_admins.go
@@ -52,9 +52,9 @@ func (c *BusinessProfileLocationAdminsListCmd) Run(ctx context.Context, flags *R
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"admins": resp.Admins,
-		})
+		}, resp.Admins))
 	}
 
 	if len(resp.Admins) == 0 {
@@ -114,7 +114,7 @@ func (c *BusinessProfileLocationAdminsCreateCmd) Run(ctx context.Context, flags 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"admin": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"admin": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -205,7 +205,7 @@ func (c *BusinessProfileLocationAdminsPatchCmd) Run(ctx context.Context, flags *
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"admin": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"admin": resp}, resp))
 	}
 
 	if resp.Name != "" {

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -77,7 +77,7 @@ func (c *CalendarCalendarsListCmd) Run(ctx context.Context, flags *RootFlags) er
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"calendars":     resp.Items,
 			"nextPageToken": resp.NextPageToken,
 		}, resp.Items))
@@ -209,7 +209,7 @@ func (c *CalendarEventCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	tz, loc, _ := getCalendarLocation(ctx, svc, calendarID)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"event": wrapEventWithDaysWithTimezone(event, tz, loc)})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"event": wrapEventWithDaysWithTimezone(event, tz, loc)}, wrapEventWithDaysWithTimezone(event, tz, loc)))
 	}
 	printCalendarEventWithTimezone(u, event, tz, loc)
 	return nil

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -77,10 +77,10 @@ func (c *CalendarCalendarsListCmd) Run(ctx context.Context, flags *RootFlags) er
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"calendars":     resp.Items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 	if len(resp.Items) == 0 {
 		u.Err().Println("No calendars")

--- a/internal/cmd/calendar_acl.go
+++ b/internal/cmd/calendar_acl.go
@@ -64,10 +64,10 @@ func (c *CalendarAclListCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"rules":         resp.Items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 	if len(resp.Items) == 0 {
 		u.Err().Println("No ACL rules")
@@ -122,7 +122,7 @@ func (c *CalendarAclGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"rule": rule})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"rule": rule}, rule))
 	}
 
 	u.Out().Printf("id\t%s", rule.Id)
@@ -197,7 +197,7 @@ func (c *CalendarAclInsertCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"rule": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"rule": created}, created))
 	}
 
 	u.Out().Printf("id\t%s", created.Id)
@@ -247,10 +247,10 @@ func (c *CalendarAclDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":      ruleID,
 			"deleted": true,
-		})
+		}))
 	}
 
 	u.Err().Printf("ACL rule %q deleted from calendar %q", ruleID, calendarID)
@@ -305,7 +305,7 @@ func (c *CalendarAclPatchCmd) Run(ctx context.Context, kctx *kong.Context, flags
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"rule": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"rule": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -379,7 +379,7 @@ func (c *CalendarAclWatchCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"channel": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"channel": resp}, resp))
 	}
 
 	u.Out().Printf("channel_id\t%s", resp.Id)

--- a/internal/cmd/calendar_channels.go
+++ b/internal/cmd/calendar_channels.go
@@ -56,11 +56,11 @@ func (c *CalendarChannelsStopCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"stopped":    true,
 			"channelId":  channelID,
 			"resourceId": resourceID,
-		})
+		}))
 	}
 
 	u.Out().Printf("stopped\ttrue")

--- a/internal/cmd/calendar_colors.go
+++ b/internal/cmd/calendar_colors.go
@@ -35,10 +35,10 @@ func (c *CalendarColorsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"event":    colors.Event,
 			"calendar": colors.Calendar,
-		})
+		}))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/calendar_conflicts.go
+++ b/internal/cmd/calendar_conflicts.go
@@ -97,7 +97,7 @@ func (c *CalendarConflictsCmd) Run(ctx context.Context, flags *RootFlags) error 
 		if incomplete {
 			payload["errors"] = sourceErrors
 		}
-		if err := outfmt.WriteJSON(os.Stdout, payload); err != nil {
+		if err := outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(payload, conflicts)); err != nil {
 			return err
 		}
 		if incomplete {

--- a/internal/cmd/calendar_conflicts.go
+++ b/internal/cmd/calendar_conflicts.go
@@ -97,7 +97,7 @@ func (c *CalendarConflictsCmd) Run(ctx context.Context, flags *RootFlags) error 
 		if incomplete {
 			payload["errors"] = sourceErrors
 		}
-		if err := outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(payload, conflicts)); err != nil {
+		if err := outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(payload, conflicts)); err != nil {
 			return err
 		}
 		if incomplete {

--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -159,7 +159,7 @@ func (c *CalendarCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	tz, loc, _ := getCalendarLocation(ctx, svc, calendarID)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"event": wrapEventWithDaysWithTimezone(created, tz, loc)})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"event": wrapEventWithDaysWithTimezone(created, tz, loc)}, wrapEventWithDaysWithTimezone(created, tz, loc)))
 	}
 	printCalendarEventWithTimezone(u, created, tz, loc)
 	return nil
@@ -425,7 +425,7 @@ func (c *CalendarUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 	}
 	tz, loc, _ := getCalendarLocation(ctx, svc, calendarID)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"event": wrapEventWithDaysWithTimezone(updated, tz, loc)})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"event": wrapEventWithDaysWithTimezone(updated, tz, loc)}, wrapEventWithDaysWithTimezone(updated, tz, loc)))
 	}
 	printCalendarEventWithTimezone(u, updated, tz, loc)
 	return nil
@@ -890,11 +890,11 @@ func (c *CalendarDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":    true,
 			"calendarId": calendarID,
 			"eventId":    targetEventID,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("calendarId\t%s", calendarID)

--- a/internal/cmd/calendar_events_edit.go
+++ b/internal/cmd/calendar_events_edit.go
@@ -66,7 +66,7 @@ func (c *CalendarEventsWatchCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"channel": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"channel": resp}, resp))
 	}
 
 	u.Out().Printf("channel_id\t%s", resp.Id)
@@ -174,7 +174,7 @@ func (c *CalendarEventsImportCmd) Run(ctx context.Context, flags *RootFlags) err
 
 	tz, loc, _ := getCalendarLocation(ctx, svc, calendarID)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"event": wrapEventWithDaysWithTimezone(imported, tz, loc)})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"event": wrapEventWithDaysWithTimezone(imported, tz, loc)}, wrapEventWithDaysWithTimezone(imported, tz, loc)))
 	}
 	printCalendarEventWithTimezone(u, imported, tz, loc)
 	return nil
@@ -239,11 +239,11 @@ func (c *CalendarEventsInstancesCmd) Run(ctx context.Context, flags *RootFlags) 
 
 	tz, _, _ := getCalendarLocation(ctx, svc, calendarID)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"instances":     resp.Items,
 			"nextPageToken": resp.NextPageToken,
 			"timeZone":      tz,
-		})
+		}, resp.Items))
 	}
 
 	if len(resp.Items) == 0 {
@@ -309,7 +309,7 @@ func (c *CalendarEventsQuickAddCmd) Run(ctx context.Context, flags *RootFlags) e
 
 	tz, loc, _ := getCalendarLocation(ctx, svc, calendarID)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"event": wrapEventWithDaysWithTimezone(created, tz, loc)})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"event": wrapEventWithDaysWithTimezone(created, tz, loc)}, wrapEventWithDaysWithTimezone(created, tz, loc)))
 	}
 	printCalendarEventWithTimezone(u, created, tz, loc)
 	return nil
@@ -365,11 +365,12 @@ func (c *CalendarEventsMoveCmd) Run(ctx context.Context, flags *RootFlags) error
 
 	tz, loc, _ := getCalendarLocation(ctx, svc, destinationCalendarID)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
-			"event":          wrapEventWithDaysWithTimezone(moved, tz, loc),
+		event := wrapEventWithDaysWithTimezone(moved, tz, loc)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
+			"event":          event,
 			"sourceCalendar": sourceCalendarID,
 			"destCalendar":   destinationCalendarID,
-		})
+		}, event))
 	}
 
 	u.Out().Printf("moved\ttrue")

--- a/internal/cmd/calendar_focus_time.go
+++ b/internal/cmd/calendar_focus_time.go
@@ -66,7 +66,7 @@ func (c *CalendarFocusTimeCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 	tz, loc, _ := getCalendarLocation(ctx, svc, c.CalendarID)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"event": wrapEventWithDaysWithTimezone(created, tz, loc)})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"event": wrapEventWithDaysWithTimezone(created, tz, loc)}, wrapEventWithDaysWithTimezone(created, tz, loc)))
 	}
 	printCalendarEventWithTimezone(u, created, tz, loc)
 	return nil

--- a/internal/cmd/calendar_freebusy.go
+++ b/internal/cmd/calendar_freebusy.go
@@ -53,7 +53,7 @@ func (c *CalendarFreeBusyCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"calendars": resp.Calendars})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"calendars": resp.Calendars}, resp.Calendars))
 	}
 
 	if len(resp.Calendars) == 0 {

--- a/internal/cmd/calendar_freebusy_errors_test.go
+++ b/internal/cmd/calendar_freebusy_errors_test.go
@@ -160,7 +160,10 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"calendars": map[string]any{
 					"primary": map[string]any{
-						"busy": []map[string]any{},
+						"busy": []map[string]any{{"start": "2024-12-13T10:00:00Z", "end": "2024-12-13T11:00:00Z"}},
+					},
+					"good@example.com": map[string]any{
+						"busy": []map[string]any{{"start": "2024-12-13T10:30:00Z", "end": "2024-12-13T11:30:00Z"}},
 					},
 					"bad@example.com": map[string]any{
 						"errors": []map[string]any{
@@ -195,7 +198,7 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 				"calendar", "conflicts",
 				"--from", "2024-12-13T09:00:00Z",
 				"--to", "2024-12-13T14:00:00Z",
-				"--calendars", "primary,bad@example.com",
+				"--calendars", "primary,good@example.com,bad@example.com",
 			})
 		})
 	})
@@ -216,7 +219,7 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 				"calendar", "conflicts",
 				"--from", "2024-12-13T09:00:00Z",
 				"--to", "2024-12-13T14:00:00Z",
-				"--calendars", "primary,bad@example.com",
+				"--calendars", "primary,good@example.com,bad@example.com",
 			})
 		})
 	})
@@ -230,7 +233,7 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 	if err := json.Unmarshal([]byte(transformedOut), &transformedConflicts); err != nil {
 		t.Fatalf("transformed JSON parse: %v\nout=%q", err, transformedOut)
 	}
-	if len(transformedConflicts) != 0 {
+	if len(transformedConflicts) != 1 || transformedConflicts[0]["start"] != "2024-12-13T10:30:00Z" || transformedConflicts[0]["end"] != "2024-12-13T11:00:00Z" {
 		t.Fatalf("unexpected transformed conflicts: %#v", transformedConflicts)
 	}
 
@@ -250,8 +253,8 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 	if !parsed.Incomplete {
 		t.Fatalf("expected incomplete=true, out=%q", out)
 	}
-	if parsed.Count != 0 || len(parsed.Conflicts) != 0 {
-		t.Fatalf("expected no conflicts, got count=%d conflicts=%v", parsed.Count, parsed.Conflicts)
+	if parsed.Count != 1 || len(parsed.Conflicts) != 1 {
+		t.Fatalf("expected one primary conflict, got count=%d conflicts=%v", parsed.Count, parsed.Conflicts)
 	}
 	if len(parsed.Errors) != 1 {
 		t.Fatalf("expected 1 source error, got %+v (out=%q)", parsed.Errors, out)
@@ -272,7 +275,7 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 				"calendar", "conflicts",
 				"--from", "2024-12-13T09:00:00Z",
 				"--to", "2024-12-13T14:00:00Z",
-				"--calendars", "primary,bad@example.com",
+				"--calendars", "primary,good@example.com,bad@example.com",
 			})
 		})
 	})
@@ -280,7 +283,8 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 		t.Fatalf("plain execution error = %v, want nonzero incomplete result", plainErr)
 	}
 	wantPlain := "TYPE\tSTATUS\tCALENDAR\tERROR_DOMAIN\tERROR_REASON\tSTART\tEND\tCALENDARS\n" +
-		"error\tincomplete\tbad@example.com\tglobal\tnotFound\t\t\t\n"
+		"error\tincomplete\tbad@example.com\tglobal\tnotFound\t\t\t\n" +
+		"conflict\tincomplete\t\t\t\t2024-12-13T10:30:00Z\t2024-12-13T11:00:00Z\tgood@example.com, primary\n"
 	if plainOut != wantPlain {
 		t.Fatalf("plain output = %q, want %q", plainOut, wantPlain)
 	}

--- a/internal/cmd/calendar_freebusy_errors_test.go
+++ b/internal/cmd/calendar_freebusy_errors_test.go
@@ -186,8 +186,9 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
 
 	var execErr error
+	var jsonStderr string
 	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
+		jsonStderr = captureStderr(t, func() {
 			execErr = Execute([]string{
 				"--json",
 				"--account", "a@b.com",
@@ -203,6 +204,34 @@ func TestCalendarConflicts_SourceErrors_JSONIncompleteAndNonzero(t *testing.T) {
 	}
 	if ExitCode(execErr) == 0 {
 		t.Fatalf("expected nonzero exit code, got 0 (%v)", execErr)
+	}
+
+	var transformedErr error
+	var transformedStderr string
+	transformedOut := captureStdout(t, func() {
+		transformedStderr = captureStderr(t, func() {
+			transformedErr = Execute([]string{
+				"--json", "--results-only", "--select", "start,end",
+				"--account", "a@b.com",
+				"calendar", "conflicts",
+				"--from", "2024-12-13T09:00:00Z",
+				"--to", "2024-12-13T14:00:00Z",
+				"--calendars", "primary,bad@example.com",
+			})
+		})
+	})
+	if transformedErr == nil || ExitCode(transformedErr) != ExitCode(execErr) {
+		t.Fatalf("transformed error = %v, want exit code %d", transformedErr, ExitCode(execErr))
+	}
+	if transformedStderr != jsonStderr {
+		t.Fatalf("transformed stderr changed\ngot:  %q\nwant: %q", transformedStderr, jsonStderr)
+	}
+	var transformedConflicts []map[string]any
+	if err := json.Unmarshal([]byte(transformedOut), &transformedConflicts); err != nil {
+		t.Fatalf("transformed JSON parse: %v\nout=%q", err, transformedOut)
+	}
+	if len(transformedConflicts) != 0 {
+		t.Fatalf("unexpected transformed conflicts: %#v", transformedConflicts)
 	}
 
 	var parsed struct {

--- a/internal/cmd/calendar_list.go
+++ b/internal/cmd/calendar_list.go
@@ -62,10 +62,11 @@ func listCalendarEvents(ctx context.Context, svc *calendar.Service, calendarID, 
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
-			"events":        wrapEventsWithDays(resp.Items),
+		events := wrapEventsWithDays(resp.Items)
+		return outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{
+			"events":        events,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, events))
 	}
 
 	if len(resp.Items) == 0 {
@@ -227,12 +228,12 @@ func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarI
 	}
 
 	if outfmt.IsJSON(ctx) {
-		if err := outfmt.WriteJSON(os.Stdout, map[string]any{
+		if err := outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"events":        all,
 			"errors":        failures,
 			"complete":      len(failures) == 0,
 			"nextPageToken": nextPageToken,
-		}); err != nil {
+		}, all)); err != nil {
 			return err
 		}
 		return resultErr

--- a/internal/cmd/calendar_list.go
+++ b/internal/cmd/calendar_list.go
@@ -63,7 +63,7 @@ func listCalendarEvents(ctx context.Context, svc *calendar.Service, calendarID, 
 	}
 	if outfmt.IsJSON(ctx) {
 		events := wrapEventsWithDays(resp.Items)
-		return outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"events":        events,
 			"nextPageToken": resp.NextPageToken,
 		}, events))
@@ -228,7 +228,7 @@ func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarI
 	}
 
 	if outfmt.IsJSON(ctx) {
-		if err := outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{
+		if err := outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"events":        all,
 			"errors":        failures,
 			"complete":      len(failures) == 0,

--- a/internal/cmd/calendar_list_edit.go
+++ b/internal/cmd/calendar_list_edit.go
@@ -55,7 +55,7 @@ func (c *CalendarCalendarsGetCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"calendar": entry})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"calendar": entry}, entry))
 	}
 
 	u.Out().Printf("id\t%s", entry.Id)
@@ -141,7 +141,7 @@ func (c *CalendarCalendarsInsertCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"calendar": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"calendar": created}, created))
 	}
 
 	u.Out().Printf("id\t%s", created.Id)
@@ -235,7 +235,7 @@ func (c *CalendarCalendarsUpdateCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"calendar": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"calendar": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -347,7 +347,7 @@ func (c *CalendarCalendarsPatchCmd) Run(ctx context.Context, kctx *kong.Context,
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"calendar": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"calendar": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -390,10 +390,10 @@ func (c *CalendarCalendarsDeleteCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":      calendarID,
 			"deleted": true,
-		})
+		}))
 	}
 
 	u.Err().Printf("Calendar %q removed from your list", calendarID)
@@ -444,7 +444,7 @@ func (c *CalendarCalendarsWatchCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"channel": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"channel": resp}, resp))
 	}
 
 	u.Out().Printf("channel_id\t%s", resp.Id)

--- a/internal/cmd/calendar_ooo.go
+++ b/internal/cmd/calendar_ooo.go
@@ -57,7 +57,7 @@ func (c *CalendarOOOCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	tz, loc, _ := getCalendarLocation(ctx, svc, c.CalendarID)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"event": wrapEventWithDaysWithTimezone(created, tz, loc)})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"event": wrapEventWithDaysWithTimezone(created, tz, loc)}, wrapEventWithDaysWithTimezone(created, tz, loc)))
 	}
 	printCalendarEventWithTimezone(u, created, tz, loc)
 	return nil

--- a/internal/cmd/calendar_propose_time.go
+++ b/internal/cmd/calendar_propose_time.go
@@ -133,7 +133,7 @@ func (c *CalendarProposeTimeCmd) Run(ctx context.Context, flags *RootFlags) erro
 				result["comment"] = strings.TrimSpace(c.Comment)
 			}
 		}
-		return outfmt.WriteJSON(os.Stdout, result)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(result))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/calendar_respond.go
+++ b/internal/cmd/calendar_respond.go
@@ -91,7 +91,7 @@ func (c *CalendarRespondCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	if outfmt.IsJSON(ctx) {
 		tz, loc, _ := getCalendarLocation(ctx, svc, calendarID)
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"event": wrapEventWithDaysWithTimezone(updated, tz, loc)})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"event": wrapEventWithDaysWithTimezone(updated, tz, loc)}, wrapEventWithDaysWithTimezone(updated, tz, loc)))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)

--- a/internal/cmd/calendar_search.go
+++ b/internal/cmd/calendar_search.go
@@ -58,10 +58,10 @@ func (c *CalendarSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"events": wrapEventsWithDays(resp.Items),
 			"query":  query,
-		})
+		}, wrapEventsWithDays(resp.Items)))
 	}
 
 	if len(resp.Items) == 0 {

--- a/internal/cmd/calendar_settings.go
+++ b/internal/cmd/calendar_settings.go
@@ -46,10 +46,10 @@ func (c *CalendarSettingsListCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"settings":      resp.Items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 
 	if len(resp.Items) == 0 {
@@ -94,7 +94,7 @@ func (c *CalendarSettingsGetCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"setting": setting})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"setting": setting}, setting))
 	}
 
 	u.Out().Printf("id\t%s", setting.Id)
@@ -146,7 +146,7 @@ func (c *CalendarSettingsWatchCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"channel": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"channel": resp}, resp))
 	}
 
 	u.Out().Printf("channel_id\t%s", resp.Id)

--- a/internal/cmd/calendar_team.go
+++ b/internal/cmd/calendar_team.go
@@ -141,13 +141,13 @@ func (c *CalendarTeamCmd) runFreeBusy(ctx context.Context, svc *calendar.Service
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"group":    c.GroupEmail,
 			"timeMin":  tr.From.Format(time.RFC3339),
 			"timeMax":  tr.To.Format(time.RFC3339),
 			"timezone": tr.Location.String(),
 			"freebusy": results,
-		})
+		}, results))
 	}
 
 	// Text output
@@ -284,7 +284,7 @@ func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		if err := outfmt.WriteJSON(os.Stdout, map[string]any{
+		if err := outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"group":    c.GroupEmail,
 			"timeMin":  tr.From.Format(time.RFC3339),
 			"timeMax":  tr.To.Format(time.RFC3339),
@@ -292,7 +292,7 @@ func (c *CalendarTeamCmd) runEvents(ctx context.Context, svc *calendar.Service, 
 			"events":   events,
 			"errors":   failures,
 			"complete": len(failures) == 0,
-		}); err != nil {
+		}, events)); err != nil {
 			return err
 		}
 		return resultErr

--- a/internal/cmd/calendar_time.go
+++ b/internal/cmd/calendar_time.go
@@ -50,11 +50,11 @@ func (c *CalendarTimeCmd) Run(ctx context.Context, flags *RootFlags) error {
 	formatted := now.Format("Monday, January 02, 2006 03:04 PM")
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"timezone":     tz,
 			"current_time": now.Format(time.RFC3339),
 			"formatted":    formatted,
-		})
+		}))
 	}
 
 	u.Out().Printf("timezone\t%s", tz)

--- a/internal/cmd/calendar_users.go
+++ b/internal/cmd/calendar_users.go
@@ -71,10 +71,10 @@ func (c *CalendarUsersCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Name:  primaryName(p),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"users":         items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.People) == 0 {

--- a/internal/cmd/calendar_working_location.go
+++ b/internal/cmd/calendar_working_location.go
@@ -58,7 +58,7 @@ func (c *CalendarWorkingLocationCmd) Run(ctx context.Context, flags *RootFlags) 
 
 	tz, loc, _ := getCalendarLocation(ctx, svc, c.CalendarID)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"event": wrapEventWithDaysWithTimezone(created, tz, loc)})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"event": wrapEventWithDaysWithTimezone(created, tz, loc)}, wrapEventWithDaysWithTimezone(created, tz, loc)))
 	}
 	printCalendarEventWithTimezone(u, created, tz, loc)
 	return nil

--- a/internal/cmd/chat_dm.go
+++ b/internal/cmd/chat_dm.go
@@ -77,7 +77,7 @@ func (c *ChatDMSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"message": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"message": resp}, resp))
 	}
 
 	if resp == nil {
@@ -126,7 +126,7 @@ func (c *ChatDMSpaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"space": space})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"space": space}, space))
 	}
 	if space.Name != "" {
 		u.Out().Printf("resource\t%s", space.Name)

--- a/internal/cmd/chat_emoji.go
+++ b/internal/cmd/chat_emoji.go
@@ -77,10 +77,10 @@ func (c *ChatEmojiListCmd) Run(ctx context.Context, flags *RootFlags) error {
 				ImageURI: emoji.TemporaryImageUri,
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"customEmojis":  items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.CustomEmojis) == 0 {
@@ -141,7 +141,7 @@ func (c *ChatEmojiGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"customEmoji": emoji})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"customEmoji": emoji}, emoji))
 	}
 
 	if emoji.Name != "" {
@@ -240,7 +240,7 @@ func (c *ChatEmojiCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"customEmoji": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"customEmoji": resp}, resp))
 	}
 
 	if resp.Name != "" {

--- a/internal/cmd/chat_events.go
+++ b/internal/cmd/chat_events.go
@@ -47,7 +47,7 @@ func (c *ChatEventsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"event": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"event": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -119,10 +119,10 @@ func (c *ChatEventsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 				EventTime: evt.EventTime,
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"spaceEvents":   items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.SpaceEvents) == 0 {

--- a/internal/cmd/chat_media.go
+++ b/internal/cmd/chat_media.go
@@ -110,10 +110,10 @@ func (c *ChatMediaUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"attachmentDataRef": resp.AttachmentDataRef,
 			"filename":          filename,
-		})
+		}))
 	}
 
 	if resp.AttachmentDataRef != nil {
@@ -197,11 +197,11 @@ func (c *ChatMediaDownloadCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"resource": resource,
 			"path":     destPath,
 			"size":     n,
-		})
+		}))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/chat_members.go
+++ b/internal/cmd/chat_members.go
@@ -93,10 +93,10 @@ func (c *ChatMembersListCmd) Run(ctx context.Context, flags *RootFlags) error {
 				State:    member.State,
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"memberships":   items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.Memberships) == 0 {
@@ -153,7 +153,7 @@ func (c *ChatMembersGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"membership": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"membership": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -215,7 +215,7 @@ func (c *ChatMembersCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"membership": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"membership": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -314,7 +314,7 @@ func (c *ChatMembersPatchCmd) Run(ctx context.Context, flags *RootFlags, kctx *k
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"membership": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"membership": resp}, resp))
 	}
 
 	if resp.Name != "" {

--- a/internal/cmd/chat_messages.go
+++ b/internal/cmd/chat_messages.go
@@ -107,10 +107,10 @@ func (c *ChatMessagesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Thread:     chatMessageThread(msg),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"messages":      items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.Messages) == 0 {
@@ -188,7 +188,7 @@ func (c *ChatMessagesSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"message": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"message": resp}, resp))
 	}
 
 	if resp == nil {

--- a/internal/cmd/chat_messages_edit.go
+++ b/internal/cmd/chat_messages_edit.go
@@ -44,7 +44,7 @@ func (c *ChatMessagesGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"message": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"message": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -153,7 +153,7 @@ func (c *ChatMessagesPatchCmd) Run(ctx context.Context, flags *RootFlags, kctx *
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"message": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"message": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -216,7 +216,7 @@ func (c *ChatMessagesUpdateCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"message": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"message": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -267,7 +267,7 @@ func (c *ChatAttachmentsGetCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"attachment": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"attachment": resp}, resp))
 	}
 
 	if resp.Name != "" {

--- a/internal/cmd/chat_reactions.go
+++ b/internal/cmd/chat_reactions.go
@@ -77,10 +77,10 @@ func (c *ChatReactionsListCmd) Run(ctx context.Context, flags *RootFlags) error 
 				User:     reactionUser(r),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"reactions":     items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.Reactions) == 0 {
@@ -151,7 +151,7 @@ func (c *ChatReactionsCreateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"reaction": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"reaction": resp}, resp))
 	}
 
 	if resp.Name != "" {

--- a/internal/cmd/chat_readstate.go
+++ b/internal/cmd/chat_readstate.go
@@ -59,7 +59,7 @@ func (c *ChatNotificationSettingsGetCmd) Run(ctx context.Context, flags *RootFla
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"notificationSetting": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"notificationSetting": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -117,7 +117,7 @@ func (c *ChatNotificationSettingsPatchCmd) Run(ctx context.Context, flags *RootF
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"notificationSetting": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"notificationSetting": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -160,7 +160,7 @@ func (c *ChatThreadReadStateGetCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"threadReadState": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"threadReadState": resp}, resp))
 	}
 
 	if resp.Name != "" {
@@ -218,7 +218,7 @@ func (c *ChatSpaceReadStateUpdateCmd) Run(ctx context.Context, flags *RootFlags,
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"spaceReadState": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"spaceReadState": resp}, resp))
 	}
 
 	if resp.Name != "" {

--- a/internal/cmd/chat_spaces.go
+++ b/internal/cmd/chat_spaces.go
@@ -74,10 +74,10 @@ func (c *ChatSpacesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 				ThreadState: space.SpaceThreadingState,
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"spaces":        items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.Spaces) == 0 {
@@ -171,7 +171,7 @@ func (c *ChatSpacesFindCmd) Run(ctx context.Context, flags *RootFlags) error {
 				SpaceURI:  space.SpaceUri,
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"spaces": items})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"spaces": items}, items))
 	}
 
 	if len(matches) == 0 {
@@ -250,7 +250,7 @@ func (c *ChatSpacesCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"space": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"space": resp}, resp))
 	}
 
 	if resp == nil {

--- a/internal/cmd/chat_spaces_edit.go
+++ b/internal/cmd/chat_spaces_edit.go
@@ -47,7 +47,7 @@ func (c *ChatSpacesCompleteImportCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"space": resp.Space})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"space": resp.Space}, resp.Space))
 	}
 
 	printSpaceDetails(u, resp.Space)
@@ -107,7 +107,7 @@ func (c *ChatSpacesCreateDirectCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"space": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"space": resp}, resp))
 	}
 
 	printSpaceDetails(u, resp)
@@ -186,7 +186,7 @@ func (c *ChatSpacesFindDmCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"space": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"space": resp}, resp))
 	}
 
 	printSpaceDetails(u, resp)
@@ -227,7 +227,7 @@ func (c *ChatSpacesGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"space": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"space": resp}, resp))
 	}
 
 	printSpaceDetails(u, resp)
@@ -298,7 +298,7 @@ func (c *ChatSpacesPatchCmd) Run(ctx context.Context, flags *RootFlags, kctx *ko
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"space": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"space": resp}, resp))
 	}
 
 	printSpaceDetails(u, resp)
@@ -363,10 +363,10 @@ func (c *ChatSpacesSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 				ThreadState: space.SpaceThreadingState,
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"spaces":        items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.Spaces) == 0 {

--- a/internal/cmd/chat_threads.go
+++ b/internal/cmd/chat_threads.go
@@ -81,10 +81,10 @@ func (c *ChatThreadsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 				"createTime": item.message.CreateTime,
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"threads":       items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(threads) == 0 {

--- a/internal/cmd/classroom_announcements.go
+++ b/internal/cmd/classroom_announcements.go
@@ -63,10 +63,10 @@ func (c *ClassroomAnnouncementsListCmd) Run(ctx context.Context, flags *RootFlag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"announcements": resp.Announcements,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Announcements))
 	}
 
 	if len(resp.Announcements) == 0 {
@@ -124,7 +124,7 @@ func (c *ClassroomAnnouncementsGetCmd) Run(ctx context.Context, flags *RootFlags
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"announcement": ann})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"announcement": ann}, ann))
 	}
 
 	u.Out().Printf("id\t%s", ann.Id)
@@ -181,7 +181,7 @@ func (c *ClassroomAnnouncementsCreateCmd) Run(ctx context.Context, flags *RootFl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"announcement": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"announcement": created}, created))
 	}
 	u.Out().Printf("id\t%s", created.Id)
 	u.Out().Printf("state\t%s", created.State)
@@ -240,7 +240,7 @@ func (c *ClassroomAnnouncementsUpdateCmd) Run(ctx context.Context, flags *RootFl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"announcement": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"announcement": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("state\t%s", updated.State)
@@ -282,11 +282,11 @@ func (c *ClassroomAnnouncementsDeleteCmd) Run(ctx context.Context, flags *RootFl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":        true,
 			"courseId":       courseID,
 			"announcementId": announcementID,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("course_id\t%s", courseID)
@@ -340,7 +340,7 @@ func (c *ClassroomAnnouncementsAssigneesCmd) Run(ctx context.Context, flags *Roo
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"announcement": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"announcement": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("assignee_mode\t%s", updated.AssigneeMode)

--- a/internal/cmd/classroom_courses.go
+++ b/internal/cmd/classroom_courses.go
@@ -66,10 +66,10 @@ func (c *ClassroomCoursesListCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"courses":       resp.Courses,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Courses))
 	}
 
 	if len(resp.Courses) == 0 {
@@ -122,7 +122,7 @@ func (c *ClassroomCoursesGetCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"course": course})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"course": course}, course))
 	}
 
 	u.Out().Printf("id\t%s", course.Id)
@@ -208,7 +208,7 @@ func (c *ClassroomCoursesCreateCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"course": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"course": created}, created))
 	}
 	u.Out().Printf("id\t%s", created.Id)
 	u.Out().Printf("name\t%s", created.Name)
@@ -285,7 +285,7 @@ func (c *ClassroomCoursesUpdateCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"course": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"course": updated}, updated))
 	}
 	u := ui.FromContext(ctx)
 	u.Out().Printf("id\t%s", updated.Id)
@@ -324,10 +324,10 @@ func (c *ClassroomCoursesDeleteCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":  true,
 			"courseId": courseID,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("course_id\t%s", courseID)
@@ -373,7 +373,7 @@ func updateCourseState(ctx context.Context, flags *RootFlags, courseID, state st
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"course": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"course": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("state\t%s", updated.CourseState)
@@ -420,7 +420,7 @@ func (c *ClassroomCoursesJoinCmd) Run(ctx context.Context, flags *RootFlags) err
 			return wrapClassroomError(err)
 		}
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(os.Stdout, map[string]any{"student": created})
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"student": created}, created))
 		}
 		u.Out().Printf("user_id\t%s", created.UserId)
 		u.Out().Printf("email\t%s", profileEmail(created.Profile))
@@ -433,7 +433,7 @@ func (c *ClassroomCoursesJoinCmd) Run(ctx context.Context, flags *RootFlags) err
 			return wrapClassroomError(err)
 		}
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(os.Stdout, map[string]any{"teacher": created})
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"teacher": created}, created))
 		}
 		u.Out().Printf("user_id\t%s", created.UserId)
 		u.Out().Printf("email\t%s", profileEmail(created.Profile))
@@ -490,12 +490,12 @@ func (c *ClassroomCoursesLeaveCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"removed":  true,
 			"courseId": courseID,
 			"userId":   userID,
 			"role":     role,
-		})
+		}))
 	}
 	u.Out().Printf("removed\ttrue")
 	u.Out().Printf("course_id\t%s", courseID)
@@ -532,7 +532,7 @@ func (c *ClassroomCoursesURLCmd) Run(ctx context.Context, flags *RootFlags) erro
 			}
 			urls = append(urls, map[string]string{"id": id, "url": link})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"urls": urls})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"urls": urls}, urls))
 	}
 
 	for _, id := range c.CourseIDs {

--- a/internal/cmd/classroom_coursework.go
+++ b/internal/cmd/classroom_coursework.go
@@ -85,10 +85,10 @@ func (c *ClassroomCourseworkListCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"coursework":    coursework,
 			"nextPageToken": nextPageToken,
-		})
+		}, coursework))
 	}
 
 	if len(coursework) == 0 {
@@ -148,7 +148,7 @@ func (c *ClassroomCourseworkGetCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"coursework": work})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"coursework": work}, work))
 	}
 
 	u.Out().Printf("id\t%s", work.Id)
@@ -264,7 +264,7 @@ func (c *ClassroomCourseworkCreateCmd) Run(ctx context.Context, flags *RootFlags
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"coursework": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"coursework": created}, created))
 	}
 	u.Out().Printf("id\t%s", created.Id)
 	u.Out().Printf("title\t%s", created.Title)
@@ -377,7 +377,7 @@ func (c *ClassroomCourseworkUpdateCmd) Run(ctx context.Context, flags *RootFlags
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"coursework": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"coursework": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("title\t%s", updated.Title)
@@ -420,11 +420,11 @@ func (c *ClassroomCourseworkDeleteCmd) Run(ctx context.Context, flags *RootFlags
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":      true,
 			"courseId":     courseID,
 			"courseworkId": courseworkID,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("course_id\t%s", courseID)
@@ -478,7 +478,7 @@ func (c *ClassroomCourseworkAssigneesCmd) Run(ctx context.Context, flags *RootFl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"coursework": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"coursework": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("assignee_mode\t%s", updated.AssigneeMode)

--- a/internal/cmd/classroom_guardians.go
+++ b/internal/cmd/classroom_guardians.go
@@ -52,10 +52,10 @@ func (c *ClassroomGuardiansListCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"guardians":     resp.Guardians,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Guardians))
 	}
 
 	if len(resp.Guardians) == 0 {
@@ -111,7 +111,7 @@ func (c *ClassroomGuardiansGetCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"guardian": guardian})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"guardian": guardian}, guardian))
 	}
 
 	u.Out().Printf("id\t%s", guardian.GuardianId)
@@ -156,11 +156,11 @@ func (c *ClassroomGuardiansDeleteCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":    true,
 			"studentId":  studentID,
 			"guardianId": guardianID,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("student_id\t%s", studentID)
@@ -216,10 +216,10 @@ func (c *ClassroomGuardianInvitesListCmd) Run(ctx context.Context, flags *RootFl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"invitations":   resp.GuardianInvitations,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.GuardianInvitations))
 	}
 
 	if len(resp.GuardianInvitations) == 0 {
@@ -276,7 +276,7 @@ func (c *ClassroomGuardianInvitesGetCmd) Run(ctx context.Context, flags *RootFla
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"invitation": inv})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"invitation": inv}, inv))
 	}
 
 	u.Out().Printf("id\t%s", inv.InvitationId)
@@ -321,7 +321,7 @@ func (c *ClassroomGuardianInvitesCreateCmd) Run(ctx context.Context, flags *Root
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"invitation": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"invitation": created}, created))
 	}
 	u.Out().Printf("id\t%s", created.InvitationId)
 	u.Out().Printf("student_id\t%s", created.StudentId)

--- a/internal/cmd/classroom_invitations.go
+++ b/internal/cmd/classroom_invitations.go
@@ -53,10 +53,10 @@ func (c *ClassroomInvitationsListCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"invitations":   resp.Invitations,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Invitations))
 	}
 
 	if len(resp.Invitations) == 0 {
@@ -108,7 +108,7 @@ func (c *ClassroomInvitationsGetCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"invitation": inv})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"invitation": inv}, inv))
 	}
 
 	u.Out().Printf("id\t%s", inv.Id)
@@ -155,7 +155,7 @@ func (c *ClassroomInvitationsCreateCmd) Run(ctx context.Context, flags *RootFlag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"invitation": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"invitation": created}, created))
 	}
 	u.Out().Printf("id\t%s", created.Id)
 	u.Out().Printf("course_id\t%s", created.CourseId)
@@ -189,10 +189,10 @@ func (c *ClassroomInvitationsAcceptCmd) Run(ctx context.Context, flags *RootFlag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"accepted":     true,
 			"invitationId": invitationID,
-		})
+		}))
 	}
 	u.Out().Printf("accepted\ttrue")
 	u.Out().Printf("invitation_id\t%s", invitationID)
@@ -229,10 +229,10 @@ func (c *ClassroomInvitationsDeleteCmd) Run(ctx context.Context, flags *RootFlag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":      true,
 			"invitationId": invitationID,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("invitation_id\t%s", invitationID)

--- a/internal/cmd/classroom_materials.go
+++ b/internal/cmd/classroom_materials.go
@@ -84,10 +84,10 @@ func (c *ClassroomMaterialsListCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"materials":     materials,
 			"nextPageToken": nextPageToken,
-		})
+		}, materials))
 	}
 
 	if len(materials) == 0 {
@@ -145,7 +145,7 @@ func (c *ClassroomMaterialsGetCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"material": material})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"material": material}, material))
 	}
 
 	u.Out().Printf("id\t%s", material.Id)
@@ -211,7 +211,7 @@ func (c *ClassroomMaterialsCreateCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"material": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"material": created}, created))
 	}
 	u.Out().Printf("id\t%s", created.Id)
 	u.Out().Printf("title\t%s", created.Title)
@@ -281,7 +281,7 @@ func (c *ClassroomMaterialsUpdateCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"material": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"material": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("title\t%s", updated.Title)
@@ -324,11 +324,11 @@ func (c *ClassroomMaterialsDeleteCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":    true,
 			"courseId":   courseID,
 			"materialId": materialID,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("course_id\t%s", courseID)

--- a/internal/cmd/classroom_profile.go
+++ b/internal/cmd/classroom_profile.go
@@ -39,7 +39,7 @@ func (c *ClassroomProfileGetCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"profile": profile})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"profile": profile}, profile))
 	}
 
 	u.Out().Printf("id\t%s", profile.Id)

--- a/internal/cmd/classroom_rosters.go
+++ b/internal/cmd/classroom_rosters.go
@@ -47,10 +47,10 @@ func (c *ClassroomStudentsListCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"students":      resp.Students,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Students))
 	}
 
 	if len(resp.Students) == 0 {
@@ -106,7 +106,7 @@ func (c *ClassroomStudentsGetCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"student": student})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"student": student}, student))
 	}
 
 	u.Out().Printf("user_id\t%s", student.UserId)
@@ -155,7 +155,7 @@ func (c *ClassroomStudentsAddCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"student": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"student": created}, created))
 	}
 	u.Out().Printf("user_id\t%s", created.UserId)
 	u.Out().Printf("email\t%s", profileEmail(created.Profile))
@@ -198,11 +198,11 @@ func (c *ClassroomStudentsRemoveCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"removed":  true,
 			"courseId": courseID,
 			"userId":   userID,
-		})
+		}))
 	}
 	u.Out().Printf("removed\ttrue")
 	u.Out().Printf("course_id\t%s", courseID)
@@ -245,10 +245,10 @@ func (c *ClassroomTeachersListCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"teachers":      resp.Teachers,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Teachers))
 	}
 
 	if len(resp.Teachers) == 0 {
@@ -304,7 +304,7 @@ func (c *ClassroomTeachersGetCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"teacher": teacher})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"teacher": teacher}, teacher))
 	}
 
 	u.Out().Printf("user_id\t%s", teacher.UserId)
@@ -345,7 +345,7 @@ func (c *ClassroomTeachersAddCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"teacher": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"teacher": created}, created))
 	}
 	u.Out().Printf("user_id\t%s", created.UserId)
 	u.Out().Printf("email\t%s", profileEmail(created.Profile))
@@ -388,11 +388,11 @@ func (c *ClassroomTeachersRemoveCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"removed":  true,
 			"courseId": courseID,
 			"userId":   userID,
-		})
+		}))
 	}
 	u.Out().Printf("removed\ttrue")
 	u.Out().Printf("course_id\t%s", courseID)
@@ -453,7 +453,7 @@ func (c *ClassroomRosterCmd) Run(ctx context.Context, flags *RootFlags) error {
 			payload["teachers"] = teachersResp.Teachers
 			payload["teachersNextPageToken"] = teachersResp.NextPageToken
 		}
-		return outfmt.WriteJSON(os.Stdout, payload)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(payload))
 	}
 
 	w, flush := tableWriter(ctx)

--- a/internal/cmd/classroom_submissions.go
+++ b/internal/cmd/classroom_submissions.go
@@ -79,10 +79,10 @@ func (c *ClassroomSubmissionsListCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"submissions":   resp.StudentSubmissions,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.StudentSubmissions))
 	}
 
 	if len(resp.StudentSubmissions) == 0 {
@@ -147,7 +147,7 @@ func (c *ClassroomSubmissionsGetCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"submission": sub})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"submission": sub}, sub))
 	}
 
 	u.Out().Printf("id\t%s", sub.Id)
@@ -237,13 +237,13 @@ func submissionAction(ctx context.Context, flags *RootFlags, courseID, coursewor
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"ok":           true,
 			"courseId":     courseID,
 			"courseworkId": courseworkID,
 			"submissionId": submissionID,
 			"action":       action,
-		})
+		}))
 	}
 	u.Out().Printf("ok\ttrue")
 	u.Out().Printf("course_id\t%s", courseID)
@@ -313,7 +313,7 @@ func (c *ClassroomSubmissionsGradeCmd) Run(ctx context.Context, flags *RootFlags
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"submission": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"submission": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("draft_grade\t%s", formatFloatValue(updated.DraftGrade))

--- a/internal/cmd/classroom_topics.go
+++ b/internal/cmd/classroom_topics.go
@@ -48,10 +48,10 @@ func (c *ClassroomTopicsListCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"topics":        resp.Topic,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Topic))
 	}
 
 	if len(resp.Topic) == 0 {
@@ -107,7 +107,7 @@ func (c *ClassroomTopicsGetCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"topic": topic})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"topic": topic}, topic))
 	}
 
 	u.Out().Printf("id\t%s", topic.TopicId)
@@ -150,7 +150,7 @@ func (c *ClassroomTopicsCreateCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"topic": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"topic": created}, created))
 	}
 	u.Out().Printf("id\t%s", created.TopicId)
 	u.Out().Printf("name\t%s", created.Name)
@@ -194,7 +194,7 @@ func (c *ClassroomTopicsUpdateCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"topic": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"topic": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.TopicId)
 	u.Out().Printf("name\t%s", updated.Name)
@@ -236,11 +236,11 @@ func (c *ClassroomTopicsDeleteCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":  true,
 			"courseId": courseID,
 			"topicId":  topicID,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("course_id\t%s", courseID)

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -39,7 +39,7 @@ func (c *ConfigGetCmd) Run(ctx context.Context) error {
 	value := config.GetValue(cfg, key)
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, outfmt.KeyValuePayload(key.String(), value))
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(outfmt.KeyValuePayload(key.String(), value)))
 	}
 	fmt.Fprintln(os.Stdout, formatConfigValue(value, spec.EmptyHint))
 	return nil
@@ -50,7 +50,7 @@ type ConfigKeysCmd struct{}
 func (c *ConfigKeysCmd) Run(ctx context.Context) error {
 	keys := config.KeyNames()
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, outfmt.KeysPayload(keys))
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(outfmt.KeysPayload(keys), keys))
 	}
 	for _, key := range keys {
 		fmt.Fprintln(os.Stdout, key)
@@ -85,7 +85,7 @@ func (c *ConfigSetCmd) Run(ctx context.Context) error {
 	if outfmt.IsJSON(ctx) {
 		payload := outfmt.KeyValuePayload(key.String(), c.Value)
 		payload["saved"] = true
-		return outfmt.WriteJSON(os.Stdout, payload)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(payload))
 	}
 	if outfmt.IsPlain(ctx) {
 		fmt.Fprintln(os.Stdout, "ACTION\tKEY\tVALUE")
@@ -122,7 +122,7 @@ func (c *ConfigUnsetCmd) Run(ctx context.Context) error {
 	if outfmt.IsJSON(ctx) {
 		payload := outfmt.KeyValuePayload(key.String(), "")
 		payload["removed"] = true
-		return outfmt.WriteJSON(os.Stdout, payload)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(payload))
 	}
 	if outfmt.IsPlain(ctx) {
 		fmt.Fprintln(os.Stdout, "ACTION\tKEY\tVALUE")
@@ -149,7 +149,7 @@ func (c *ConfigListCmd) Run(ctx context.Context) error {
 		for _, key := range keys {
 			payload[key.String()] = config.GetValue(cfg, key)
 		}
-		return outfmt.WriteJSON(os.Stdout, payload)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(payload))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -177,7 +177,7 @@ func (c *ConfigPathCmd) Run(ctx context.Context) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, outfmt.PathPayload(path))
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(outfmt.PathPayload(path)))
 	}
 	fmt.Fprintln(os.Stdout, path)
 	return nil

--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -72,7 +72,7 @@ func (c *ContactsSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Phone:    primaryPhone(p),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"contacts": items})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"contacts": items}, items))
 	}
 	if len(resp.Results) == 0 {
 		u.Err().Println("No results")

--- a/internal/cmd/contacts_crud.go
+++ b/internal/cmd/contacts_crud.go
@@ -62,10 +62,10 @@ func (c *ContactsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Phone:    primaryPhone(p),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"contacts":      items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 	if len(resp.Connections) == 0 {
 		u.Err().Println("No contacts")
@@ -140,7 +140,7 @@ func (c *ContactsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 		if p == nil {
 			if outfmt.IsJSON(ctx) {
-				return outfmt.WriteJSON(os.Stdout, map[string]any{"found": false})
+				return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"found": false}))
 			}
 			u.Err().Println("Not found")
 			return nil
@@ -148,7 +148,7 @@ func (c *ContactsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"contact": p})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"contact": p}, p))
 	}
 
 	u.Out().Printf("resource\t%s", p.ResourceName)
@@ -205,7 +205,7 @@ func (c *ContactsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"contact": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"contact": created}, created))
 	}
 	u.Out().Printf("resource\t%s", created.ResourceName)
 	return nil
@@ -287,7 +287,7 @@ func (c *ContactsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"contact": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"contact": updated}, updated))
 	}
 	u.Out().Printf("resource\t%s", updated.ResourceName)
 	return nil

--- a/internal/cmd/contacts_directory.go
+++ b/internal/cmd/contacts_directory.go
@@ -70,10 +70,10 @@ func (c *ContactsDirectoryListCmd) Run(ctx context.Context, flags *RootFlags) er
 				Email:    primaryEmail(p),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"people":        items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.People) == 0 {
@@ -148,10 +148,10 @@ func (c *ContactsDirectorySearchCmd) Run(ctx context.Context, flags *RootFlags) 
 				Email:    primaryEmail(p),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"people":        items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.People) == 0 {
@@ -226,10 +226,10 @@ func (c *ContactsOtherListCmd) Run(ctx context.Context, flags *RootFlags) error 
 				Phone:    primaryPhone(p),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"contacts":      items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.OtherContacts) == 0 {
@@ -301,7 +301,7 @@ func (c *ContactsOtherSearchCmd) Run(ctx context.Context, flags *RootFlags) erro
 				Phone:    primaryPhone(p),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"contacts": items})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"contacts": items}, items))
 	}
 
 	if len(resp.Results) == 0 {

--- a/internal/cmd/contacts_groups.go
+++ b/internal/cmd/contacts_groups.go
@@ -59,12 +59,12 @@ func (c *ContactGroupsListCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"contactGroups": resp.ContactGroups,
 			"nextPageToken": resp.NextPageToken,
 			"nextSyncToken": resp.NextSyncToken,
 			"totalItems":    resp.TotalItems,
-		})
+		}, resp.ContactGroups))
 	}
 
 	if len(resp.ContactGroups) == 0 {
@@ -129,7 +129,7 @@ func (c *ContactGroupsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"contactGroup": g})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"contactGroup": g}, g))
 	}
 
 	u.Out().Printf("resource\t%s", g.ResourceName)
@@ -190,9 +190,9 @@ func (c *ContactGroupsBatchGetCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"responses": resp.Responses,
-		})
+		}, resp.Responses))
 	}
 
 	if len(resp.Responses) == 0 {
@@ -254,7 +254,7 @@ func (c *ContactGroupsCreateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"contactGroup": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"contactGroup": created}, created))
 	}
 
 	u.Out().Printf("resource\t%s", created.ResourceName)
@@ -318,7 +318,7 @@ func (c *ContactGroupsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, fl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"contactGroup": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"contactGroup": updated}, updated))
 	}
 
 	u.Out().Printf("resource\t%s", updated.ResourceName)

--- a/internal/cmd/contacts_output.go
+++ b/internal/cmd/contacts_output.go
@@ -11,7 +11,7 @@ import (
 
 func writeDeleteResult(ctx context.Context, u *ui.UI, resourceName string) error {
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "resource": resourceName})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"deleted": true, "resource": resourceName}))
 	}
 	if u == nil {
 		_, _ = fmt.Fprintf(os.Stdout, "deleted\ttrue\nresource\t%s\n", resourceName)

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -124,7 +124,7 @@ func (c *DocsInfoCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if tabProps != nil {
 			payload["tab"] = tabProps
 		}
-		return outfmt.WriteJSON(os.Stdout, payload)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(payload, doc))
 	}
 
 	u.Out().Printf("id\t%s", doc.DocumentId)
@@ -211,10 +211,10 @@ func (c *DocsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if link := docsWebViewLink(doc.DocumentId, ""); link != "" {
 			file["webViewLink"] = link
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			strFile:    file,
 			"document": doc,
-		})
+		}, doc))
 	}
 
 	u.Out().Printf("id\t%s", doc.DocumentId)
@@ -340,7 +340,7 @@ func (c *DocsWriteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootF
 		if resp.WriteControl != nil {
 			payload["writeControl"] = resp.WriteControl
 		}
-		return outfmt.WriteJSON(os.Stdout, payload)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(payload))
 	}
 
 	u.Out().Printf("id\t%s", resp.DocumentId)
@@ -403,7 +403,7 @@ func (c *DocsCatCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"text": text})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"text": text}, text))
 	}
 	_, err = io.WriteString(os.Stdout, text)
 	return err
@@ -485,7 +485,7 @@ func (c *DocsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if tabID != "" {
 			out["tabId"] = tabID
 		}
-		return outfmt.WriteJSON(os.Stdout, out)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(out))
 	}
 
 	u.Out().Printf("id\t%s", resp.DocumentId)
@@ -566,7 +566,7 @@ func (c *DocsReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if tabID != "" {
 			out["tabId"] = tabID
 		}
-		return outfmt.WriteJSON(os.Stdout, out)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(out))
 	}
 
 	u.Out().Printf("id\t%s", resp.DocumentId)
@@ -823,11 +823,11 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"documentId":   resp.DocumentId,
 			"replies":      resp.Replies,
 			"writeControl": resp.WriteControl,
-		})
+		}, resp.Replies))
 	}
 
 	u.Out().Printf("id\t%s", resp.DocumentId)
@@ -882,11 +882,11 @@ func (c *DocsTabsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	tabs := flattenDocsTabs(doc.Tabs)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"documentId": doc.DocumentId,
 			"tabs":       tabs,
 			"tabCount":   len(tabs),
-		})
+		}, tabs))
 	}
 
 	if len(tabs) == 0 {
@@ -974,10 +974,10 @@ func (c *DocsTabsAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"documentId": resp.DocumentId,
 			"tab":        tabProps,
-		})
+		}, tabProps))
 	}
 
 	if tabProps != nil {
@@ -1071,11 +1071,11 @@ func (c *DocsTabsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"documentId": resp.DocumentId,
 			"tabId":      tabID,
 			"fields":     fields,
-		})
+		}))
 	}
 
 	u.Out().Printf("tab\t%s", tabID)
@@ -1128,11 +1128,11 @@ func (c *DocsTabsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":    true,
 			"documentId": id,
 			"tabId":      tabID,
-		})
+		}))
 	}
 
 	u.Out().Printf("deleted\ttrue")

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -60,10 +60,10 @@ func (c *DocsDeleteRangeCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"documentId": resp.DocumentId,
 			"replies":    resp.Replies,
-		})
+		}, resp.Replies))
 	}
 
 	u.Out().Printf("id\t%s", resp.DocumentId)
@@ -180,10 +180,10 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"documentId": resp.DocumentId,
 			"replies":    resp.Replies,
-		})
+		}, resp.Replies))
 	}
 
 	u.Out().Printf("id\t%s", resp.DocumentId)
@@ -241,10 +241,10 @@ func (c *DocsInsertTableCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"documentId": resp.DocumentId,
 			"replies":    resp.Replies,
-		})
+		}, resp.Replies))
 	}
 
 	u.Out().Printf("id\t%s", resp.DocumentId)
@@ -299,10 +299,10 @@ func (c *DocsInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"documentId": resp.DocumentId,
 			"replies":    resp.Replies,
-		})
+		}, resp.Replies))
 	}
 
 	u.Out().Printf("id\t%s", resp.DocumentId)
@@ -362,10 +362,10 @@ func (c *DocsBulletsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"documentId": resp.DocumentId,
 			"replies":    resp.Replies,
-		})
+		}, resp.Replies))
 	}
 
 	u.Out().Printf("id\t%s", resp.DocumentId)

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -111,7 +111,7 @@ func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"files":         resp.Files,
 			"nextPageToken": resp.NextPageToken,
 		}, resp.Files))
@@ -178,7 +178,7 @@ func (c *DriveSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"files":         resp.Files,
 			"nextPageToken": resp.NextPageToken,
 		}, resp.Files))
@@ -237,7 +237,7 @@ func (c *DriveGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{strFile: f}, f))
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{strFile: f}, f))
 	}
 
 	u.Out().Printf("id\t%s", f.Id)
@@ -302,10 +302,10 @@ func (c *DriveDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"path": downloadedPath,
 			"size": size,
-		})
+		}))
 	}
 
 	u.Out().Printf("path\t%s", downloadedPath)
@@ -389,7 +389,7 @@ func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{strFile: created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{strFile: created}, created))
 	}
 
 	u.Out().Printf("id\t%s", created.Id)
@@ -440,7 +440,7 @@ func (c *DriveMkdirCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"folder": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"folder": created}, created))
 	}
 
 	u.Out().Printf("id\t%s", created.Id)
@@ -484,10 +484,10 @@ func (c *DriveDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"trashed": file.Trashed,
 			"id":      fileID,
-		})
+		}))
 	}
 	u.Out().Printf("trashed\t%v", file.Trashed)
 	u.Out().Printf("id\t%s", fileID)
@@ -542,7 +542,7 @@ func (c *DriveMoveCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{strFile: updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{strFile: updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -585,7 +585,7 @@ func (c *DriveRenameCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{strFile: updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{strFile: updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -653,11 +653,11 @@ func (c *DriveShareCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"link":         link,
 			"permissionId": created.Id,
 			"permission":   created,
-		})
+		}, created))
 	}
 
 	u.Out().Printf("link\t%s", link)
@@ -699,11 +699,11 @@ func (c *DriveUnshareCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"removed":      true,
 			"fileId":       fileID,
 			"permissionId": permissionID,
-		})
+		}))
 	}
 
 	u.Out().Printf("removed\ttrue")
@@ -741,7 +741,7 @@ func (c *DriveURLCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"urls": urls})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"urls": urls}, urls))
 	}
 	return nil
 }

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -111,10 +111,10 @@ func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"files":         resp.Files,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Files))
 	}
 
 	if len(resp.Files) == 0 {
@@ -178,10 +178,10 @@ func (c *DriveSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"files":         resp.Files,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Files))
 	}
 
 	if len(resp.Files) == 0 {
@@ -237,7 +237,7 @@ func (c *DriveGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{strFile: f})
+		return outfmt.WriteJSON(os.Stdout, outfmt.PrimaryResult(map[string]any{strFile: f}, f))
 	}
 
 	u.Out().Printf("id\t%s", f.Id)

--- a/internal/cmd/drive_about.go
+++ b/internal/cmd/drive_about.go
@@ -35,7 +35,7 @@ func (c *DriveAboutCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"about": about})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"about": about}, about))
 	}
 
 	// User info

--- a/internal/cmd/drive_changes.go
+++ b/internal/cmd/drive_changes.go
@@ -49,10 +49,10 @@ func (c *DriveChangesGetStartPageTokCmd) Run(ctx context.Context, flags *RootFla
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"startPageToken": resp.StartPageToken,
 			"kind":           resp.Kind,
-		})
+		}))
 	}
 
 	u.Out().Printf("start_page_token\t%s", resp.StartPageToken)
@@ -108,12 +108,12 @@ func (c *DriveChangesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"changes":           resp.Changes,
 			"changeCount":       len(resp.Changes),
 			"nextPageToken":     resp.NextPageToken,
 			"newStartPageToken": resp.NewStartPageToken,
-		})
+		}, resp.Changes))
 	}
 
 	if len(resp.Changes) == 0 {
@@ -216,10 +216,10 @@ func (c *DriveChangesWatchCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"channel":  resp,
 			"resource": resp.ResourceId,
-		})
+		}, resp))
 	}
 
 	u.Out().Printf("channel_id\t%s", resp.Id)

--- a/internal/cmd/drive_channels.go
+++ b/internal/cmd/drive_channels.go
@@ -54,11 +54,11 @@ func (c *DriveChannelsStopCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"stopped":    true,
 			"channelId":  channelID,
 			"resourceId": resourceID,
-		})
+		}))
 	}
 
 	u.Out().Printf("stopped\ttrue")

--- a/internal/cmd/drive_comments.go
+++ b/internal/cmd/drive_comments.go
@@ -70,11 +70,11 @@ func (c *DriveCommentsListCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"fileId":        fileID,
 			"comments":      resp.Comments,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Comments))
 	}
 
 	if len(resp.Comments) == 0 {
@@ -159,7 +159,7 @@ func (c *DriveCommentsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"comment": comment})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"comment": comment}, comment))
 	}
 
 	u.Out().Printf("id\t%s", comment.Id)
@@ -225,7 +225,7 @@ func (c *DriveCommentsCreateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"comment": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"comment": created}, created))
 	}
 
 	u.Out().Printf("id\t%s", created.Id)
@@ -277,7 +277,7 @@ func (c *DriveCommentsUpdateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"comment": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"comment": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -320,11 +320,11 @@ func (c *DriveCommentsDeleteCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":   true,
 			"fileId":    fileID,
 			"commentId": commentID,
-		})
+		}))
 	}
 
 	u.Out().Printf("deleted\ttrue")
@@ -376,7 +376,7 @@ func (c *DriveCommentReplyCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"reply": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"reply": created}, created))
 	}
 
 	u.Out().Printf("id\t%s", created.Id)
@@ -437,12 +437,12 @@ func (c *DriveRepliesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"fileId":        fileID,
 			"commentId":     commentID,
 			"replies":       resp.Replies,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Replies))
 	}
 
 	if len(resp.Replies) == 0 {
@@ -510,7 +510,7 @@ func (c *DriveRepliesGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"reply": reply})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"reply": reply}, reply))
 	}
 
 	u.Out().Printf("id\t%s", reply.Id)
@@ -567,7 +567,7 @@ func (c *DriveRepliesCreateCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"reply": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"reply": created}, created))
 	}
 
 	u.Out().Printf("id\t%s", created.Id)
@@ -625,7 +625,7 @@ func (c *DriveRepliesUpdateCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"reply": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"reply": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -674,12 +674,12 @@ func (c *DriveRepliesDeleteCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":   true,
 			"fileId":    fileID,
 			"commentId": commentID,
 			"replyId":   replyID,
-		})
+		}))
 	}
 
 	u.Out().Printf("deleted\ttrue")

--- a/internal/cmd/drive_copy.go
+++ b/internal/cmd/drive_copy.go
@@ -82,7 +82,7 @@ func copyViaDrive(ctx context.Context, flags *RootFlags, opts copyViaDriveOption
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{strFile: created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{strFile: created}, created))
 	}
 	u.Out().Printf("id\t%s", created.Id)
 	u.Out().Printf("name\t%s", created.Name)

--- a/internal/cmd/drive_drives.go
+++ b/internal/cmd/drive_drives.go
@@ -47,10 +47,10 @@ func (c *DriveDrivesCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"drives":        resp.Drives,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Drives))
 	}
 
 	if len(resp.Drives) == 0 {

--- a/internal/cmd/drive_drives_admin.go
+++ b/internal/cmd/drive_drives_admin.go
@@ -63,7 +63,7 @@ func (c *DriveDrivesCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"drive": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"drive": created}, created))
 	}
 
 	u.Out().Printf("id\t%s", created.Id)
@@ -112,7 +112,7 @@ func (c *DriveDrivesUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"drive": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"drive": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -158,10 +158,10 @@ func (c *DriveDrivesDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":      driveID,
 			"deleted": true,
-		})
+		}))
 	}
 
 	u.Out().Printf("deleted\ttrue")
@@ -199,7 +199,7 @@ func (c *DriveDrivesHideCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"drive": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"drive": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -238,7 +238,7 @@ func (c *DriveDrivesUnhideCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"drive": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"drive": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)

--- a/internal/cmd/drive_files_edit.go
+++ b/internal/cmd/drive_files_edit.go
@@ -73,11 +73,11 @@ func (c *DriveFilesWatchCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"channel":    resp,
 			"channelId":  resp.Id,
 			"resourceId": resp.ResourceId,
-		})
+		}, resp))
 	}
 
 	u.Out().Printf("channel_id\t%s", resp.Id)
@@ -136,11 +136,11 @@ func (c *DriveFilesGenerateIdsCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"ids":   resp.Ids,
 			"space": resp.Space,
 			"kind":  resp.Kind,
-		})
+		}, resp.Ids))
 	}
 
 	for _, id := range resp.Ids {
@@ -176,9 +176,9 @@ func (c *DriveFilesEmptyTrashCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"emptied": true,
-		})
+		}))
 	}
 
 	u.Out().Printf("emptied\ttrue")

--- a/internal/cmd/drive_permissions.go
+++ b/internal/cmd/drive_permissions.go
@@ -76,12 +76,12 @@ func (c *DrivePermissionsListCmd) Run(ctx context.Context, flags *RootFlags) err
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"fileId":          fileID,
 			"permissions":     resp.Permissions,
 			"permissionCount": len(resp.Permissions),
 			"nextPageToken":   resp.NextPageToken,
-		})
+		}, resp.Permissions))
 	}
 	if len(resp.Permissions) == 0 {
 		u.Err().Println("No permissions")
@@ -150,7 +150,7 @@ func (c *DrivePermissionsGetCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"permission": perm})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"permission": perm}, perm))
 	}
 
 	u.Out().Printf("id\t%s", perm.Id)
@@ -289,11 +289,11 @@ func (c *DrivePermissionsCreateCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"link":         link,
 			"permissionId": created.Id,
 			"permission":   created,
-		})
+		}, created))
 	}
 
 	u.Out().Printf("link\t%s", link)
@@ -375,7 +375,7 @@ func (c *DrivePermissionsUpdateCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"permission": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"permission": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -425,11 +425,11 @@ func (c *DrivePermissionsDeleteCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"removed":      true,
 			"fileId":       fileID,
 			"permissionId": permissionID,
-		})
+		}))
 	}
 
 	u.Out().Printf("removed\ttrue")

--- a/internal/cmd/drive_revisions.go
+++ b/internal/cmd/drive_revisions.go
@@ -60,12 +60,12 @@ func (c *DriveRevisionsListCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"fileId":        fileID,
 			"revisions":     resp.Revisions,
 			"revisionCount": len(resp.Revisions),
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Revisions))
 	}
 
 	if len(resp.Revisions) == 0 {
@@ -140,7 +140,7 @@ func (c *DriveRevisionsGetCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"revision": rev})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"revision": rev}, rev))
 	}
 
 	u.Out().Printf("id\t%s", rev.Id)
@@ -178,12 +178,12 @@ func downloadRevision(ctx context.Context, svc *drive.Service, fileID, revisionI
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"path":       outputPath,
 			"size":       size,
 			"revisionId": revisionID,
 			"mimeType":   rev.MimeType,
-		})
+		}))
 	}
 
 	u.Out().Printf("path\t%s", outputPath)
@@ -226,11 +226,11 @@ func (c *DriveRevisionsDeleteCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":    true,
 			"fileId":     fileID,
 			"revisionId": revisionID,
-		})
+		}))
 	}
 
 	u.Out().Printf("deleted\ttrue")
@@ -291,7 +291,7 @@ func (c *DriveRevisionsUpdateCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"revision": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"revision": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)

--- a/internal/cmd/execute_calendar_events_text_test.go
+++ b/internal/cmd/execute_calendar_events_text_test.go
@@ -59,6 +59,57 @@ func TestExecute_CalendarEvents_Text_WithPaging(t *testing.T) {
 	}
 }
 
+func TestExecute_CalendarEvents_SelectCoexistsWithAPIFields(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/calendars/c1/events") {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("fields"); got != "items(id,summary),nextPageToken" {
+			t.Fatalf("fields=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":         []map[string]any{{"id": "e1", "summary": "Meeting", "description": "hidden"}},
+			"nextPageToken": "npt",
+		})
+	})))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--results-only", "--select", "id,summary", "--account", "a@b.com",
+				"calendar", "events", "c1", "--from", "2025-12-17T00:00:00Z", "--to", "2025-12-18T00:00:00Z",
+				"--fields", "items(id,summary),nextPageToken",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var events []map[string]any
+	if err := json.Unmarshal([]byte(out), &events); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if len(events) != 1 || len(events[0]) != 2 || events[0]["id"] != "e1" || events[0]["summary"] != "Meeting" {
+		t.Fatalf("unexpected events: %#v", events)
+	}
+}
+
 func setupCalendarFailureService(t *testing.T, failAll bool) {
 	t.Helper()
 

--- a/internal/cmd/execute_calendar_paging_test.go
+++ b/internal/cmd/execute_calendar_paging_test.go
@@ -73,6 +73,27 @@ func TestExecute_CalendarCalendars_MaxAndPage_JSON(t *testing.T) {
 	if len(parsed.Calendars) != 1 || parsed.Calendars[0].ID != "c1" || parsed.NextPageToken != "npt" {
 		t.Fatalf("unexpected payload: %#v", parsed)
 	}
+
+	resultsOnly := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json", "--results-only", "--select", "id,summary",
+				"--account", "a@b.com",
+				"calendar", "calendars", "list",
+				"--max", "1",
+				"--page", "p1",
+			}); err != nil {
+				t.Fatalf("Execute transformed: %v", err)
+			}
+		})
+	})
+	var calendars []map[string]any
+	if err := json.Unmarshal([]byte(resultsOnly), &calendars); err != nil {
+		t.Fatalf("results-only JSON parse: %v\nout=%q", err, resultsOnly)
+	}
+	if len(calendars) != 1 || len(calendars[0]) != 2 || calendars[0]["id"] != "c1" || calendars[0]["summary"] != "One" {
+		t.Fatalf("unexpected results-only payload: %#v", calendars)
+	}
 }
 
 func TestExecute_CalendarAcl_MaxAndPage_JSON(t *testing.T) {

--- a/internal/cmd/execute_drive_test.go
+++ b/internal/cmd/execute_drive_test.go
@@ -75,6 +75,21 @@ func TestExecute_DriveGet_JSON(t *testing.T) {
 	if parsed.File.ID != "id1" || parsed.File.Name != "Doc" || !parsed.File.Starred {
 		t.Fatalf("unexpected file: %#v", parsed.File)
 	}
+
+	selected := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "--results-only", "--select", "id,name", "--account", "a@b.com", "drive", "get", "id1"}); err != nil {
+				t.Fatalf("Execute transformed: %v", err)
+			}
+		})
+	})
+	var selectedFile map[string]any
+	if err := json.Unmarshal([]byte(selected), &selectedFile); err != nil {
+		t.Fatalf("selected JSON parse: %v\nout=%q", err, selected)
+	}
+	if len(selectedFile) != 2 || selectedFile["id"] != "id1" || selectedFile["name"] != "Doc" {
+		t.Fatalf("unexpected selected file: %#v", selectedFile)
+	}
 }
 
 func TestExecute_DriveDownload_JSON(t *testing.T) {

--- a/internal/cmd/execute_gmail_test.go
+++ b/internal/cmd/execute_gmail_test.go
@@ -110,6 +110,21 @@ func TestExecute_GmailSearch_JSON(t *testing.T) {
 	if len(parsed.Threads[0].Labels) != 1 || parsed.Threads[0].Labels[0] != "INBOX" {
 		t.Fatalf("unexpected labels: %#v", parsed.Threads[0].Labels)
 	}
+
+	resultsOnly := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "--results-only", "--select", "id,subject", "--account", "a@b.com", "gmail", "search", "newer_than:7d", "--max", "1", "--timezone", "UTC"}); err != nil {
+				t.Fatalf("Execute results-only: %v", err)
+			}
+		})
+	})
+	var threads []map[string]any
+	if err := json.Unmarshal([]byte(resultsOnly), &threads); err != nil {
+		t.Fatalf("results-only JSON parse: %v\nout=%q", err, resultsOnly)
+	}
+	if len(threads) != 1 || len(threads[0]) != 2 || threads[0]["id"] != "t1" || threads[0]["subject"] != "Hello" {
+		t.Fatalf("unexpected results-only threads: %#v", threads)
+	}
 }
 
 func TestExecute_GmailURL_JSON(t *testing.T) {

--- a/internal/cmd/export_via_drive.go
+++ b/internal/cmd/export_via_drive.go
@@ -80,7 +80,7 @@ func exportViaDrive(ctx context.Context, flags *RootFlags, opts exportViaDriveOp
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"path": downloadedPath, "size": size})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"path": downloadedPath, "size": size}))
 	}
 	u.Out().Printf("path\t%s", downloadedPath)
 	u.Out().Printf("size\t%s", formatDriveSize(size))

--- a/internal/cmd/gmail.go
+++ b/internal/cmd/gmail.go
@@ -113,10 +113,10 @@ func (c *GmailSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"threads":       items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(items) == 0 {

--- a/internal/cmd/gmail_attachment.go
+++ b/internal/cmd/gmail_attachment.go
@@ -65,7 +65,7 @@ func (c *GmailAttachmentCmd) Run(ctx context.Context, flags *RootFlags) error {
 			return dlErr
 		}
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(os.Stdout, map[string]any{"path": path, "cached": cached, "bytes": bytes})
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"path": path, "cached": cached, "bytes": bytes}))
 		}
 		u.Out().Printf("path\t%s", path)
 		u.Out().Printf("cached\t%t", cached)
@@ -82,7 +82,7 @@ func (c *GmailAttachmentCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"path": path, "cached": cached, "bytes": bytes})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"path": path, "cached": cached, "bytes": bytes}))
 	}
 	u.Out().Printf("path\t%s", path)
 	u.Out().Printf("cached\t%t", cached)

--- a/internal/cmd/gmail_autoforward.go
+++ b/internal/cmd/gmail_autoforward.go
@@ -38,7 +38,7 @@ func (c *GmailAutoForwardGetCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"autoForwarding": autoForward})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"autoForwarding": autoForward}, autoForward))
 	}
 
 	u.Out().Printf("enabled\t%t", autoForward.Enabled)
@@ -117,7 +117,7 @@ func (c *GmailAutoForwardUpdateCmd) Run(ctx context.Context, kctx *kong.Context,
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"autoForwarding": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"autoForwarding": updated}, updated))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/gmail_batch.go
+++ b/internal/cmd/gmail_batch.go
@@ -50,10 +50,10 @@ func (c *GmailBatchDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"deleted": c.MessageIDs,
 			"count":   len(c.MessageIDs),
-		})
+		}, c.MessageIDs))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -106,12 +106,12 @@ func (c *GmailBatchModifyCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"modified":      c.MessageIDs,
 			"count":         len(c.MessageIDs),
 			"addedLabels":   addIDs,
 			"removedLabels": removeIDs,
-		})
+		}, c.MessageIDs))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/gmail_cse.go
+++ b/internal/cmd/gmail_cse.go
@@ -53,7 +53,7 @@ func (c *GmailCseIdentitiesListCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseIdentities": resp.CseIdentities})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"cseIdentities": resp.CseIdentities}, resp.CseIdentities))
 	}
 
 	if len(resp.CseIdentities) == 0 {
@@ -99,7 +99,7 @@ func (c *GmailCseIdentitiesGetCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseIdentity": identity})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"cseIdentity": identity}, identity))
 	}
 
 	u.Out().Printf("email_address\t%s", identity.EmailAddress)
@@ -157,7 +157,7 @@ func (c *GmailCseIdentitiesCreateCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseIdentity": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"cseIdentity": created}, created))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -207,10 +207,10 @@ func (c *GmailCseIdentitiesDeleteCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"success": true,
 			"email":   email,
-		})
+		}))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -286,7 +286,7 @@ func (c *GmailCseIdentitiesPatchCmd) Run(ctx context.Context, kctx *kong.Context
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseIdentity": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"cseIdentity": updated}, updated))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -334,7 +334,7 @@ func (c *GmailCseKeypairsListCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseKeyPairs": resp.CseKeyPairs})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"cseKeyPairs": resp.CseKeyPairs}, resp.CseKeyPairs))
 	}
 
 	if len(resp.CseKeyPairs) == 0 {
@@ -385,7 +385,7 @@ func (c *GmailCseKeypairsGetCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseKeyPair": kp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"cseKeyPair": kp}, kp))
 	}
 
 	u.Out().Printf("key_pair_id\t%s", kp.KeyPairId)
@@ -451,7 +451,7 @@ func (c *GmailCseKeypairsCreateCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseKeyPair": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"cseKeyPair": created}, created))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -497,7 +497,7 @@ func (c *GmailCseKeypairsEnableCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseKeyPair": enabled})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"cseKeyPair": enabled}, enabled))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -547,7 +547,7 @@ func (c *GmailCseKeypairsDisableCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"cseKeyPair": disabled})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"cseKeyPair": disabled}, disabled))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -600,11 +600,11 @@ func (c *GmailCseKeypairsObliterateCmd) Run(ctx context.Context, flags *RootFlag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"success":     true,
 			"keyPairId":   keyPairID,
 			"obliterated": true,
-		})
+		}))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/gmail_delegates.go
+++ b/internal/cmd/gmail_delegates.go
@@ -40,7 +40,7 @@ func (c *GmailDelegatesListCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"delegates": resp.Delegates})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"delegates": resp.Delegates}, resp.Delegates))
 	}
 
 	if len(resp.Delegates) == 0 {
@@ -85,7 +85,7 @@ func (c *GmailDelegatesGetCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"delegate": delegate})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"delegate": delegate}, delegate))
 	}
 
 	u.Out().Printf("delegate_email\t%s", delegate.DelegateEmail)
@@ -123,7 +123,7 @@ func (c *GmailDelegatesAddCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"delegate": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"delegate": created}, created))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -168,10 +168,10 @@ func (c *GmailDelegatesRemoveCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"success":       true,
 			"delegateEmail": delegateEmail,
-		})
+		}))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -64,10 +64,10 @@ func (c *GmailDraftsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 			}
 			items = append(items, item{ID: d.Id, MessageID: msgID, ThreadID: threadID})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"drafts":        items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 	if len(resp.Drafts) == 0 {
 		u.Err().Println("No drafts")
@@ -115,7 +115,7 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	if draft.Message == nil {
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(os.Stdout, map[string]any{"draft": draft})
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"draft": draft}, draft))
 		}
 		if outfmt.IsPlain(ctx) {
 			return writeGmailDraftGetPlain(ctx, os.Stdout, draft, nil, nil)
@@ -134,7 +134,7 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 			}
 			out["downloaded"] = attachmentDownloadDraftOutputs(downloads)
 		}
-		return outfmt.WriteJSON(os.Stdout, out)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(out, draft))
 	}
 
 	attachments := collectAttachments(msg.Payload)
@@ -276,7 +276,7 @@ func (c *GmailDraftsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "draftId": draftID})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"deleted": true, "draftId": draftID}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("draft_id\t%s", draftID)
@@ -308,10 +308,10 @@ func (c *GmailDraftsSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"messageId": msg.Id,
 			"threadId":  msg.ThreadId,
-		})
+		}))
 	}
 	u.Out().Printf("message_id\t%s", msg.Id)
 	if msg.ThreadId != "" {
@@ -423,11 +423,11 @@ func writeDraftResult(ctx context.Context, u *ui.UI, draft *gmail.Draft, threadI
 		threadID = draft.Message.ThreadId
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"draftId":  draft.Id,
 			"message":  draft.Message,
 			"threadId": threadID,
-		})
+		}, draft))
 	}
 	u.Out().Printf("draft_id\t%s", draft.Id)
 	if draft.Message != nil && draft.Message.Id != "" {

--- a/internal/cmd/gmail_filters.go
+++ b/internal/cmd/gmail_filters.go
@@ -41,7 +41,7 @@ func (c *GmailFiltersListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"filters": resp.Filter})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"filters": resp.Filter}, resp.Filter))
 	}
 
 	if len(resp.Filter) == 0 {
@@ -100,7 +100,7 @@ func (c *GmailFiltersGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"filter": filter})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"filter": filter}, filter))
 	}
 
 	u.Out().Printf("id\t%s", filter.Id)
@@ -293,7 +293,7 @@ func (c *GmailFiltersCreateCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"filter": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"filter": created}, created))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -351,10 +351,10 @@ func (c *GmailFiltersDeleteCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"success":  true,
 			"filterId": filterID,
-		})
+		}))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/gmail_forwarding.go
+++ b/internal/cmd/gmail_forwarding.go
@@ -40,7 +40,7 @@ func (c *GmailForwardingListCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"forwardingAddresses": resp.ForwardingAddresses})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"forwardingAddresses": resp.ForwardingAddresses}, resp.ForwardingAddresses))
 	}
 
 	if len(resp.ForwardingAddresses) == 0 {
@@ -85,7 +85,7 @@ func (c *GmailForwardingGetCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"forwardingAddress": address})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"forwardingAddress": address}, address))
 	}
 
 	u.Out().Printf("forwarding_email\t%s", address.ForwardingEmail)
@@ -123,7 +123,7 @@ func (c *GmailForwardingCreateCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"forwardingAddress": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"forwardingAddress": created}, created))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -169,10 +169,10 @@ func (c *GmailForwardingDeleteCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"success":         true,
 			"forwardingEmail": forwardingEmail,
-		})
+		}))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/gmail_get.go
+++ b/internal/cmd/gmail_get.go
@@ -99,7 +99,7 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 				payload["attachments"] = attachmentOutputs(attachments)
 			}
 		}
-		return outfmt.WriteJSON(os.Stdout, payload)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(payload, msg))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/gmail_history.go
+++ b/internal/cmd/gmail_history.go
@@ -46,11 +46,11 @@ func (c *GmailHistoryCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	ids := collectHistoryMessageIDs(resp)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"historyId":     formatHistoryID(resp.HistoryId),
 			"messages":      ids,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, ids))
 	}
 	if len(ids) == 0 {
 		u.Err().Println("No history")

--- a/internal/cmd/gmail_imap_pop_language.go
+++ b/internal/cmd/gmail_imap_pop_language.go
@@ -53,7 +53,7 @@ func (c *GmailImapGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"imap": imap})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"imap": imap}, imap))
 	}
 
 	u.Out().Printf("enabled\t%t", imap.Enabled)
@@ -148,7 +148,7 @@ func (c *GmailImapUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"imap": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"imap": updated}, updated))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -190,7 +190,7 @@ func (c *GmailPopGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"pop": pop})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"pop": pop}, pop))
 	}
 
 	u.Out().Printf("access_window\t%s", pop.AccessWindow)
@@ -260,7 +260,7 @@ func (c *GmailPopUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"pop": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"pop": updated}, updated))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -298,7 +298,7 @@ func (c *GmailLanguageGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"language": lang})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"language": lang}, lang))
 	}
 
 	u.Out().Printf("display_language\t%s", lang.DisplayLanguage)
@@ -335,7 +335,7 @@ func (c *GmailLanguageUpdateCmd) Run(ctx context.Context, kctx *kong.Context, fl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"language": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"language": updated}, updated))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/gmail_labels.go
+++ b/internal/cmd/gmail_labels.go
@@ -56,7 +56,7 @@ func (c *GmailLabelsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"label": l})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"label": l}, l))
 	}
 	u := ui.FromContext(ctx)
 	u.Out().Printf("id\t%s", l.Id)
@@ -101,7 +101,7 @@ func (c *GmailLabelsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"label": label})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"label": label}, label))
 	}
 	if outfmt.IsPlain(ctx) {
 		writePlainReceipt(ctx, []string{"ID", "NAME"}, []string{label.Id, label.Name})
@@ -138,7 +138,7 @@ func (c *GmailLabelsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"labels": resp.Labels})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"labels": resp.Labels}, resp.Labels))
 	}
 	if len(resp.Labels) == 0 {
 		u.Err().Println("No labels")
@@ -211,7 +211,7 @@ func (c *GmailLabelsModifyCmd) Run(ctx context.Context, flags *RootFlags) error 
 		}
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"results": results})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"results": results}, results))
 	}
 	return nil
 }
@@ -273,10 +273,10 @@ func (c *GmailLabelsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":      id,
 			"deleted": true,
-		})
+		}))
 	}
 
 	u.Err().Printf("Label %q deleted", raw)
@@ -355,7 +355,7 @@ func (c *GmailLabelsPatchCmd) Run(ctx context.Context, kctx *kong.Context, flags
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"label": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"label": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)
@@ -421,7 +421,7 @@ func (c *GmailLabelsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"label": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"label": updated}, updated))
 	}
 
 	u.Out().Printf("id\t%s", updated.Id)

--- a/internal/cmd/gmail_messages.go
+++ b/internal/cmd/gmail_messages.go
@@ -75,10 +75,10 @@ func (c *GmailMessagesSearchCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"messages":      items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(items) == 0 {

--- a/internal/cmd/gmail_messages_edit.go
+++ b/internal/cmd/gmail_messages_edit.go
@@ -56,10 +56,10 @@ func (c *GmailMessagesImportCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":       imported.Id,
 			"threadId": imported.ThreadId,
-		})
+		}))
 	}
 
 	u.Out().Printf("id\t%s", imported.Id)
@@ -110,10 +110,10 @@ func (c *GmailMessagesInsertCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":       inserted.Id,
 			"threadId": inserted.ThreadId,
-		})
+		}))
 	}
 
 	u.Out().Printf("id\t%s", inserted.Id)
@@ -170,12 +170,12 @@ func (c *GmailMessagesModifyCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":            modified.Id,
 			"threadId":      modified.ThreadId,
 			"addedLabels":   addIDs,
 			"removedLabels": removeIDs,
-		})
+		}))
 	}
 
 	u.Out().Printf("id\t%s", modified.Id)
@@ -214,11 +214,11 @@ func (c *GmailMessagesTrashCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":       msg.Id,
 			"threadId": msg.ThreadId,
 			"trashed":  true,
-		})
+		}))
 	}
 
 	u.Err().Printf("Message %s moved to trash", msg.Id)
@@ -253,11 +253,11 @@ func (c *GmailMessagesUntrashCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":        msg.Id,
 			"threadId":  msg.ThreadId,
 			"untrashed": true,
-		})
+		}))
 	}
 
 	u.Err().Printf("Message %s removed from trash", msg.Id)

--- a/internal/cmd/gmail_send.go
+++ b/internal/cmd/gmail_send.go
@@ -324,7 +324,7 @@ func writeSendResults(ctx context.Context, u *ui.UI, fromAddr string, results []
 			if results[0].TrackingID != "" {
 				resp["tracking_id"] = results[0].TrackingID
 			}
-			return outfmt.WriteJSON(os.Stdout, resp)
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(resp))
 		}
 
 		items := make([]map[string]any, 0, len(results))
@@ -342,7 +342,7 @@ func writeSendResults(ctx context.Context, u *ui.UI, fromAddr string, results []
 			}
 			items = append(items, item)
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"messages": items})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"messages": items}, items))
 	}
 
 	if len(results) == 1 {

--- a/internal/cmd/gmail_sendas.go
+++ b/internal/cmd/gmail_sendas.go
@@ -46,7 +46,7 @@ func (c *GmailSendAsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"sendAs": resp.SendAs})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"sendAs": resp.SendAs}, resp.SendAs))
 	}
 
 	if len(resp.SendAs) == 0 {
@@ -102,7 +102,7 @@ func (c *GmailSendAsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"sendAs": sa})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"sendAs": sa}, sa))
 	}
 
 	u.Out().Printf("send_as_email\t%s", sa.SendAsEmail)
@@ -154,7 +154,7 @@ func (c *GmailSendAsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"sendAs": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"sendAs": created}, created))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -194,10 +194,10 @@ func (c *GmailSendAsVerifyCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"email":   sendAsEmail,
 			"message": "Verification email sent",
-		})
+		}))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -238,10 +238,10 @@ func (c *GmailSendAsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"email":   sendAsEmail,
 			"deleted": true,
-		})
+		}))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -307,7 +307,7 @@ func (c *GmailSendAsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"sendAs": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"sendAs": updated}, updated))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -116,10 +116,10 @@ func (c *GmailThreadGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 				downloadedFiles = append(downloadedFiles, attachmentDownloadSummaries(downloads)...)
 			}
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"thread":     thread,
 			"downloaded": downloadedFiles,
-		})
+		}, thread))
 	}
 	if outfmt.IsPlain(ctx) {
 		return writeGmailThreadPlainTSV(ctx, os.Stdout, threadID, thread, c.Full, c.Download, attachDir, svc)
@@ -311,11 +311,11 @@ func (c *GmailThreadModifyCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"modified":      threadID,
 			"addedLabels":   addIDs,
 			"removedLabels": removeIDs,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		writePlainReceipt(ctx,
@@ -359,10 +359,10 @@ func (c *GmailThreadAttachmentsCmd) Run(ctx context.Context, flags *RootFlags) e
 
 	if thread == nil || len(thread.Messages) == 0 {
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(os.Stdout, map[string]any{
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 				"threadId":    threadID,
 				"attachments": []any{},
-			})
+			}, []any{}))
 		}
 		if outfmt.IsPlain(ctx) {
 			return writeGmailThreadAttachmentsPlainTSV(ctx, threadID, nil, false)
@@ -402,10 +402,10 @@ func (c *GmailThreadAttachmentsCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"threadId":    threadID,
 			"attachments": allAttachments,
-		})
+		}, allAttachments))
 	}
 	if outfmt.IsPlain(ctx) {
 		return writeGmailThreadAttachmentsPlainTSV(ctx, threadID, allAttachments, c.Download)
@@ -482,7 +482,7 @@ func (c *GmailURLCmd) Run(ctx context.Context, flags *RootFlags) error {
 				"url": fmt.Sprintf("https://mail.google.com/mail/?authuser=%s#all/%s", url.QueryEscape(account), id),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"urls": urls})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"urls": urls}, urls))
 	}
 	for _, id := range c.ThreadIDs {
 		threadURL := fmt.Sprintf("https://mail.google.com/mail/?authuser=%s#all/%s", url.QueryEscape(account), id)

--- a/internal/cmd/gmail_threads_edit.go
+++ b/internal/cmd/gmail_threads_edit.go
@@ -44,10 +44,10 @@ func (c *GmailThreadDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":      threadID,
 			"deleted": true,
-		})
+		}))
 	}
 
 	u.Err().Printf("Thread %s permanently deleted", threadID)
@@ -82,11 +82,11 @@ func (c *GmailThreadTrashCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":       thread.Id,
 			"threadId": thread.Id,
 			"trashed":  true,
-		})
+		}))
 	}
 
 	u.Err().Printf("Thread %s moved to trash", thread.Id)
@@ -121,11 +121,11 @@ func (c *GmailThreadUntrashCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":        thread.Id,
 			"threadId":  thread.Id,
 			"untrashed": true,
-		})
+		}))
 	}
 
 	u.Err().Printf("Thread %s removed from trash", thread.Id)

--- a/internal/cmd/gmail_track_opens.go
+++ b/internal/cmd/gmail_track_opens.go
@@ -72,7 +72,7 @@ func (c *GmailTrackOpensCmd) queryByTrackingID(ctx context.Context, cfg *trackin
 		if err := json.Unmarshal(body, &anyJSON); err != nil {
 			return fmt.Errorf("decode response: %w", err)
 		}
-		return outfmt.WriteJSON(os.Stdout, anyJSON)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(anyJSON))
 	}
 
 	var result struct {
@@ -171,7 +171,7 @@ func (c *GmailTrackOpensCmd) queryAdmin(ctx context.Context, cfg *tracking.Confi
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, result)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(result, result.Opens))
 	}
 
 	if len(result.Opens) == 0 {

--- a/internal/cmd/gmail_track_setup.go
+++ b/internal/cmd/gmail_track_setup.go
@@ -168,7 +168,7 @@ func (c *GmailTrackSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	switch {
 	case outfmt.IsJSON(ctx):
-		if err := outfmt.WriteJSON(os.Stdout, result); err != nil {
+		if err := outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(result)); err != nil {
 			return err
 		}
 	case outfmt.IsPlain(ctx):

--- a/internal/cmd/gmail_track_status.go
+++ b/internal/cmd/gmail_track_status.go
@@ -31,7 +31,7 @@ func (c *GmailTrackStatusCmd) Run(ctx context.Context, flags *RootFlags) error {
 		AdminConfigured: strings.TrimSpace(cfg.AdminKey) != "",
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, result)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(result))
 	}
 	if outfmt.IsPlain(ctx) {
 		writeGmailTrackPlain(ctx, result)

--- a/internal/cmd/gmail_trash.go
+++ b/internal/cmd/gmail_trash.go
@@ -36,11 +36,11 @@ func (c *GmailTrashCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"id":       msg.Id,
 			"threadId": msg.ThreadId,
 			"trashed":  true,
-		})
+		}))
 	}
 
 	u.Err().Printf("Message %s moved to trash", msg.Id)

--- a/internal/cmd/gmail_vacation.go
+++ b/internal/cmd/gmail_vacation.go
@@ -39,7 +39,7 @@ func (c *GmailVacationGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"vacation": vacation})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"vacation": vacation}, vacation))
 	}
 
 	u.Out().Printf("enable_auto_reply\t%t", vacation.EnableAutoReply)
@@ -145,7 +145,7 @@ func (c *GmailVacationUpdateCmd) Run(ctx context.Context, kctx *kong.Context, fl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"vacation": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"vacation": updated}, updated))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -186,7 +186,7 @@ func (c *GmailWatchStopCmd) Run(ctx context.Context, flags *RootFlags) error {
 		removeMatchingLegacyGmailWatchState(account, store.path)
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"stopped": true})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"stopped": true}))
 	}
 	u.Out().Printf("stopped\ttrue")
 	return nil
@@ -340,7 +340,7 @@ func (c *GmailWatchServeCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 func writeWatchState(ctx context.Context, state gmailWatchState) error {
 	view := watchStatusView(state)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"watch": view})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"watch": view}, view))
 	}
 	u := ui.FromContext(ctx)
 	u.Out().Printf("account\t%s", view.Account)

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -74,10 +74,10 @@ func (c *GroupsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Role:        getRelationType(m.RelationType),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"groups":        items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.Memberships) == 0 {
@@ -187,10 +187,10 @@ func (c *GroupsMembersCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Type:  m.Type,
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"members":       items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.Memberships) == 0 {

--- a/internal/cmd/info_via_drive.go
+++ b/internal/cmd/info_via_drive.go
@@ -60,7 +60,7 @@ func infoViaDrive(ctx context.Context, flags *RootFlags, opts infoViaDriveOption
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{strFile: f})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{strFile: f}, f))
 	}
 
 	u.Out().Printf("id\t%s", f.Id)

--- a/internal/cmd/json_output_contract_test.go
+++ b/internal/cmd/json_output_contract_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+)
+
+func TestProductionWriteJSONCallsDeclareResultsContract(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob command files: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	for _, file := range files {
+		if filepath.Ext(file) != ".go" || len(file) >= len("_test.go") && file[len(file)-len("_test.go"):] == "_test.go" {
+			continue
+		}
+		parsed, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok || !isOutfmtCall(call.Fun, "WriteJSON") {
+				return true
+			}
+			if len(call.Args) != 3 {
+				t.Errorf("%s: WriteJSON must receive context, writer, and explicit result contract", fset.Position(call.Pos()))
+				return true
+			}
+			contract, ok := call.Args[2].(*ast.CallExpr)
+			if !ok || !(isOutfmtCall(contract.Fun, "DirectResult") || isOutfmtCall(contract.Fun, "PrimaryResult")) {
+				t.Errorf("%s: WriteJSON output must use outfmt.DirectResult or outfmt.PrimaryResult", fset.Position(call.Args[2].Pos()))
+			}
+			return true
+		})
+	}
+}
+
+func isOutfmtCall(expr ast.Expr, name string) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != name {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && pkg.Name == "outfmt"
+}

--- a/internal/cmd/json_output_contract_test.go
+++ b/internal/cmd/json_output_contract_test.go
@@ -5,10 +5,14 @@ import (
 	"go/parser"
 	"go/token"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 )
 
-func TestProductionWriteJSONCallsDeclareResultsContract(t *testing.T) {
+// This contract check intentionally covers direct production call sites in
+// internal/cmd only; integration tests own command-specific output semantics.
+func TestInternalCmdProductionWriteJSONCallsDeclareResultsContract(t *testing.T) {
 	files, err := filepath.Glob("*.go")
 	if err != nil {
 		t.Fatalf("glob command files: %v", err)
@@ -16,24 +20,29 @@ func TestProductionWriteJSONCallsDeclareResultsContract(t *testing.T) {
 
 	fset := token.NewFileSet()
 	for _, file := range files {
-		if filepath.Ext(file) != ".go" || len(file) >= len("_test.go") && file[len(file)-len("_test.go"):] == "_test.go" {
+		if filepath.Ext(file) != ".go" || strings.HasSuffix(file, "_test.go") {
 			continue
 		}
 		parsed, err := parser.ParseFile(fset, file, nil, 0)
 		if err != nil {
 			t.Fatalf("parse %s: %v", file, err)
 		}
+		outfmtAliases := importedPackageAliases(parsed, "github.com/steipete/gogcli/internal/outfmt")
 		ast.Inspect(parsed, func(node ast.Node) bool {
 			call, ok := node.(*ast.CallExpr)
-			if !ok || !isOutfmtCall(call.Fun, "WriteJSON") {
+			if !ok || !isPackageCall(call.Fun, outfmtAliases, "WriteJSON") {
 				return true
 			}
 			if len(call.Args) != 3 {
 				t.Errorf("%s: WriteJSON must receive context, writer, and explicit result contract", fset.Position(call.Pos()))
 				return true
 			}
+			ctx, ok := call.Args[0].(*ast.Ident)
+			if !ok || ctx.Name != "ctx" {
+				t.Errorf("%s: WriteJSON first argument must be the current command context ctx", fset.Position(call.Args[0].Pos()))
+			}
 			contract, ok := call.Args[2].(*ast.CallExpr)
-			if !ok || !(isOutfmtCall(contract.Fun, "DirectResult") || isOutfmtCall(contract.Fun, "PrimaryResult")) {
+			if !ok || !(isPackageCall(contract.Fun, outfmtAliases, "DirectResult") || isPackageCall(contract.Fun, outfmtAliases, "PrimaryResult")) {
 				t.Errorf("%s: WriteJSON output must use outfmt.DirectResult or outfmt.PrimaryResult", fset.Position(call.Args[2].Pos()))
 			}
 			return true
@@ -41,11 +50,34 @@ func TestProductionWriteJSONCallsDeclareResultsContract(t *testing.T) {
 	}
 }
 
-func isOutfmtCall(expr ast.Expr, name string) bool {
+func importedPackageAliases(file *ast.File, importPath string) map[string]struct{} {
+	aliases := make(map[string]struct{})
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || path != importPath {
+			continue
+		}
+
+		alias := filepath.Base(path)
+		if spec.Name != nil {
+			alias = spec.Name.Name
+		}
+		if alias != "." && alias != "_" {
+			aliases[alias] = struct{}{}
+		}
+	}
+	return aliases
+}
+
+func isPackageCall(expr ast.Expr, aliases map[string]struct{}, name string) bool {
 	selector, ok := expr.(*ast.SelectorExpr)
 	if !ok || selector.Sel.Name != name {
 		return false
 	}
 	pkg, ok := selector.X.(*ast.Ident)
-	return ok && pkg.Name == "outfmt"
+	if !ok {
+		return false
+	}
+	_, ok = aliases[pkg.Name]
+	return ok
 }

--- a/internal/cmd/keep.go
+++ b/internal/cmd/keep.go
@@ -62,10 +62,10 @@ func (c *KeepListCmd) Run(ctx context.Context, flags *RootFlags, keep *KeepCmd) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"notes":         resp.Notes,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Notes))
 	}
 
 	if len(resp.Notes) == 0 {
@@ -152,11 +152,11 @@ func (c *KeepSearchCmd) Run(ctx context.Context, flags *RootFlags, keep *KeepCmd
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"notes": allNotes,
 			"query": c.Query,
 			"count": len(allNotes),
-		})
+		}, allNotes))
 	}
 
 	if len(allNotes) == 0 {
@@ -201,7 +201,7 @@ func (c *KeepGetCmd) Run(ctx context.Context, flags *RootFlags, keep *KeepCmd) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"note": note})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"note": note}, note))
 	}
 	if outfmt.IsPlain(ctx) {
 		return writeKeepGetPlain(ctx, note)
@@ -326,11 +326,11 @@ func (c *KeepAttachmentCmd) Run(ctx context.Context, flags *RootFlags, keep *Kee
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"downloaded": true,
 			"path":       outPath,
 			"bytes":      written,
-		})
+		}))
 	}
 
 	u.Out().Printf("path\t%s", outPath)

--- a/internal/cmd/keep_notes_edit.go
+++ b/internal/cmd/keep_notes_edit.go
@@ -92,7 +92,7 @@ func (c *KeepNotesCreateCmd) Run(ctx context.Context, flags *RootFlags, keep *Ke
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"note": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"note": created}, created))
 	}
 
 	noteType := "text"
@@ -138,10 +138,10 @@ func (c *KeepNotesDeleteCmd) Run(ctx context.Context, flags *RootFlags, keep *Ke
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted": true,
 			"name":    name,
-		})
+		}))
 	}
 	u.Err().Printf("Deleted note %s", name)
 	return nil

--- a/internal/cmd/keep_permissions.go
+++ b/internal/cmd/keep_permissions.go
@@ -75,7 +75,7 @@ func (c *KeepPermissionsBatchCreateCmd) Run(ctx context.Context, flags *RootFlag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"permissions": resp.Permissions})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"permissions": resp.Permissions}, resp.Permissions))
 	}
 
 	w, flush := tableWriter(ctx)
@@ -140,11 +140,11 @@ func (c *KeepPermissionsBatchDeleteCmd) Run(ctx context.Context, flags *RootFlag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted": true,
 			"parent":  parent,
 			"count":   len(names),
-		})
+		}))
 	}
 	u.Err().Printf("Removed %d permission(s) from %s", len(names), parent)
 	return nil

--- a/internal/cmd/people.go
+++ b/internal/cmd/people.go
@@ -37,7 +37,7 @@ func (c *PeopleMeCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"person": person})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"person": person}, person))
 	}
 
 	name := ""

--- a/internal/cmd/people_batch.go
+++ b/internal/cmd/people_batch.go
@@ -96,10 +96,10 @@ func (c *ContactsBatchCreateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"createdContacts": resp.CreatedPeople,
 			"count":           len(resp.CreatedPeople),
-		})
+		}, resp.CreatedPeople))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -252,10 +252,10 @@ func (c *ContactsBatchUpdateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"updatedContacts": resp.UpdateResult,
 			"count":           len(contactsMap),
-		})
+		}, resp.UpdateResult))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -331,9 +331,9 @@ func (c *ContactsBatchGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"responses": resp.Responses,
-		})
+		}, resp.Responses))
 	}
 
 	if len(resp.Responses) == 0 {

--- a/internal/cmd/people_group_members.go
+++ b/internal/cmd/people_group_members.go
@@ -90,12 +90,12 @@ func (c *ContactGroupMembersModifyCmd) Run(ctx context.Context, kctx *kong.Conte
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"modifiedGroup":    existing,
 			"notFoundCount":    len(resp.NotFoundResourceNames),
 			"notFound":         resp.NotFoundResourceNames,
 			"cannotRemoveLast": resp.CanNotRemoveLastContactGroupResourceNames,
-		})
+		}))
 	}
 
 	// Human-friendly output

--- a/internal/cmd/people_photo.go
+++ b/internal/cmd/people_photo.go
@@ -131,10 +131,10 @@ func (c *ContactsPhotoUpdateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"person":       resp.Person,
 			"resourceName": resourceName,
-		})
+		}, resp.Person))
 	}
 
 	if outfmt.IsPlain(ctx) {

--- a/internal/cmd/people_profile.go
+++ b/internal/cmd/people_profile.go
@@ -42,7 +42,7 @@ func (c *PeopleGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return wrapPeopleAPIError(err)
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"person": person})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"person": person}, person))
 	}
 
 	name := primaryName(person)
@@ -119,10 +119,10 @@ func (c *PeopleSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Email:    primaryEmail(p),
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"people":        items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, items))
 	}
 
 	if len(resp.People) == 0 {
@@ -201,7 +201,7 @@ func (c *PeopleRelationsCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if relationType != "" {
 			resp["relationType"] = relationType
 		}
-		return outfmt.WriteJSON(os.Stdout, resp)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(resp, relations))
 	}
 
 	if len(relations) == 0 {

--- a/internal/cmd/policy.go
+++ b/internal/cmd/policy.go
@@ -49,10 +49,10 @@ func (c *PolicyCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	saved, _ := config.GetPolicy(cfg, c.Name)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"created": true,
 			"policy":  saved,
-		})
+		}, saved))
 	}
 	if outfmt.IsPlain(ctx) {
 		fmt.Fprintln(os.Stdout, "ACTION\tNAME\tACCOUNT\tCLIENT\tALLOW\tDENY\tREASON")
@@ -82,7 +82,7 @@ func (c *PolicyGetCmd) Run(ctx context.Context) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"policy": policy})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"policy": policy}, policy))
 	}
 	fmt.Fprintf(os.Stdout, "name\t%s\n", policy.Name)
 	if policy.Account != "" {
@@ -112,7 +112,7 @@ func (c *PolicyListCmd) Run(ctx context.Context) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"policies": cfg.Policies})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"policies": cfg.Policies}, cfg.Policies))
 	}
 	if len(cfg.Policies) == 0 && !outfmt.IsPlain(ctx) {
 		fmt.Fprintln(os.Stdout, "No policies")
@@ -148,10 +148,10 @@ func (c *PolicyDeleteCmd) Run(ctx context.Context) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted": true,
 			"name":    c.Name,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		fmt.Fprintln(os.Stdout, "ACTION\tNAME\tACCOUNT\tCLIENT\tALLOW\tDENY\tREASON")

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -90,12 +90,11 @@ func Execute(args []string) (err error) {
 		if innerErr != nil {
 			return reportPreUIError(newUsageError(innerErr))
 		}
-		restoreJSON, innerErr := outfmt.ConfigureJSON(jsonConfig)
+		ctx := outfmt.WithMode(context.Background(), mode)
+		ctx, innerErr = outfmt.WithJSONConfig(ctx, jsonConfig)
 		if innerErr != nil {
 			return reportPreUIError(newUsageError(innerErr))
 		}
-		defer restoreJSON()
-		ctx := outfmt.WithMode(context.Background(), mode)
 		return (&VersionCmd{}).Run(ctx)
 	}
 
@@ -150,14 +149,12 @@ func Execute(args []string) (err error) {
 	if err != nil {
 		return reportPreUIError(newUsageError(err))
 	}
-	restoreJSON, err := outfmt.ConfigureJSON(jsonConfig)
+	ctx := context.Background()
+	ctx = outfmt.WithMode(ctx, mode)
+	ctx, err = outfmt.WithJSONConfig(ctx, jsonConfig)
 	if err != nil {
 		return reportPreUIError(newUsageError(err))
 	}
-	defer restoreJSON()
-
-	ctx := context.Background()
-	ctx = outfmt.WithMode(ctx, mode)
 	ctx = authclient.WithClient(ctx, cli.Client)
 
 	uiColor := cli.Color
@@ -360,7 +357,7 @@ func outputModeFromVersionArgs(args []string) (outfmt.Mode, outfmt.JSONConfig, e
 		case arg == "--results-only":
 			resultsOnly = true
 		case arg == "--select":
-			if i+1 >= len(args) {
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
 				return outfmt.Mode{}, outfmt.JSONConfig{}, errors.New("--select requires a value")
 			}
 			i++

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -145,7 +145,7 @@ func Execute(args []string) (err error) {
 	if err != nil {
 		return reportPreUIError(newUsageError(err))
 	}
-	jsonConfig, err := jsonConfigFromFlags(mode, cli.ResultsOnly, cli.Select)
+	jsonConfig, err := jsonConfigFromFlags(mode, cli.ResultsOnly, cli.Select, hasSelectFlag(args))
 	if err != nil {
 		return reportPreUIError(newUsageError(err))
 	}
@@ -200,14 +200,17 @@ func Execute(args []string) (err error) {
 	return err
 }
 
-func jsonConfigFromFlags(mode outfmt.Mode, resultsOnly bool, selectPaths string) (outfmt.JSONConfig, error) {
+func jsonConfigFromFlags(mode outfmt.Mode, resultsOnly bool, selectPaths string, selectSet bool) (outfmt.JSONConfig, error) {
 	selectPaths = strings.TrimSpace(selectPaths)
-	if !mode.JSON && (resultsOnly || selectPaths != "") {
+	if !mode.JSON && (resultsOnly || selectSet) {
 		return outfmt.JSONConfig{}, errors.New("--results-only and --select require --json")
+	}
+	if selectSet && selectPaths == "" {
+		return outfmt.JSONConfig{}, errors.New("--select requires a value")
 	}
 
 	jsonOutput := outfmt.JSONConfig{ResultsOnly: resultsOnly}
-	if selectPaths != "" {
+	if selectSet {
 		jsonOutput.Select = strings.Split(selectPaths, ",")
 	}
 	return jsonOutput, nil
@@ -337,12 +340,25 @@ func hasVersionFlag(args []string) bool {
 	return false
 }
 
+func hasSelectFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		if arg == "--select" || strings.HasPrefix(arg, "--select=") {
+			return true
+		}
+	}
+	return false
+}
+
 func outputModeFromVersionArgs(args []string) (outfmt.Mode, outfmt.JSONConfig, error) {
 	envMode := outfmt.FromEnv()
 	jsonOut := envMode.JSON
 	plainOut := envMode.Plain
 	resultsOnly := false
 	selectPaths := ""
+	selectSet := false
 
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -362,6 +378,7 @@ func outputModeFromVersionArgs(args []string) (outfmt.Mode, outfmt.JSONConfig, e
 			}
 			i++
 			selectPaths = args[i]
+			selectSet = true
 		case strings.HasPrefix(arg, "--json="):
 			v, err := parseFlagBool(strings.TrimPrefix(arg, "--json="))
 			if err != nil {
@@ -382,6 +399,7 @@ func outputModeFromVersionArgs(args []string) (outfmt.Mode, outfmt.JSONConfig, e
 			resultsOnly = v
 		case strings.HasPrefix(arg, "--select="):
 			selectPaths = strings.TrimPrefix(arg, "--select=")
+			selectSet = true
 		}
 	}
 
@@ -389,7 +407,7 @@ func outputModeFromVersionArgs(args []string) (outfmt.Mode, outfmt.JSONConfig, e
 	if err != nil {
 		return outfmt.Mode{}, outfmt.JSONConfig{}, err
 	}
-	jsonOutput, err := jsonConfigFromFlags(mode, resultsOnly, selectPaths)
+	jsonOutput, err := jsonConfigFromFlags(mode, resultsOnly, selectPaths, selectSet)
 	if err != nil {
 		return outfmt.Mode{}, outfmt.JSONConfig{}, err
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -41,6 +41,8 @@ type RootFlags struct {
 	EnableCommands string `help:"Comma-separated list of enabled top-level commands (restricts CLI)" default:"${enabled_commands}"`
 	JSON           bool   `help:"Output JSON to stdout (best for scripting)" default:"${json}"`
 	Plain          bool   `help:"Output stable, parseable text to stdout (TSV; no colors)" default:"${plain}"`
+	ResultsOnly    bool   `name:"results-only" help:"Output only the declared primary result (requires --json)"`
+	Select         string `name:"select" help:"Comma-separated fields to select from JSON output (requires --json)"`
 	Version        bool   `help:"Print version and exit"`
 	Force          bool   `help:"Skip confirmations for destructive commands"`
 	NoInput        bool   `help:"Never prompt; fail instead (useful for CI)"`
@@ -84,10 +86,15 @@ type exitPanic struct{ code int }
 
 func Execute(args []string) (err error) {
 	if hasVersionFlag(args) {
-		mode, innerErr := outputModeFromVersionArgs(args)
+		mode, jsonConfig, innerErr := outputModeFromVersionArgs(args)
 		if innerErr != nil {
 			return reportPreUIError(newUsageError(innerErr))
 		}
+		restoreJSON, innerErr := outfmt.ConfigureJSON(jsonConfig)
+		if innerErr != nil {
+			return reportPreUIError(newUsageError(innerErr))
+		}
+		defer restoreJSON()
 		ctx := outfmt.WithMode(context.Background(), mode)
 		return (&VersionCmd{}).Run(ctx)
 	}
@@ -139,6 +146,15 @@ func Execute(args []string) (err error) {
 	if err != nil {
 		return reportPreUIError(newUsageError(err))
 	}
+	jsonConfig, err := jsonConfigFromFlags(mode, cli.ResultsOnly, cli.Select)
+	if err != nil {
+		return reportPreUIError(newUsageError(err))
+	}
+	restoreJSON, err := outfmt.ConfigureJSON(jsonConfig)
+	if err != nil {
+		return reportPreUIError(newUsageError(err))
+	}
+	defer restoreJSON()
 
 	ctx := context.Background()
 	ctx = outfmt.WithMode(ctx, mode)
@@ -185,6 +201,19 @@ func Execute(args []string) (err error) {
 	}
 	_, _ = fmt.Fprintln(os.Stderr, errfmt.Format(err))
 	return err
+}
+
+func jsonConfigFromFlags(mode outfmt.Mode, resultsOnly bool, selectPaths string) (outfmt.JSONConfig, error) {
+	selectPaths = strings.TrimSpace(selectPaths)
+	if !mode.JSON && (resultsOnly || selectPaths != "") {
+		return outfmt.JSONConfig{}, errors.New("--results-only and --select require --json")
+	}
+
+	jsonOutput := outfmt.JSONConfig{ResultsOnly: resultsOnly}
+	if selectPaths != "" {
+		jsonOutput.Select = strings.Split(selectPaths, ",")
+	}
+	return jsonOutput, nil
 }
 
 func wrapParseError(err error) error {
@@ -311,12 +340,15 @@ func hasVersionFlag(args []string) bool {
 	return false
 }
 
-func outputModeFromVersionArgs(args []string) (outfmt.Mode, error) {
+func outputModeFromVersionArgs(args []string) (outfmt.Mode, outfmt.JSONConfig, error) {
 	envMode := outfmt.FromEnv()
 	jsonOut := envMode.JSON
 	plainOut := envMode.Plain
+	resultsOnly := false
+	selectPaths := ""
 
-	for _, arg := range args {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
 		if arg == "--" {
 			break
 		}
@@ -325,22 +357,46 @@ func outputModeFromVersionArgs(args []string) (outfmt.Mode, error) {
 			jsonOut = true
 		case arg == "--plain":
 			plainOut = true
+		case arg == "--results-only":
+			resultsOnly = true
+		case arg == "--select":
+			if i+1 >= len(args) {
+				return outfmt.Mode{}, outfmt.JSONConfig{}, errors.New("--select requires a value")
+			}
+			i++
+			selectPaths = args[i]
 		case strings.HasPrefix(arg, "--json="):
 			v, err := parseFlagBool(strings.TrimPrefix(arg, "--json="))
 			if err != nil {
-				return outfmt.Mode{}, err
+				return outfmt.Mode{}, outfmt.JSONConfig{}, err
 			}
 			jsonOut = v
 		case strings.HasPrefix(arg, "--plain="):
 			v, err := parseFlagBool(strings.TrimPrefix(arg, "--plain="))
 			if err != nil {
-				return outfmt.Mode{}, err
+				return outfmt.Mode{}, outfmt.JSONConfig{}, err
 			}
 			plainOut = v
+		case strings.HasPrefix(arg, "--results-only="):
+			v, err := parseFlagBool(strings.TrimPrefix(arg, "--results-only="))
+			if err != nil {
+				return outfmt.Mode{}, outfmt.JSONConfig{}, err
+			}
+			resultsOnly = v
+		case strings.HasPrefix(arg, "--select="):
+			selectPaths = strings.TrimPrefix(arg, "--select=")
 		}
 	}
 
-	return outfmt.FromFlags(jsonOut, plainOut)
+	mode, err := outfmt.FromFlags(jsonOut, plainOut)
+	if err != nil {
+		return outfmt.Mode{}, outfmt.JSONConfig{}, err
+	}
+	jsonOutput, err := jsonConfigFromFlags(mode, resultsOnly, selectPaths)
+	if err != nil {
+		return outfmt.Mode{}, outfmt.JSONConfig{}, err
+	}
+	return mode, jsonOutput, nil
 }
 
 func parseFlagBool(value string) (bool, error) {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -87,6 +87,51 @@ func TestExecute_UnknownFlag(t *testing.T) {
 	}
 }
 
+func TestExecute_JSONTransformationsRequireJSON(t *testing.T) {
+	for _, args := range [][]string{
+		{"--results-only", "version"},
+		{"--select", "version,commit", "version"},
+		{"--plain", "--results-only", "version"},
+		{"--version", "--select", "version"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			var execErr error
+			stdout := captureStdout(t, func() {
+				stderr := captureStderr(t, func() {
+					execErr = Execute(args)
+				})
+				if !strings.Contains(stderr, "require --json") {
+					t.Fatalf("expected require --json diagnostic, got %q", stderr)
+				}
+			})
+			if execErr == nil || ExitCode(execErr) != 2 {
+				t.Fatalf("expected usage error, got %v", execErr)
+			}
+			if stdout != "" {
+				t.Fatalf("unexpected partial output: %q", stdout)
+			}
+		})
+	}
+}
+
+func TestExecute_InvalidJSONSelectionReportsUsageError(t *testing.T) {
+	var execErr error
+	stdout := captureStdout(t, func() {
+		stderr := captureStderr(t, func() {
+			execErr = Execute([]string{"--json", "--select", "version,,commit", "version"})
+		})
+		if !strings.Contains(stderr, "invalid JSON selection path") {
+			t.Fatalf("unexpected stderr: %q", stderr)
+		}
+	})
+	if execErr == nil || ExitCode(execErr) != 2 {
+		t.Fatalf("expected usage error, got %v", execErr)
+	}
+	if stdout != "" {
+		t.Fatalf("unexpected partial output: %q", stdout)
+	}
+}
+
 func TestExecute_ConflictingOutputModesReportsStderr(t *testing.T) {
 	errText := captureStderr(t, func() {
 		_ = captureStdout(t, func() {
@@ -101,6 +146,19 @@ func TestExecute_ConflictingOutputModesReportsStderr(t *testing.T) {
 	})
 	if !strings.Contains(errText, "invalid output mode") {
 		t.Fatalf("expected stderr diagnostic, got %q", errText)
+	}
+}
+
+func TestExecute_VersionSelectsJSONFields(t *testing.T) {
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--version", "--json", "--select", "version"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(out, "\"version\"") || strings.Contains(out, "\"commit\"") {
+		t.Fatalf("unexpected selected version output: %q", out)
 	}
 }
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -132,6 +132,41 @@ func TestExecute_InvalidJSONSelectionReportsUsageError(t *testing.T) {
 	}
 }
 
+func TestExecute_ExplicitEmptySelectReportsUsageError(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		diagnostic string
+	}{
+		{name: "parser equals", args: []string{"--json", "--select=", "version"}, diagnostic: "--select requires a value"},
+		{name: "parser whitespace", args: []string{"--json", "--select", " ", "version"}, diagnostic: "--select requires a value"},
+		{name: "parser empty still requires json", args: []string{"--select=", "version"}, diagnostic: "require --json"},
+		{name: "parser whitespace still requires json", args: []string{"--select", " ", "version"}, diagnostic: "require --json"},
+		{name: "version equals", args: []string{"--version", "--json", "--select="}, diagnostic: "--select requires a value"},
+		{name: "version whitespace", args: []string{"--version", "--json", "--select", " "}, diagnostic: "--select requires a value"},
+		{name: "version empty still requires json", args: []string{"--version", "--select="}, diagnostic: "require --json"},
+		{name: "version whitespace still requires json", args: []string{"--version", "--select", " "}, diagnostic: "require --json"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var execErr error
+			stdout := captureStdout(t, func() {
+				stderr := captureStderr(t, func() {
+					execErr = Execute(tc.args)
+				})
+				if !strings.Contains(stderr, tc.diagnostic) {
+					t.Fatalf("expected %q diagnostic, got %q", tc.diagnostic, stderr)
+				}
+			})
+			if execErr == nil || ExitCode(execErr) != 2 {
+				t.Fatalf("expected usage error, got %v", execErr)
+			}
+			if stdout != "" {
+				t.Fatalf("unexpected partial output: %q", stdout)
+			}
+		})
+	}
+}
+
 func TestExecute_ConflictingOutputModesReportsStderr(t *testing.T) {
 	errText := captureStderr(t, func() {
 		_ = captureStdout(t, func() {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -162,6 +162,24 @@ func TestExecute_VersionSelectsJSONFields(t *testing.T) {
 	}
 }
 
+func TestExecute_VersionSelectRequiresValueBeforeVersionFlag(t *testing.T) {
+	var execErr error
+	stdout := captureStdout(t, func() {
+		stderr := captureStderr(t, func() {
+			execErr = Execute([]string{"--json", "--select", "--version"})
+		})
+		if !strings.Contains(stderr, "--select requires a value") {
+			t.Fatalf("unexpected stderr: %q", stderr)
+		}
+	})
+	if execErr == nil || ExitCode(execErr) != 2 {
+		t.Fatalf("expected usage error, got %v", execErr)
+	}
+	if stdout != "" {
+		t.Fatalf("unexpected stdout: %q", stdout)
+	}
+}
+
 func TestExecute_VersionConflictingOutputModesReportsStderr(t *testing.T) {
 	errText := captureStderr(t, func() {
 		_ = captureStdout(t, func() {

--- a/internal/cmd/searchconsole.go
+++ b/internal/cmd/searchconsole.go
@@ -61,9 +61,9 @@ func (c *SearchConsoleSitesListCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"sites": resp.SiteEntry,
-		})
+		}, resp.SiteEntry))
 	}
 
 	if len(resp.SiteEntry) == 0 {
@@ -137,9 +137,9 @@ func (c *SearchConsoleQueryCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"rows": resp.Rows,
-		})
+		}, resp.Rows))
 	}
 
 	if len(resp.Rows) == 0 {
@@ -187,9 +187,9 @@ func (c *SearchConsoleSitemapsListCmd) Run(ctx context.Context, flags *RootFlags
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"sitemaps": resp.Sitemap,
-		})
+		}, resp.Sitemap))
 	}
 
 	if len(resp.Sitemap) == 0 {
@@ -284,9 +284,9 @@ func (c *SearchConsoleInspectCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"inspectionResult": resp.InspectionResult,
-		})
+		}, resp.InspectionResult))
 	}
 
 	result := resp.InspectionResult
@@ -318,7 +318,7 @@ func writeSearchConsoleMutationReceipt(ctx context.Context, action, siteURL, sit
 		if sitemapURL != "" {
 			payload["sitemapUrl"] = sitemapURL
 		}
-		return outfmt.WriteJSON(os.Stdout, payload)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(payload))
 	}
 	if outfmt.IsPlain(ctx) {
 		writePlainReceipt(ctx,

--- a/internal/cmd/searchconsole_sitemaps.go
+++ b/internal/cmd/searchconsole_sitemaps.go
@@ -43,7 +43,7 @@ func (c *SearchConsoleSitemapsGetCmd) Run(ctx context.Context, flags *RootFlags)
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"sitemap": sm})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"sitemap": sm}, sm))
 	}
 
 	// Text output

--- a/internal/cmd/searchconsole_sites.go
+++ b/internal/cmd/searchconsole_sites.go
@@ -40,7 +40,7 @@ func (c *SearchConsoleSitesGetCmd) Run(ctx context.Context, flags *RootFlags) er
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"site": site})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"site": site}, site))
 	}
 
 	// Text output
@@ -160,7 +160,7 @@ func (c *SearchConsoleMobileFriendlyTestCmd) Run(ctx context.Context, flags *Roo
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"testResult": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"testResult": resp}, resp))
 	}
 
 	// Text output

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -119,10 +119,10 @@ func (c *SheetsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"range":  resp.Range,
 			"values": resp.Values,
-		})
+		}, resp.Values))
 	}
 
 	if len(resp.Values) == 0 {
@@ -221,12 +221,12 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"updatedRange":   resp.UpdatedRange,
 			"updatedRows":    resp.UpdatedRows,
 			"updatedColumns": resp.UpdatedColumns,
 			"updatedCells":   resp.UpdatedCells,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		writeSheetsValueMutationPlainSingle(ctx, "update", sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId), resp.UpdatedRange, resp.UpdatedRows, resp.UpdatedColumns, resp.UpdatedCells)
@@ -319,12 +319,12 @@ func (c *SheetsAppendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"updatedRange":   resp.Updates.UpdatedRange,
 			"updatedRows":    resp.Updates.UpdatedRows,
 			"updatedColumns": resp.Updates.UpdatedColumns,
 			"updatedCells":   resp.Updates.UpdatedCells,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		spreadsheetIDOut := sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId)
@@ -381,9 +381,9 @@ func (c *SheetsClearCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"clearedRange": resp.ClearedRange,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		spreadsheetIDOut := sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId)
@@ -422,13 +422,13 @@ func (c *SheetsMetadataCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"spreadsheetId": resp.SpreadsheetId,
 			"title":         resp.Properties.Title,
 			"locale":        resp.Properties.Locale,
 			"timeZone":      resp.Properties.TimeZone,
 			"sheets":        resp.Sheets,
-		})
+		}, resp.Sheets))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -558,11 +558,11 @@ func (c *SheetsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"spreadsheetId":  resp.SpreadsheetId,
 			"title":          resp.Properties.Title,
 			"spreadsheetUrl": resp.SpreadsheetUrl,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		writeSheetsStructuralPlain(ctx, "create", resp.SpreadsheetId, "", resp.Properties.Title, "")

--- a/internal/cmd/sheets_batch.go
+++ b/internal/cmd/sheets_batch.go
@@ -74,10 +74,10 @@ func (c *SheetsBatchGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"spreadsheetId": resp.SpreadsheetId,
 			"valueRanges":   resp.ValueRanges,
-		})
+		}, resp.ValueRanges))
 	}
 	if outfmt.IsPlain(ctx) {
 		writeSheetsValueRangesPlain(ctx, resp.ValueRanges)
@@ -152,13 +152,13 @@ func (c *SheetsBatchUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"spreadsheetId":       resp.SpreadsheetId,
 			"totalUpdatedRows":    resp.TotalUpdatedRows,
 			"totalUpdatedColumns": resp.TotalUpdatedColumns,
 			"totalUpdatedCells":   resp.TotalUpdatedCells,
 			"totalUpdatedSheets":  resp.TotalUpdatedSheets,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		spreadsheetIDOut := sheetsMutationSpreadsheetID(id, resp.SpreadsheetId)

--- a/internal/cmd/sheets_format.go
+++ b/internal/cmd/sheets_format.go
@@ -94,10 +94,10 @@ func (c *SheetsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"range":  rangeSpec,
 			"fields": formatFields,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		sheetID := ""

--- a/internal/cmd/sheets_gaps.go
+++ b/internal/cmd/sheets_gaps.go
@@ -48,7 +48,7 @@ func (c *SheetsDeveloperMetadataGetCmd) Run(ctx context.Context, flags *RootFlag
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"metadata": resp})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"metadata": resp}, resp))
 	}
 
 	u.Out().Printf("ID\t%d", resp.MetadataId)
@@ -148,9 +148,9 @@ func (c *SheetsDeveloperMetadataSearchCmd) Run(ctx context.Context, flags *RootF
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"matchedDeveloperMetadata": resp.MatchedDeveloperMetadata,
-		})
+		}, resp.MatchedDeveloperMetadata))
 	}
 
 	if len(resp.MatchedDeveloperMetadata) == 0 {
@@ -216,11 +216,11 @@ func (c *SheetsGetByFilterCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"spreadsheetId": resp.SpreadsheetId,
 			"title":         resp.Properties.Title,
 			"sheets":        resp.Sheets,
-		})
+		}, resp.Sheets))
 	}
 
 	u.Out().Printf("ID\t%s", resp.SpreadsheetId)
@@ -267,12 +267,12 @@ func (c *SheetsCopyToCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"sheetId":   resp.SheetId,
 			"title":     resp.Title,
 			"index":     resp.Index,
 			"sheetType": resp.SheetType,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		writeSheetsStructuralPlain(ctx, "copy-to", destID, fmt.Sprintf("%d", resp.SheetId), resp.Title, "")
@@ -332,10 +332,10 @@ func (c *SheetsValuesBatchClearCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"spreadsheetId": resp.SpreadsheetId,
 			"clearedRanges": resp.ClearedRanges,
-		})
+		}, resp.ClearedRanges))
 	}
 	if outfmt.IsPlain(ctx) {
 		spreadsheetIDOut := sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId)
@@ -394,10 +394,10 @@ func (c *SheetsValuesBatchClearByFilterCmd) Run(ctx context.Context, flags *Root
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"spreadsheetId": resp.SpreadsheetId,
 			"clearedRanges": resp.ClearedRanges,
-		})
+		}, resp.ClearedRanges))
 	}
 	if outfmt.IsPlain(ctx) {
 		spreadsheetIDOut := sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId)
@@ -465,9 +465,9 @@ func (c *SheetsValuesBatchGetByFilterCmd) Run(ctx context.Context, flags *RootFl
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"valueRanges": resp.ValueRanges,
-		})
+		}, resp.ValueRanges))
 	}
 
 	if outfmt.IsPlain(ctx) {
@@ -563,14 +563,14 @@ func (c *SheetsValuesBatchUpdateByFilterCmd) Run(ctx context.Context, flags *Roo
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"spreadsheetId":       resp.SpreadsheetId,
 			"totalUpdatedRows":    resp.TotalUpdatedRows,
 			"totalUpdatedColumns": resp.TotalUpdatedColumns,
 			"totalUpdatedCells":   resp.TotalUpdatedCells,
 			"totalUpdatedSheets":  resp.TotalUpdatedSheets,
 			"responses":           resp.Responses,
-		})
+		}, resp.Responses))
 	}
 	if outfmt.IsPlain(ctx) {
 		spreadsheetIDOut := sheetsMutationSpreadsheetID(spreadsheetID, resp.SpreadsheetId)

--- a/internal/cmd/sheets_tabs.go
+++ b/internal/cmd/sheets_tabs.go
@@ -73,7 +73,7 @@ func (c *SheetsSheetAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 			out["sheetId"] = addedProps.SheetId
 			out["title"] = addedProps.Title
 		}
-		return outfmt.WriteJSON(os.Stdout, out)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(out))
 	}
 	if outfmt.IsPlain(ctx) {
 		sheetID, title := "", ""
@@ -131,10 +131,10 @@ func (c *SheetsSheetDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"spreadsheetId":  resp.SpreadsheetId,
 			"deletedSheetId": c.SheetID,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		writeSheetsStructuralPlain(ctx, "delete", resp.SpreadsheetId, fmt.Sprintf("%d", c.SheetID), "", "")
@@ -212,11 +212,11 @@ func (c *SheetsSheetUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"spreadsheetId": resp.SpreadsheetId,
 			"sheetId":       c.SheetID,
 			"updatedFields": fields,
-		})
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		writeSheetsStructuralPlain(ctx, "update", resp.SpreadsheetId, fmt.Sprintf("%d", c.SheetID), strings.TrimSpace(c.Title), "")

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -43,10 +43,10 @@ func (c *SkillsStatusCmd) Run(ctx context.Context) error {
 				RealPath: r.RealPath,
 			})
 		}
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"pack_version": VersionString(),
 			"skills":       out,
-		})
+		}, out))
 	}
 	if outfmt.IsPlain(ctx) {
 		for _, r := range rows {
@@ -109,7 +109,7 @@ func runSkillUpdate(ctx context.Context, force, install bool) error {
 
 func printSkillResults(ctx context.Context, results []skillpack.ApplyResult) error {
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"results": results})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"results": results}, results))
 	}
 
 	var updated, installed, dirty, current, missing []string

--- a/internal/cmd/slides.go
+++ b/internal/cmd/slides.go
@@ -90,7 +90,7 @@ func (c *SlidesCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{strFile: created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{strFile: created}, created))
 	}
 
 	u.Out().Printf("id\t%s", created.Id)

--- a/internal/cmd/tagmanager.go
+++ b/internal/cmd/tagmanager.go
@@ -58,9 +58,9 @@ func (c *TagManagerAccountsCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"accounts": resp.Account,
-		})
+		}, resp.Account))
 	}
 
 	if len(resp.Account) == 0 {
@@ -105,9 +105,9 @@ func (c *TagManagerContainersCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"containers": resp.Container,
-		})
+		}, resp.Container))
 	}
 
 	if len(resp.Container) == 0 {
@@ -157,9 +157,9 @@ func (c *TagManagerTagsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"tags": resp.Tag,
-		})
+		}, resp.Tag))
 	}
 
 	if len(resp.Tag) == 0 {
@@ -204,7 +204,7 @@ func (c *TagManagerTagCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"tag": tag})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"tag": tag}, tag))
 	}
 	if outfmt.IsPlain(ctx) {
 		return writeTagManagerTagPlain(ctx, tag)
@@ -350,9 +350,9 @@ func (c *TagManagerTriggersListCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"triggers": resp.Trigger,
-		})
+		}, resp.Trigger))
 	}
 
 	if len(resp.Trigger) == 0 {
@@ -411,9 +411,9 @@ func (c *TagManagerVariablesListCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"variables": resp.Variable,
-		})
+		}, resp.Variable))
 	}
 
 	if len(resp.Variable) == 0 {
@@ -467,9 +467,9 @@ func (c *TagManagerVersionsListCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"versionHeaders": resp.ContainerVersionHeader,
-		})
+		}, resp.ContainerVersionHeader))
 	}
 
 	if len(resp.ContainerVersionHeader) == 0 {

--- a/internal/cmd/tagmanager_built_in_variables.go
+++ b/internal/cmd/tagmanager_built_in_variables.go
@@ -62,7 +62,7 @@ func (c *TagManagerBuiltInVariablesDeleteCmd) Run(ctx context.Context, flags *Ro
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "path": path, "types": types})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"deleted": true, "path": path, "types": types}))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -102,7 +102,7 @@ func (c *TagManagerBuiltInVariablesListCmd) Run(ctx context.Context, flags *Root
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, resp.BuiltInVariable)
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(resp.BuiltInVariable, resp.BuiltInVariable))
 	}
 	return writeTagManagerBuiltInVariables(ctx, resp.BuiltInVariable, resp.NextPageToken)
 }
@@ -129,7 +129,7 @@ func (c *TagManagerBuiltInVariablesRevertCmd) Run(ctx context.Context, flags *Ro
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"type": types[0], "enabled": resp.Enabled})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"type": types[0], "enabled": resp.Enabled}))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -167,7 +167,7 @@ func tagManagerBuiltInRequest(flags *RootFlags, workspace tagManagerWorkspaceFla
 
 func writeTagManagerBuiltInVariables(ctx context.Context, variables []*tagmanager.BuiltInVariable, nextPageToken string) error {
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"builtInVariables": variables, "nextPageToken": nextPageToken})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"builtInVariables": variables, "nextPageToken": nextPageToken}, variables))
 	}
 	if len(variables) == 0 {
 		ui.FromContext(ctx).Err().Println("No built-in variables")

--- a/internal/cmd/tagmanager_publishing.go
+++ b/internal/cmd/tagmanager_publishing.go
@@ -89,12 +89,12 @@ func (c *TagManagerWorkspacesCreateVersionCmd) Run(ctx context.Context, flags *R
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"compilerError":    resp.CompilerError,
 			"containerVersion": resp.ContainerVersion,
 			"newWorkspacePath": resp.NewWorkspacePath,
 			"path":             versionPath,
-		})
+		}, resp.ContainerVersion))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -150,11 +150,11 @@ func (c *TagManagerVersionsPublishCmd) Run(ctx context.Context, flags *RootFlags
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"compilerError":    resp.CompilerError,
 			"containerVersion": resp.ContainerVersion,
 			"path":             versionPath,
-		})
+		}, resp.ContainerVersion))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)

--- a/internal/cmd/tagmanager_publishing.go
+++ b/internal/cmd/tagmanager_publishing.go
@@ -89,12 +89,12 @@ func (c *TagManagerWorkspacesCreateVersionCmd) Run(ctx context.Context, flags *R
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"compilerError":    resp.CompilerError,
 			"containerVersion": resp.ContainerVersion,
 			"newWorkspacePath": resp.NewWorkspacePath,
 			"path":             versionPath,
-		}, resp.ContainerVersion))
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -150,11 +150,11 @@ func (c *TagManagerVersionsPublishCmd) Run(ctx context.Context, flags *RootFlags
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"compilerError":    resp.CompilerError,
 			"containerVersion": resp.ContainerVersion,
 			"path":             versionPath,
-		}, resp.ContainerVersion))
+		}))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)

--- a/internal/cmd/tagmanager_publishing_test.go
+++ b/internal/cmd/tagmanager_publishing_test.go
@@ -60,7 +60,8 @@ func TestExecute_TagManagerWorkspacesCreateVersion(t *testing.T) {
 				"path": "accounts/111/containers/c1/versions/42",
 				"fingerprint": "fp-42"
 			},
-			"newWorkspacePath": "accounts/111/containers/c1/workspaces/8"
+			"newWorkspacePath": "accounts/111/containers/c1/workspaces/8",
+			"compilerError": true
 		}`))
 	}))
 
@@ -80,6 +81,7 @@ func TestExecute_TagManagerWorkspacesCreateVersion(t *testing.T) {
 		Path             string                       `json:"path"`
 		ContainerVersion *tagmanager.ContainerVersion `json:"containerVersion"`
 		NewWorkspacePath string                       `json:"newWorkspacePath"`
+		CompilerError    bool                         `json:"compilerError"`
 	}
 	if err := json.Unmarshal([]byte(out), &result); err != nil {
 		t.Fatalf("decode output: %v\nout=%q", err, out)
@@ -92,6 +94,9 @@ func TestExecute_TagManagerWorkspacesCreateVersion(t *testing.T) {
 	}
 	if result.NewWorkspacePath != "accounts/111/containers/c1/workspaces/8" {
 		t.Fatalf("newWorkspacePath = %q", result.NewWorkspacePath)
+	}
+	if !result.CompilerError {
+		t.Fatal("compilerError = false, want true")
 	}
 }
 
@@ -115,7 +120,8 @@ func TestExecute_TagManagerVersionsPublish(t *testing.T) {
 				"name": "Release 42",
 				"path": "accounts/111/containers/c1/versions/42",
 				"fingerprint": "fp-published"
-			}
+			},
+			"compilerError": true
 		}`))
 	}))
 
@@ -133,6 +139,7 @@ func TestExecute_TagManagerVersionsPublish(t *testing.T) {
 	var result struct {
 		Path             string                       `json:"path"`
 		ContainerVersion *tagmanager.ContainerVersion `json:"containerVersion"`
+		CompilerError    bool                         `json:"compilerError"`
 	}
 	if err := json.Unmarshal([]byte(out), &result); err != nil {
 		t.Fatalf("decode output: %v\nout=%q", err, out)
@@ -142,6 +149,65 @@ func TestExecute_TagManagerVersionsPublish(t *testing.T) {
 	}
 	if result.ContainerVersion == nil || result.ContainerVersion.Fingerprint != "fp-published" {
 		t.Fatalf("unexpected container version: %#v", result.ContainerVersion)
+	}
+	if !result.CompilerError {
+		t.Fatal("compilerError = false, want true")
+	}
+}
+
+func TestExecute_TagManagerPublishingResultsOnlyPreservesCompilerError(t *testing.T) {
+	setupTagManagerPublishingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/tagmanager/v2/accounts/111/containers/c1/workspaces/7:create_version":
+			_, _ = w.Write([]byte(`{
+				"containerVersion": {"path": "accounts/111/containers/c1/versions/42"},
+				"newWorkspacePath": "accounts/111/containers/c1/workspaces/8",
+				"compilerError": true
+			}`))
+		case "/tagmanager/v2/accounts/111/containers/c1/versions/42:publish":
+			_, _ = w.Write([]byte(`{
+				"containerVersion": {"path": "accounts/111/containers/c1/versions/42"},
+				"compilerError": true
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "create version",
+			args: []string{"--json", "--results-only", "--account", "admin@example.com", "gtm", "workspaces", "create-version", "accounts/111/containers/c1/workspaces/7"},
+		},
+		{
+			name: "publish",
+			args: []string{"--json", "--results-only", "--account", "admin@example.com", "gtm", "versions", "publish", "accounts/111/containers/c1/versions/42"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				_ = captureStderr(t, func() {
+					if err := Execute(tc.args); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+
+			var result map[string]any
+			if err := json.Unmarshal([]byte(out), &result); err != nil {
+				t.Fatalf("decode output: %v\nout=%q", err, out)
+			}
+			if compilerError, ok := result["compilerError"].(bool); !ok || !compilerError {
+				t.Fatalf("compilerError = %#v, want true", result["compilerError"])
+			}
+			if _, ok := result["containerVersion"]; !ok {
+				t.Fatalf("containerVersion missing from output: %#v", result)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/tagmanager_resources.go
+++ b/internal/cmd/tagmanager_resources.go
@@ -86,7 +86,7 @@ func parseTagManagerJSONObject[T any](flagName, value string) (*T, error) {
 
 func writeTagManagerDelete(ctx context.Context, resource, path string) error {
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "path": path})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"deleted": true, "path": path}))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)

--- a/internal/cmd/tagmanager_triggers_edit.go
+++ b/internal/cmd/tagmanager_triggers_edit.go
@@ -252,7 +252,7 @@ func (c *TagManagerTriggersUpdateCmd) buildPatch(kctx *kong.Context) (func(*tagm
 
 func writeTagManagerTrigger(ctx context.Context, action string, trigger *tagmanager.Trigger) error {
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"trigger": trigger})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"trigger": trigger}, trigger))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)

--- a/internal/cmd/tagmanager_user_permissions.go
+++ b/internal/cmd/tagmanager_user_permissions.go
@@ -141,7 +141,7 @@ func (c *TagManagerUserPermissionsDeleteCmd) Run(ctx context.Context, flags *Roo
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"deleted": true, "path": path})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{"deleted": true, "path": path}))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)
@@ -205,7 +205,7 @@ func (c *TagManagerUserPermissionsListCmd) Run(ctx context.Context, flags *RootF
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"userPermissions": resp.UserPermission, "nextPageToken": resp.NextPageToken})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"userPermissions": resp.UserPermission, "nextPageToken": resp.NextPageToken}, resp.UserPermission))
 	}
 	u := ui.FromContext(ctx)
 	if len(resp.UserPermission) == 0 {
@@ -291,7 +291,7 @@ func tagManagerPermissionID(path string) string {
 
 func writeTagManagerUserPermission(ctx context.Context, action string, permission *tagmanager.UserPermission) error {
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"userPermission": permission})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"userPermission": permission}, permission))
 	}
 	accountAccess := ""
 	if permission.AccountAccess != nil {

--- a/internal/cmd/tagmanager_variables_edit.go
+++ b/internal/cmd/tagmanager_variables_edit.go
@@ -166,7 +166,7 @@ func (c *TagManagerVariablesUpdateCmd) Run(ctx context.Context, kctx *kong.Conte
 
 func writeTagManagerVariable(ctx context.Context, action string, variable *tagmanager.Variable) error {
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"variable": variable})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"variable": variable}, variable))
 	}
 	if outfmt.IsPlain(ctx) {
 		w, flush := tableWriter(ctx)

--- a/internal/cmd/tasks_edit.go
+++ b/internal/cmd/tasks_edit.go
@@ -53,7 +53,7 @@ func (c *TasksMoveCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"task": moved})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"task": moved}, moved))
 	}
 	u.Out().Printf("id\t%s", moved.Id)
 	u.Out().Printf("title\t%s", moved.Title)
@@ -127,7 +127,7 @@ func (c *TasksReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"task": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"task": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("title\t%s", updated.Title)

--- a/internal/cmd/tasks_items.go
+++ b/internal/cmd/tasks_items.go
@@ -79,10 +79,10 @@ func (c *TasksListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"tasks":         resp.Items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 
 	if len(resp.Items) == 0 {
@@ -134,7 +134,7 @@ func (c *TasksGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"task": task})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"task": task}, task))
 	}
 	u.Out().Printf("id\t%s", task.Id)
 	u.Out().Printf("title\t%s", task.Title)
@@ -212,7 +212,7 @@ func (c *TasksAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 			return createErr
 		}
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(os.Stdout, map[string]any{"task": created})
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"task": created}, created))
 		}
 		u.Out().Printf("id\t%s", created.Id)
 		u.Out().Printf("title\t%s", created.Title)
@@ -312,10 +312,10 @@ func (c *TasksAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"tasks": createdTasks,
 			"count": len(createdTasks),
-		})
+		}, createdTasks))
 	}
 	if len(createdTasks) == 1 {
 		created := createdTasks[0]
@@ -409,7 +409,7 @@ func (c *TasksUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Roo
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"task": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"task": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("title\t%s", updated.Title)
@@ -455,7 +455,7 @@ func (c *TasksDoneCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"task": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"task": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("status\t%s", strings.TrimSpace(updated.Status))
@@ -492,7 +492,7 @@ func (c *TasksUndoCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"task": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"task": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("status\t%s", strings.TrimSpace(updated.Status))
@@ -532,10 +532,10 @@ func (c *TasksDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted": true,
 			"id":      taskID,
-		})
+		}))
 	}
 	u.Out().Printf("deleted\ttrue")
 	u.Out().Printf("id\t%s", taskID)
@@ -570,10 +570,10 @@ func (c *TasksClearCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"cleared":    true,
 			"tasklistId": tasklistID,
-		})
+		}))
 	}
 	u.Out().Printf("cleared\ttrue")
 	u.Out().Printf("tasklistId\t%s", tasklistID)

--- a/internal/cmd/tasks_lists.go
+++ b/internal/cmd/tasks_lists.go
@@ -45,10 +45,10 @@ func (c *TasksListsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"tasklists":     resp.Items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 
 	if len(resp.Items) == 0 {
@@ -92,7 +92,7 @@ func (c *TasksListsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"tasklist": created})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"tasklist": created}, created))
 	}
 	u.Out().Printf("id\t%s", created.Id)
 	u.Out().Printf("title\t%s", created.Title)

--- a/internal/cmd/tasks_tasklists_edit.go
+++ b/internal/cmd/tasks_tasklists_edit.go
@@ -40,7 +40,7 @@ func (c *TasksListsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"tasklist": tl})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"tasklist": tl}, tl))
 	}
 	u.Out().Printf("id\t%s", tl.Id)
 	u.Out().Printf("title\t%s", tl.Title)
@@ -78,10 +78,10 @@ func (c *TasksListsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"deleted":    true,
 			"tasklistId": tasklistID,
-		})
+		}))
 	}
 	u.Err().Printf("Deleted task list %s", tasklistID)
 	return nil
@@ -125,7 +125,7 @@ func (c *TasksListsPatchCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"tasklist": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"tasklist": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("title\t%s", updated.Title)
@@ -165,7 +165,7 @@ func (c *TasksListsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"tasklist": updated})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"tasklist": updated}, updated))
 	}
 	u.Out().Printf("id\t%s", updated.Id)
 	u.Out().Printf("title\t%s", updated.Title)

--- a/internal/cmd/time_now.go
+++ b/internal/cmd/time_now.go
@@ -37,12 +37,12 @@ func (c *TimeNowCmd) Run(ctx context.Context) error {
 	offset := formatUTCOffset(now)
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"timezone":     tz,
 			"current_time": now.Format(time.RFC3339),
 			"utc_offset":   offset,
 			"formatted":    formatted,
-		})
+		}))
 	}
 	if u != nil {
 		u.Out().Printf("timezone\t%s", tz)

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -47,7 +47,7 @@ func (c *UpdateCmd) Run(ctx context.Context) error {
 		}
 
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(os.Stdout, res)
+			return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(res))
 		}
 		if outfmt.IsPlain(ctx) {
 			fmt.Fprintln(os.Stdout, "CURRENT\tLATEST\tUPDATE\tASSET")

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -36,11 +36,11 @@ type VersionCmd struct{}
 
 func (c *VersionCmd) Run(ctx context.Context) error {
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"version": strings.TrimSpace(version),
 			"commit":  strings.TrimSpace(commit),
 			"date":    strings.TrimSpace(date),
-		})
+		}))
 	}
 	fmt.Fprintln(os.Stdout, VersionString())
 	return nil

--- a/internal/cmd/youtube.go
+++ b/internal/cmd/youtube.go
@@ -62,10 +62,10 @@ func (c *YoutubeChannelsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"channels":      resp.Items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 
 	if len(resp.Items) == 0 {
@@ -131,10 +131,10 @@ func (c *YoutubeVideosCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"videos":        resp.Items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 
 	if len(resp.Items) == 0 {
@@ -195,7 +195,7 @@ func (c *YoutubeVideoCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	video := resp.Items[0]
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"video": video})
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{"video": video}, video))
 	}
 
 	u.Out().Printf("id\t%s", video.Id)
@@ -253,10 +253,10 @@ func (c *YoutubeSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"results":       resp.Items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 
 	if len(resp.Items) == 0 {
@@ -335,10 +335,10 @@ func (c *YoutubePlaylistsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"playlists":     resp.Items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 
 	if len(resp.Items) == 0 {
@@ -399,10 +399,10 @@ func (c *YoutubePlaylistItemsCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"items":         resp.Items,
 			"nextPageToken": resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 
 	if len(resp.Items) == 0 {
@@ -466,10 +466,10 @@ func (c *YoutubeCommentsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.PrimaryResult(map[string]any{
 			"commentThreads": resp.Items,
 			"nextPageToken":  resp.NextPageToken,
-		})
+		}, resp.Items))
 	}
 
 	if len(resp.Items) == 0 {

--- a/internal/outfmt/outfmt.go
+++ b/internal/outfmt/outfmt.go
@@ -3,15 +3,45 @@ package outfmt
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"strings"
+	"sync"
 )
 
 type Mode struct {
 	JSON  bool
 	Plain bool
+}
+
+type JSONConfig struct {
+	ResultsOnly bool
+	Select      []string
+}
+
+type primaryResult struct {
+	output  any
+	primary any
+}
+
+var (
+	errInvalidSelectionPath = errors.New("invalid JSON selection path")
+	errPrimaryResultMissing = errors.New("JSON output does not declare a primary result")
+	errCannotSelectFields   = errors.New("cannot select fields from JSON")
+
+	jsonConfigState struct {
+		sync.RWMutex
+		config JSONConfig
+	}
+)
+
+// PrimaryResult declares the primary value in a JSON response envelope while
+// preserving output unchanged when results-only mode is not requested.
+func PrimaryResult(output any, primary any) any {
+	return primaryResult{output: output, primary: primary}
 }
 
 type ParseError struct{ msg string }
@@ -52,16 +82,181 @@ func FromContext(ctx context.Context) Mode {
 func IsJSON(ctx context.Context) bool  { return FromContext(ctx).JSON }
 func IsPlain(ctx context.Context) bool { return FromContext(ctx).Plain }
 
+func ConfigureJSON(config JSONConfig) (func(), error) {
+	config, err := validateJSONConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonConfigState.Lock()
+	previous := jsonConfigState.config
+	jsonConfigState.config = config
+	jsonConfigState.Unlock()
+
+	var once sync.Once
+
+	return func() {
+		once.Do(func() {
+			jsonConfigState.Lock()
+			jsonConfigState.config = previous
+			jsonConfigState.Unlock()
+		})
+	}, nil
+}
+
 func WriteJSON(w io.Writer, v any) error {
+	jsonConfigState.RLock()
+	config := jsonConfigState.config
+	config.Select = append([]string(nil), config.Select...)
+
+	jsonConfigState.RUnlock()
+
+	return WriteJSONWithConfig(w, v, config)
+}
+
+func WriteJSONWithConfig(w io.Writer, v any, config JSONConfig) error {
+	config, err := validateJSONConfig(config)
+	if err != nil {
+		return err
+	}
+
+	value, err := transformJSON(v, config)
+	if err != nil {
+		return err
+	}
+
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 
-	if err := enc.Encode(v); err != nil {
+	if err := enc.Encode(value); err != nil {
 		return fmt.Errorf("encode json: %w", err)
 	}
 
 	return nil
+}
+
+func validateJSONConfig(config JSONConfig) (JSONConfig, error) {
+	config.Select = append([]string(nil), config.Select...)
+	for i, path := range config.Select {
+		path = strings.TrimSpace(path)
+
+		parts := strings.Split(path, ".")
+		for _, part := range parts {
+			if part == "" {
+				return JSONConfig{}, fmt.Errorf("%w %q", errInvalidSelectionPath, path)
+			}
+		}
+		config.Select[i] = path
+	}
+
+	return config, nil
+}
+
+func transformJSON(v any, config JSONConfig) (any, error) {
+	value := v
+	if result, ok := v.(primaryResult); ok {
+		value = result.output
+		if config.ResultsOnly {
+			value = result.primary
+		}
+	} else if config.ResultsOnly {
+		return nil, errPrimaryResultMissing
+	}
+
+	if len(config.Select) == 0 {
+		return value, nil
+	}
+
+	return projectJSON(value, config.Select)
+}
+
+func projectJSON(value any, paths []string) (any, error) {
+	reflected := reflect.ValueOf(value)
+	if reflected.IsValid() && reflected.Kind() == reflect.Slice && reflected.IsNil() {
+		return []any{}, nil
+	}
+
+	normalized, err := normalizeJSON(value)
+	if err != nil {
+		return nil, err
+	}
+
+	switch value := normalized.(type) {
+	case map[string]any:
+		return projectJSONObject(value, paths), nil
+	case []any:
+		projected := make([]any, 0, len(value))
+		for i, item := range value {
+			object, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("%w array element %d (%T)", errCannotSelectFields, i, item)
+			}
+
+			projected = append(projected, projectJSONObject(object, paths))
+		}
+
+		return projected, nil
+	default:
+		return nil, fmt.Errorf("%w %T", errCannotSelectFields, normalized)
+	}
+}
+
+func normalizeJSON(value any) (any, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode JSON for selection: %w", err)
+	}
+
+	var normalized any
+	if err := json.Unmarshal(data, &normalized); err != nil {
+		return nil, fmt.Errorf("decode JSON for selection: %w", err)
+	}
+
+	return normalized, nil
+}
+
+func projectJSONObject(object map[string]any, paths []string) map[string]any {
+	projected := make(map[string]any)
+
+	for _, path := range paths {
+		parts := strings.Split(path, ".")
+		if value, ok := lookupJSONPath(object, parts); ok {
+			setJSONPath(projected, parts, value)
+		}
+	}
+
+	return projected
+}
+
+func lookupJSONPath(object map[string]any, parts []string) (any, bool) {
+	var current any = object
+	for _, part := range parts {
+		next, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+
+		current, ok = next[part]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return current, true
+}
+
+func setJSONPath(object map[string]any, parts []string, value any) {
+	current := object
+	for _, part := range parts[:len(parts)-1] {
+		next, ok := current[part].(map[string]any)
+		if !ok {
+			next = make(map[string]any)
+			current[part] = next
+		}
+		current = next
+	}
+	current[parts[len(parts)-1]] = value
 }
 
 func KeyValuePayload(key string, value any) map[string]any {

--- a/internal/outfmt/outfmt.go
+++ b/internal/outfmt/outfmt.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"sync"
 )
 
 type Mode struct {
@@ -31,12 +30,12 @@ var (
 	errInvalidSelectionPath = errors.New("invalid JSON selection path")
 	errPrimaryResultMissing = errors.New("JSON output does not declare a primary result")
 	errCannotSelectFields   = errors.New("cannot select fields from JSON")
-
-	jsonConfigState struct {
-		sync.RWMutex
-		config JSONConfig
-	}
 )
+
+// DirectResult declares the complete JSON value as the primary result.
+func DirectResult(output any) any {
+	return primaryResult{output: output, primary: output}
+}
 
 // PrimaryResult declares the primary value in a JSON response envelope while
 // preserving output unchanged when results-only mode is not requested.
@@ -65,53 +64,47 @@ func FromEnv() Mode {
 
 type ctxKey struct{}
 
+type contextConfig struct {
+	Mode Mode
+	JSON JSONConfig
+}
+
 func WithMode(ctx context.Context, mode Mode) context.Context {
-	return context.WithValue(ctx, ctxKey{}, mode)
+	config := fromContext(ctx)
+	config.Mode = mode
+
+	return context.WithValue(ctx, ctxKey{}, config)
 }
 
-func FromContext(ctx context.Context) Mode {
-	if v := ctx.Value(ctxKey{}); v != nil {
-		if m, ok := v.(Mode); ok {
-			return m
-		}
-	}
-
-	return Mode{}
-}
-
-func IsJSON(ctx context.Context) bool  { return FromContext(ctx).JSON }
-func IsPlain(ctx context.Context) bool { return FromContext(ctx).Plain }
-
-func ConfigureJSON(config JSONConfig) (func(), error) {
+func WithJSONConfig(ctx context.Context, config JSONConfig) (context.Context, error) {
 	config, err := validateJSONConfig(config)
 	if err != nil {
 		return nil, err
 	}
 
-	jsonConfigState.Lock()
-	previous := jsonConfigState.config
-	jsonConfigState.config = config
-	jsonConfigState.Unlock()
+	ctxConfig := fromContext(ctx)
+	ctxConfig.JSON = config
 
-	var once sync.Once
-
-	return func() {
-		once.Do(func() {
-			jsonConfigState.Lock()
-			jsonConfigState.config = previous
-			jsonConfigState.Unlock()
-		})
-	}, nil
+	return context.WithValue(ctx, ctxKey{}, ctxConfig), nil
 }
 
-func WriteJSON(w io.Writer, v any) error {
-	jsonConfigState.RLock()
-	config := jsonConfigState.config
-	config.Select = append([]string(nil), config.Select...)
+func fromContext(ctx context.Context) contextConfig {
+	if v := ctx.Value(ctxKey{}); v != nil {
+		if config, ok := v.(contextConfig); ok {
+			return config
+		}
+	}
 
-	jsonConfigState.RUnlock()
+	return contextConfig{}
+}
 
-	return WriteJSONWithConfig(w, v, config)
+func FromContext(ctx context.Context) Mode { return fromContext(ctx).Mode }
+
+func IsJSON(ctx context.Context) bool  { return FromContext(ctx).JSON }
+func IsPlain(ctx context.Context) bool { return FromContext(ctx).Plain }
+
+func WriteJSON(ctx context.Context, w io.Writer, v any) error {
+	return WriteJSONWithConfig(w, v, fromContext(ctx).JSON)
 }
 
 func WriteJSONWithConfig(w io.Writer, v any, config JSONConfig) error {
@@ -209,7 +202,10 @@ func normalizeJSON(value any) (any, error) {
 	}
 
 	var normalized any
-	if err := json.Unmarshal(data, &normalized); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.UseNumber()
+
+	if err := decoder.Decode(&normalized); err != nil {
 		return nil, fmt.Errorf("decode JSON for selection: %w", err)
 	}
 

--- a/internal/outfmt/outfmt_test.go
+++ b/internal/outfmt/outfmt_test.go
@@ -37,7 +37,7 @@ func TestContextMode(t *testing.T) {
 
 func TestWriteJSON(t *testing.T) {
 	var buf bytes.Buffer
-	if err := WriteJSON(&buf, map[string]any{"ok": true}); err != nil {
+	if err := WriteJSON(context.Background(), &buf, map[string]any{"ok": true}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -95,6 +95,19 @@ func TestWriteJSONWithConfig_ComposesResultsOnlyBeforeSelection(t *testing.T) {
 	}
 }
 
+func TestWriteJSONWithConfig_SelectionPreservesLargeIntegers(t *testing.T) {
+	var buf bytes.Buffer
+	value := map[string]any{"id": int64(9007199254740993), "name": "large"}
+
+	if err := WriteJSONWithConfig(&buf, value, JSONConfig{Select: []string{"id"}}); err != nil {
+		t.Fatalf("WriteJSONWithConfig: %v", err)
+	}
+
+	if got, want := buf.String(), "{\n  \"id\": 9007199254740993\n}\n"; got != want {
+		t.Fatalf("numeric fidelity mismatch: got %q want %q", got, want)
+	}
+}
+
 func TestWriteJSONWithConfig_RejectsNonProjectableTargets(t *testing.T) {
 	var buf bytes.Buffer
 
@@ -117,26 +130,50 @@ func TestWriteJSONWithConfig_ResultsOnlyRequiresExplicitContract(t *testing.T) {
 	}
 }
 
-func TestConfigureJSON_AppliesToWriteJSONAndRestoresPreviousConfig(t *testing.T) {
-	restore, err := ConfigureJSON(JSONConfig{Select: []string{"id"}})
+func TestWriteJSON_ConfigurationIsExecutionScoped(t *testing.T) {
+	idCtx, err := WithJSONConfig(context.Background(), JSONConfig{Select: []string{"id"}})
 	if err != nil {
-		t.Fatalf("ConfigureJSON: %v", err)
+		t.Fatalf("WithJSONConfig id: %v", err)
 	}
 
-	var selected bytes.Buffer
-	if err := WriteJSON(&selected, map[string]any{"id": "f1", "name": "Doc"}); err != nil {
-		t.Fatalf("WriteJSON configured: %v", err)
+	nameCtx, err := WithJSONConfig(context.Background(), JSONConfig{Select: []string{"name"}})
+	if err != nil {
+		t.Fatalf("WithJSONConfig name: %v", err)
 	}
 
-	restore()
+	start := make(chan struct{})
+	results := make(chan string, 2)
+
+	write := func(ctx context.Context) {
+		<-start
+
+		var buf bytes.Buffer
+		if err := WriteJSON(ctx, &buf, map[string]any{"id": "f1", "name": "Doc"}); err != nil {
+			results <- "error: " + err.Error()
+			return
+		}
+
+		results <- buf.String()
+	}
+
+	go write(idCtx)
+	go write(nameCtx)
+
+	close(start)
+
+	got := map[string]bool{<-results: true, <-results: true}
+	for _, want := range []string{
+		"{\n  \"id\": \"f1\"\n}\n",
+		"{\n  \"name\": \"Doc\"\n}\n",
+	} {
+		if !got[want] {
+			t.Fatalf("missing concurrent output %q; got %#v", want, got)
+		}
+	}
 
 	var ordinary bytes.Buffer
-	if err := WriteJSON(&ordinary, map[string]any{"id": "f1", "name": "Doc"}); err != nil {
-		t.Fatalf("WriteJSON restored: %v", err)
-	}
-
-	if got, want := selected.String(), "{\n  \"id\": \"f1\"\n}\n"; got != want {
-		t.Fatalf("selected output mismatch: got %q want %q", got, want)
+	if err := WriteJSON(context.Background(), &ordinary, map[string]any{"id": "f1", "name": "Doc"}); err != nil {
+		t.Fatalf("ordinary WriteJSON: %v", err)
 	}
 
 	if got, want := ordinary.String(), "{\n  \"id\": \"f1\",\n  \"name\": \"Doc\"\n}\n"; got != want {
@@ -144,9 +181,9 @@ func TestConfigureJSON_AppliesToWriteJSONAndRestoresPreviousConfig(t *testing.T)
 	}
 }
 
-func TestConfigureJSON_RejectsInvalidSelectionPaths(t *testing.T) {
+func TestWithJSONConfig_RejectsInvalidSelectionPaths(t *testing.T) {
 	for _, path := range []string{"", ".id", "sender.", "sender..email"} {
-		if _, err := ConfigureJSON(JSONConfig{Select: []string{path}}); err == nil {
+		if _, err := WithJSONConfig(context.Background(), JSONConfig{Select: []string{path}}); err == nil {
 			t.Fatalf("expected invalid path %q to fail", path)
 		}
 	}

--- a/internal/outfmt/outfmt_test.go
+++ b/internal/outfmt/outfmt_test.go
@@ -3,6 +3,7 @@ package outfmt
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -42,6 +43,112 @@ func TestWriteJSON(t *testing.T) {
 
 	if buf.Len() == 0 {
 		t.Fatalf("expected output")
+	}
+}
+
+func TestWriteJSONWithConfig_ResultsOnlyUsesDeclaredPrimaryResult(t *testing.T) {
+	var buf bytes.Buffer
+	value := PrimaryResult(
+		map[string]any{
+			"files":         []map[string]any{{"id": "f1"}},
+			"nextPageToken": "next",
+		},
+		[]map[string]any{{"id": "f1"}},
+	)
+
+	if err := WriteJSONWithConfig(&buf, value, JSONConfig{ResultsOnly: true}); err != nil {
+		t.Fatalf("WriteJSONWithConfig: %v", err)
+	}
+
+	if got, want := buf.String(), "[\n  {\n    \"id\": \"f1\"\n  }\n]\n"; got != want {
+		t.Fatalf("output mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestWriteJSONWithConfig_SelectionPreservesNestedShapeAndOmitsMissingPaths(t *testing.T) {
+	var buf bytes.Buffer
+	value := []map[string]any{
+		{"id": "m1", "sender": map[string]any{"email": "a@example.com", "name": "A"}},
+		{"id": "m2", "sender": map[string]any{"name": "B"}},
+	}
+
+	if err := WriteJSONWithConfig(&buf, value, JSONConfig{Select: []string{"id", "sender.email"}}); err != nil {
+		t.Fatalf("WriteJSONWithConfig: %v", err)
+	}
+
+	if got, want := buf.String(), "[\n  {\n    \"id\": \"m1\",\n    \"sender\": {\n      \"email\": \"a@example.com\"\n    }\n  },\n  {\n    \"id\": \"m2\"\n  }\n]\n"; got != want {
+		t.Fatalf("output mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestWriteJSONWithConfig_ComposesResultsOnlyBeforeSelection(t *testing.T) {
+	var buf bytes.Buffer
+	files := []map[string]any{{"id": "f1", "name": "Doc", "mimeType": "text/plain"}}
+	value := PrimaryResult(map[string]any{"files": files, "nextPageToken": "next"}, files)
+
+	if err := WriteJSONWithConfig(&buf, value, JSONConfig{ResultsOnly: true, Select: []string{"id", "name"}}); err != nil {
+		t.Fatalf("WriteJSONWithConfig: %v", err)
+	}
+
+	if got, want := buf.String(), "[\n  {\n    \"id\": \"f1\",\n    \"name\": \"Doc\"\n  }\n]\n"; got != want {
+		t.Fatalf("output mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestWriteJSONWithConfig_RejectsNonProjectableTargets(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := WriteJSONWithConfig(&buf, "not-an-object", JSONConfig{Select: []string{"id"}})
+	if err == nil || !strings.Contains(err.Error(), "cannot select fields from JSON string") {
+		t.Fatalf("expected clear projection error, got %v", err)
+	}
+
+	if buf.Len() != 0 {
+		t.Fatalf("unexpected partial output: %q", buf.String())
+	}
+}
+
+func TestWriteJSONWithConfig_ResultsOnlyRequiresExplicitContract(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := WriteJSONWithConfig(&buf, map[string]any{"files": []any{}, "nextPageToken": "next"}, JSONConfig{ResultsOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "does not declare a primary result") {
+		t.Fatalf("expected explicit primary-result error, got %v", err)
+	}
+}
+
+func TestConfigureJSON_AppliesToWriteJSONAndRestoresPreviousConfig(t *testing.T) {
+	restore, err := ConfigureJSON(JSONConfig{Select: []string{"id"}})
+	if err != nil {
+		t.Fatalf("ConfigureJSON: %v", err)
+	}
+
+	var selected bytes.Buffer
+	if err := WriteJSON(&selected, map[string]any{"id": "f1", "name": "Doc"}); err != nil {
+		t.Fatalf("WriteJSON configured: %v", err)
+	}
+
+	restore()
+
+	var ordinary bytes.Buffer
+	if err := WriteJSON(&ordinary, map[string]any{"id": "f1", "name": "Doc"}); err != nil {
+		t.Fatalf("WriteJSON restored: %v", err)
+	}
+
+	if got, want := selected.String(), "{\n  \"id\": \"f1\"\n}\n"; got != want {
+		t.Fatalf("selected output mismatch: got %q want %q", got, want)
+	}
+
+	if got, want := ordinary.String(), "{\n  \"id\": \"f1\",\n  \"name\": \"Doc\"\n}\n"; got != want {
+		t.Fatalf("ordinary output mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestConfigureJSON_RejectsInvalidSelectionPaths(t *testing.T) {
+	for _, path := range []string{"", ".id", "sender.", "sender..email"} {
+		if _, err := ConfigureJSON(JSONConfig{Select: []string{path}}); err == nil {
+			t.Fatalf("expected invalid path %q to fail", path)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Scripts and agents currently need command-specific `jq` expressions to remove JSON response envelopes or retain a small field subset. This adds global JSON transformations so callers can request concise output directly.

- add `--results-only` for explicit command-defined primary results
- add `--select` for comma-separated dotted field projection across objects and arrays
- keep transformation configuration execution-scoped and preserve large integer fidelity
- declare result contracts across command JSON output while preserving existing shapes by default
- retain failure and metadata signals where unwrapping would be misleading

## Verification

- `make test`
- `make lint`
- focused command and formatter tests, including Gmail, Calendar partial failures, Tag Manager compiler errors, invalid flag usage, numeric fidelity, and concurrent execution isolation

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
