### PR TITLE
feat(auth): add guided Google Cloud setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Auth: add guided `gog auth setup` for project selection/creation, selected-project API enablement, Console-only OAuth client guidance, credential install, and first-account authorization (re-runnable; agent-friendly). (#158)
 - Auth: add `gog auth doctor` for unified read-only diagnostics of config, keyring, OAuth client credentials, stored identities, and refresh-token usability. (#157)
 - CLI: add `--results-only` and `--select` for concise, projected JSON output. (#156)
 - CLI: add `gog schema` for deterministic, versioned JSON discovery of commands, flags, exit codes, and effective automation safeguards. (#152)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,25 @@ Before adding an account, create OAuth2 credentials from Google Cloud Console:
    - Application type: "Desktop app"
    - Download the JSON file (usually named `client_secret_....apps.googleusercontent.com.json`)
 
-### 2. Store Credentials
+### 2. Guided setup (recommended)
+
+For a re-runnable, agent-friendly flow that discovers or creates a Cloud project, enables APIs, guides Console-only OAuth client steps, installs credentials, and can authorize the first account:
+
+```bash
+gog auth setup
+```
+
+Non-interactive discovery / resume:
+
+```bash
+gog --json --no-input auth setup --discover
+gog --no-input --force auth setup --project my-proj --enable-apis --credentials ~/Downloads/client_secret.json
+```
+
+See [docs/auth-clients.md](docs/auth-clients.md) for flags, acknowledgments, and exit codes. Advanced users can still run the manual steps below.
+
+### 3. Store Credentials (manual)
+
 
 ```bash
 gog auth credentials ~/Downloads/client_secret_....json
@@ -120,7 +138,7 @@ gog --client work auth credentials ~/Downloads/work-client.json
 gog auth credentials list
 ```
 
-### 3. Authorize Your Account
+### 4. Authorize Your Account
 
 ```bash
 gog auth add you@gmail.com
@@ -128,7 +146,7 @@ gog auth add you@gmail.com
 
 This will open a browser window for OAuth authorization. The refresh token is stored securely in your system keychain.
 
-### 4. Test Authentication
+### 5. Test Authentication
 
 ```bash
 export GOG_ACCOUNT=you@gmail.com
@@ -563,6 +581,7 @@ Flag aliases:
 ### Authentication
 
 ```bash
+gog auth setup                        # Guided Cloud project + OAuth client setup
 gog auth credentials <path>           # Store OAuth client credentials
 gog auth credentials list             # List stored OAuth client credentials
 gog --client work auth credentials <path>  # Store named OAuth client credentials

--- a/docs/auth-clients.md
+++ b/docs/auth-clients.md
@@ -98,3 +98,15 @@ Notes:
 - Acknowledgments reset if the paired project for the client changes.
 - Exit codes: `0` complete or successful discovery, `1` incomplete/manual/blocked after emitting a report, `2` invalid usage.
 - Direct `gog auth credentials` / `gog auth add` remain supported for advanced use.
+
+### Machine-readable setup report
+
+`--json` emits one `SetupReport` object on stdout; `--plain` emits a stable TSV report on stdout. Progress and human guidance remain on stderr. Both forms emit a report before exit `1`.
+
+Top-level JSON fields are `complete`, `discovery_only`, `discovery_complete`, `projects_truncated`, `client`, `project_id`, `gcloud_account`, `services`, `service_usage_ids`, `missing_apis`, `projects`, `stages`, `next`, and `continue_command` (empty optional fields are omitted). `complete` means the whole setup is complete. `discovery_complete` means all requested discovery inspections succeeded; it does not mean setup is complete. Project discovery uses one list call with `limit + 1`; `projects_truncated` is true only when an extra project was found.
+
+Each `stages` element contains `id`, `status`, `action_kind`, and optional `summary`, `blocker`, `resumable`, `console_url`, `command`, `next_action`, and `detail`. The defined stage IDs, in execution order, are `gcloud_install`, `gcloud_auth`, `project`, `apis`, `branding`, `audience`, `data_access`, `desktop_client`, `credentials`, and `account`. A full report always lists every stage. After the first incomplete stage, later stages have status `unavailable`: they were not inspected and no prompts, credential reads, OAuth, or mutations occurred.
+
+Statuses are `ok`, `missing`, `blocked`, `failed`, `manual`, `acknowledged`, and `unavailable`. Action kinds are `none`, `command`, and `console`. `blocked` with `resumable: true` denotes an external prerequisite that can be retried after action or propagation; malformed input, invalid credentials, and invariant violations are `failed` and non-resumable. `next` and `continue_command` identify the first required action. Continuation commands preserve retry-defining non-secret inputs; credential paths are included when supplied, but stdin credential content and all secrets are never emitted.
+
+Plain output has the header `STAGE STATUS SUMMARY BLOCKER COMMAND` (tab-separated), one row per stage, then `meta complete <true|false> <project_id> <continue_command>`. Consumers should tolerate new JSON fields and stage IDs. Exit `0` means `complete` or successful `discovery_complete`; exit `1` means a report was emitted but work remains; exit `2` is invalid usage.

--- a/docs/auth-clients.md
+++ b/docs/auth-clients.md
@@ -64,3 +64,37 @@ Shows stored credential files plus any configured domain mappings.
 
 - Legacy `token:<email>` entries are copied to `token:default:<email>` the first time they are read.
 - Legacy `default_account` is still respected for the default client.
+
+## Guided setup
+
+Use `gog auth setup` for first-time Google Cloud + OAuth onboarding (or to resume a partial setup). It pairs a Cloud project with the current `--client` namespace, enables APIs for selected services on **that project only**, guides Console-only Auth Platform steps, installs Desktop OAuth credentials, and can authorize the first account.
+
+```bash
+# Interactive (TTY): pick a project, confirm mutations, open Console links
+gog auth setup
+
+# Named client
+gog --client work auth setup
+
+# Structured discovery only (no Cloud/local mutations)
+gog --json --no-input auth setup --discover
+gog --plain --no-input auth setup --discover --project my-proj
+
+# Non-interactive mutations require explicit flags + --force
+gog --no-input --force auth setup \
+  --project my-proj \
+  --enable-apis \
+  --services gmail,drive,calendar \
+  --ack-branding --ack-audience --ack-data-access \
+  --credentials ~/Downloads/client_secret.json
+
+# Create a project (never changes gcloud default project/config)
+gog --no-input --force auth setup --create-project --project my-new-proj --project-name "My app"
+```
+
+Notes:
+
+- Manual Auth Platform stages (branding, audience, data access, Desktop client creation) cannot be fully automated with supported public APIs; setup records **acknowledgments** only (not Google-verified completion).
+- Acknowledgments reset if the paired project for the client changes.
+- Exit codes: `0` complete or successful discovery, `1` incomplete/manual/blocked after emitting a report, `2` invalid usage.
+- Direct `gog auth credentials` / `gog auth add` remain supported for advanced use.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -152,6 +152,7 @@ Flag aliases:
 
 ### Implemented
 
+- `gog auth setup` (guided project/API/OAuth client/first-account setup; see docs/auth-clients.md)
 - `gog auth credentials <credentials.json|->`
 - `gog auth credentials list`
 - `gog --client <name> auth credentials <credentials.json|->`
@@ -312,6 +313,7 @@ Flag aliases:
 ### Planned high-level command tree
 
 - `gog auth …`
+  - `gog auth setup`
   - `gog auth credentials <credentials.json>`
   - `gog auth credentials list`
   - `gog --client <name> auth credentials <credentials.json>`

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,8 +10,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/99designs/keyring"
 
 	"github.com/steipete/gogcli/internal/authclient"
 	"github.com/steipete/gogcli/internal/config"

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -53,6 +53,7 @@ const (
 )
 
 type AuthCmd struct {
+	Setup       AuthSetupCmd          `cmd:"" name:"setup" help:"Guide Google Cloud and OAuth setup"`
 	Credentials AuthCredentialsCmd    `cmd:"" name:"credentials" help:"Manage OAuth client credentials"`
 	Add         AuthAddCmd            `cmd:"" name:"add" help:"Authorize and store a refresh token"`
 	Services    AuthServicesCmd       `cmd:"" name:"services" help:"List supported auth services and scopes"`
@@ -84,54 +85,26 @@ func (c *AuthCredentialsSetCmd) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	inPath := c.Path
-	var b []byte
-	if inPath == "-" {
-		b, err = io.ReadAll(os.Stdin)
-	} else {
-		inPath, err = config.ExpandPath(inPath)
-		if err != nil {
-			return err
-		}
-		b, err = os.ReadFile(inPath) //nolint:gosec // user-provided path
-	}
+	result, err := InstallClientCredentials(InstallCredentialsOptions{
+		Client:  client,
+		Path:    c.Path,
+		Domains: c.Domains,
+	})
 	if err != nil {
 		return err
 	}
-
-	creds, err := config.ParseGoogleOAuthClientJSON(b)
-	if err != nil {
-		return err
-	}
-
-	if err := config.WriteClientCredentialsFor(client, creds); err != nil {
-		return err
-	}
-
-	outPath, _ := config.ClientCredentialsPathFor(client)
-	if strings.TrimSpace(c.Domains) != "" {
-		cfg, err := config.ReadConfig()
-		if err != nil {
-			return err
-		}
-		for _, domain := range splitCommaList(c.Domains) {
-			if err := config.SetClientDomain(&cfg, domain, client); err != nil {
-				return err
-			}
-		}
-		if err := config.WriteConfig(cfg); err != nil {
-			return err
-		}
+	if result.Replaced {
+		u.Err().Printf("OAuth credentials for client %q changed; reauthorize stored accounts before use.", result.Client)
 	}
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"saved":  true,
-			"path":   outPath,
-			"client": client,
+			"path":   result.Path,
+			"client": result.Client,
 		}))
 	}
-	u.Out().Printf("path\t%s", outPath)
-	u.Out().Printf("client\t%s", client)
+	u.Out().Printf("path\t%s", result.Path)
+	u.Out().Printf("client\t%s", result.Client)
 	return nil
 }
 
@@ -495,121 +468,34 @@ type AuthAddCmd struct {
 
 func (c *AuthAddCmd) Run(ctx context.Context) error {
 	u := ui.FromContext(ctx)
-
-	override := authclient.ClientOverrideFromContext(ctx)
-	client, err := authclient.ResolveClientWithOverride(c.Email, override)
-	if err != nil {
-		return err
-	}
-
-	services, err := parseAuthServices(c.ServicesCSV)
-	if err != nil {
-		return err
-	}
-	if len(services) == 0 {
-		return fmt.Errorf("no services selected")
-	}
-
-	if c.Readonly && c.DriveScope == strFile {
-		return usage("cannot combine --readonly with --drive-scope=file (file is write-capable)")
-	}
-	driveScope := strings.ToLower(strings.TrimSpace(c.DriveScope))
-	gmailScope := strings.ToLower(strings.TrimSpace(c.GmailScope))
-	scopes, err := googleauth.ScopesForManageWithOptions(services, googleauth.ScopeOptions{
-		Readonly:   c.Readonly,
-		DriveScope: googleauth.DriveScopeMode(c.DriveScope),
-		GmailScope: googleauth.GmailScopeMode(c.GmailScope),
-	})
-	if err != nil {
-		return err
-	}
-
-	// Pre-flight: ensure keychain is accessible before starting OAuth
-	if keychainErr := ensureKeychainAccessIfNeeded(); keychainErr != nil {
-		return fmt.Errorf("keychain access: %w", keychainErr)
-	}
-	store, err := openSecretsStore()
-	if err != nil {
-		return err
-	}
-
-	existing, existingErr := store.GetToken(client, c.Email)
-	hasExisting := existingErr == nil
-	if existingErr != nil && !errors.Is(existingErr, keyring.ErrKeyNotFound) {
-		return fmt.Errorf("read existing token: %w", existingErr)
-	}
-
-	if hasExisting && !c.ReplaceScopes {
-		services, scopes = googleauth.MergeAuthGrant(services, scopes, existing.Services, existing.Scopes)
-	}
-
-	serviceNames := authServiceNames(services)
-	forceConsent := c.ForceConsent || c.ReplaceScopes
-	// Scope variants must be requested exactly because Google can reject a
-	// historical grant containing incompatible variants (for example old
-	// YouTube scopes plus drive.file). Existing scopes are still explicitly
-	// included above unless the user chose --replace-scopes.
-	disableIncludeGrantedScopes := forceConsent ||
-		c.Readonly ||
-		driveScope == "readonly" ||
-		driveScope == strFile ||
-		gmailScope == "readonly"
 	if c.ReplaceScopes {
 		u.Err().Println("Replacing the existing OAuth grant with exactly the selected services and scopes.")
 	}
-
-	refreshToken, err := authorizeGoogle(ctx, googleauth.AuthorizeOptions{
-		Services:                    services,
-		Scopes:                      scopes,
-		Manual:                      c.Manual,
-		ForceConsent:                forceConsent,
-		DisableIncludeGrantedScopes: disableIncludeGrantedScopes,
-		Client:                      client,
+	result, err := AuthorizeAndStoreAccount(ctx, AuthorizeAccountOptions{
+		Email:         c.Email,
+		Client:        authclient.ClientOverrideFromContext(ctx),
+		ServicesCSV:   c.ServicesCSV,
+		Manual:        c.Manual,
+		ForceConsent:  c.ForceConsent,
+		ReplaceScopes: c.ReplaceScopes,
+		Readonly:      c.Readonly,
+		DriveScope:    c.DriveScope,
+		GmailScope:    c.GmailScope,
 	})
 	if err != nil {
 		return err
-	}
-
-	authorizedEmail, err := fetchAuthorizedEmail(ctx, client, refreshToken, scopes, 15*time.Second)
-	if err != nil {
-		return fmt.Errorf("fetch authorized email: %w", err)
-	}
-	if normalizeEmail(authorizedEmail) != normalizeEmail(c.Email) {
-		return fmt.Errorf("authorized as %s, expected %s", authorizedEmail, c.Email)
-	}
-
-	if err := store.SetToken(client, authorizedEmail, secrets.Token{
-		Client:       client,
-		Email:        authorizedEmail,
-		Services:     serviceNames,
-		Scopes:       scopes,
-		RefreshToken: refreshToken,
-	}); err != nil {
-		return err
-	}
-	if override != "" {
-		cfg, err := config.ReadConfig()
-		if err != nil {
-			return err
-		}
-		if err := config.SetAccountClient(&cfg, authorizedEmail, client); err != nil {
-			return err
-		}
-		if err := config.WriteConfig(cfg); err != nil {
-			return err
-		}
 	}
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
 			"stored":   true,
-			"email":    authorizedEmail,
-			"services": serviceNames,
-			"client":   client,
+			"email":    result.Email,
+			"services": result.Services,
+			"client":   result.Client,
 		}))
 	}
-	u.Out().Printf("email\t%s", authorizedEmail)
-	u.Out().Printf("services\t%s", strings.Join(serviceNames, ","))
-	u.Out().Printf("client\t%s", client)
+	u.Out().Printf("email\t%s", result.Email)
+	u.Out().Printf("services\t%s", strings.Join(result.Services, ","))
+	u.Out().Printf("client\t%s", result.Client)
 	return nil
 }
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -98,13 +98,17 @@ func (c *AuthCredentialsSetCmd) Run(ctx context.Context) error {
 	}
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(map[string]any{
-			"saved":  true,
-			"path":   result.Path,
-			"client": result.Client,
+			"saved":    true,
+			"path":     result.Path,
+			"client":   result.Client,
+			"replaced": result.Replaced,
 		}))
 	}
 	u.Out().Printf("path\t%s", result.Path)
 	u.Out().Printf("client\t%s", result.Client)
+	if result.Replaced {
+		u.Err().Println("WARNING: credentials replaced; existing authorizations for this client must be renewed before guided setup can complete")
+	}
 	return nil
 }
 

--- a/internal/cmd/auth_ops.go
+++ b/internal/cmd/auth_ops.go
@@ -18,8 +18,9 @@ import (
 )
 
 var (
-	errNoServicesSelected = errors.New("no services selected")
-	errAuthorizedEmail    = errors.New("authorized email mismatch")
+	errNoServicesSelected  = errors.New("no services selected")
+	errAuthorizedEmail     = errors.New("authorized email mismatch")
+	writeClientCredentials = config.WriteClientCredentialsFor
 )
 
 const (
@@ -62,10 +63,9 @@ type InstallCredentialsOptions struct {
 	// Confirm is called before replacing different credentials when interactive.
 	// If nil and replacement requires confirmation, the operation fails.
 	Confirm func(action string) error
-	// BeforeReplacement runs after a replacement has been confirmed but before the
-	// new credentials are stored. Setup uses it to invalidate tokens issued to the
-	// credentials being replaced.
-	BeforeReplacement func(client string) (invalidated int, err error)
+	// AfterReplacement runs only after new credentials have been durably stored.
+	// Setup uses it to invalidate tokens issued to the credentials being replaced.
+	AfterReplacement func(client string) (invalidated int, err error)
 }
 
 // InstallClientCredentials stores OAuth client credentials for a client
@@ -141,7 +141,7 @@ func InstallClientCredentials(opts InstallCredentialsOptions) (InstallCredential
 						client,
 					)
 				}
-				if confErr := opts.Confirm(fmt.Sprintf("replace OAuth credentials for client %q", client)); confErr != nil {
+				if confErr := opts.Confirm(fmt.Sprintf("replace OAuth credentials for client %q; this invalidates existing authorizations for that client", client)); confErr != nil {
 					return InstallCredentialsResult{}, confErr
 				}
 			}
@@ -153,29 +153,49 @@ func InstallClientCredentials(opts InstallCredentialsOptions) (InstallCredential
 	}
 
 	invalidatedTokens := 0
-	if replaced && opts.BeforeReplacement != nil {
-		invalidatedTokens, err = opts.BeforeReplacement(client)
-		if err != nil {
-			return InstallCredentialsResult{}, fmt.Errorf("invalidate tokens for replaced credentials: %w", err)
+	if replaced {
+		// Persist the guard before replacing credentials. If either the replacement
+		// or subsequent invalidation fails, surviving tokens cannot complete setup.
+		cfg, cfgErr := config.ReadConfig()
+		if cfgErr != nil {
+			return InstallCredentialsResult{}, cfgErr
+		}
+		guardErr := config.SetClientSetupReauthorizationRequired(&cfg, client, true)
+		if guardErr != nil {
+			return InstallCredentialsResult{}, guardErr
+		}
+		// A standalone overwrite also loses any prior project association.
+		if !opts.RequireInstalledClient {
+			associationErr := config.SetClientSetupCredentialsProjectAssociated(&cfg, client, false)
+			if associationErr != nil {
+				return InstallCredentialsResult{}, associationErr
+			}
+		}
+		writeConfigErr := config.WriteConfig(cfg)
+		if writeConfigErr != nil {
+			return InstallCredentialsResult{}, writeConfigErr
 		}
 	}
 	if !identical {
-		if err := config.WriteClientCredentialsFor(client, creds); err != nil {
+		credentialsErr := writeClientCredentials(client, creds)
+		if credentialsErr != nil {
+			return InstallCredentialsResult{}, credentialsErr
+		}
+	}
+	if replaced && opts.AfterReplacement != nil {
+		invalidatedTokens, err = opts.AfterReplacement(client)
+		if err != nil {
+			return InstallCredentialsResult{}, fmt.Errorf("credentials replaced but token invalidation incomplete; reauthorization remains required: %w", err)
+		}
+		cfg, cfgErr := config.ReadConfig()
+		if cfgErr != nil {
+			return InstallCredentialsResult{}, cfgErr
+		}
+		if err := config.SetClientSetupReauthorizationRequired(&cfg, client, false); err != nil {
 			return InstallCredentialsResult{}, err
 		}
-		// A standalone overwrite does not prove its project association remains
-		// valid. Guided setup will require confirmation again when needed.
-		if !opts.RequireInstalledClient {
-			cfg, cfgErr := config.ReadConfig()
-			if cfgErr != nil {
-				return InstallCredentialsResult{}, cfgErr
-			}
-			if err := config.SetClientSetupCredentialsProjectAssociated(&cfg, client, false); err != nil {
-				return InstallCredentialsResult{}, err
-			}
-			if err := config.WriteConfig(cfg); err != nil {
-				return InstallCredentialsResult{}, err
-			}
+		if err := config.WriteConfig(cfg); err != nil {
+			return InstallCredentialsResult{}, err
 		}
 	}
 
@@ -334,6 +354,17 @@ func AuthorizeAndStoreAccount(ctx context.Context, opts AuthorizeAccountOptions)
 		Scopes:       scopes,
 		RefreshToken: refreshToken,
 	}); err != nil {
+		return AuthorizeAccountResult{}, err
+	}
+	// A successful authorization proves the replacement credentials are usable.
+	cfg, cfgErr := config.ReadConfig()
+	if cfgErr != nil {
+		return AuthorizeAccountResult{}, cfgErr
+	}
+	if err := config.SetClientSetupReauthorizationRequired(&cfg, client, false); err != nil {
+		return AuthorizeAccountResult{}, err
+	}
+	if err := config.WriteConfig(cfg); err != nil {
 		return AuthorizeAccountResult{}, err
 	}
 	if strings.TrimSpace(override) != "" && !opts.SuppressClientMapping {

--- a/internal/cmd/auth_ops.go
+++ b/internal/cmd/auth_ops.go
@@ -49,6 +49,11 @@ type InstallCredentialsOptions struct {
 	Domains string
 	// ExpectedProjectID, when set, rejects credentials whose project_id differs.
 	ExpectedProjectID string
+	// RequireInstalledClient rejects Web OAuth clients for guided setup.
+	RequireInstalledClient bool
+	// RequireProjectIDConfirmation requires an explicit confirmation or --force
+	// before accepting credentials that omit project_id.
+	RequireProjectIDConfirmation bool
 	// RequireForceToReplace requires Force when replacing non-identical credentials.
 	RequireForceToReplace bool
 	// Force allows replacing different credentials when RequireForceToReplace is set.
@@ -88,9 +93,21 @@ func InstallClientCredentials(opts InstallCredentialsOptions) (InstallCredential
 		return InstallCredentialsResult{}, usage("credentials path required")
 	}
 
-	creds, err := config.ParseGoogleOAuthClientJSON(b)
+	parseCredentials := config.ParseGoogleOAuthClientJSON
+	if opts.RequireInstalledClient {
+		parseCredentials = config.ParseGoogleInstalledOAuthClientJSON
+	}
+	creds, err := parseCredentials(b)
 	if err != nil {
 		return InstallCredentialsResult{}, err
+	}
+	if opts.ExpectedProjectID != "" && creds.ProjectID == "" && opts.RequireProjectIDConfirmation && !opts.Force {
+		if opts.Confirm == nil {
+			return InstallCredentialsResult{}, usage("credentials omit project_id; re-run with --force or confirm interactively")
+		}
+		if confirmErr := opts.Confirm(fmt.Sprintf("associate OAuth credentials without project_id with project %q", opts.ExpectedProjectID)); confirmErr != nil {
+			return InstallCredentialsResult{}, confirmErr
+		}
 	}
 
 	if opts.ExpectedProjectID != "" && creds.ProjectID != "" &&

--- a/internal/cmd/auth_ops.go
+++ b/internal/cmd/auth_ops.go
@@ -189,7 +189,10 @@ type AuthorizeAccountOptions struct {
 	ReplaceScopes bool
 	Readonly      bool
 	DriveScope    string
-	GmailScope    string
+	// SuppressClientMapping preserves an existing account/domain client mapping.
+	// Setup uses this when no explicit --client was supplied.
+	SuppressClientMapping bool
+	GmailScope            string
 }
 
 // AuthorizeAccountResult is returned after a successful token store.
@@ -306,7 +309,7 @@ func AuthorizeAndStoreAccount(ctx context.Context, opts AuthorizeAccountOptions)
 	}); err != nil {
 		return AuthorizeAccountResult{}, err
 	}
-	if strings.TrimSpace(override) != "" {
+	if strings.TrimSpace(override) != "" && !opts.SuppressClientMapping {
 		cfg, cfgErr := config.ReadConfig()
 		if cfgErr != nil {
 			return AuthorizeAccountResult{}, cfgErr

--- a/internal/cmd/auth_ops.go
+++ b/internal/cmd/auth_ops.go
@@ -151,6 +151,20 @@ func InstallClientCredentials(opts InstallCredentialsOptions) (InstallCredential
 		if err := config.WriteClientCredentialsFor(client, creds); err != nil {
 			return InstallCredentialsResult{}, err
 		}
+		// A standalone overwrite does not prove its project association remains
+		// valid. Guided setup will require confirmation again when needed.
+		if !opts.RequireInstalledClient {
+			cfg, cfgErr := config.ReadConfig()
+			if cfgErr != nil {
+				return InstallCredentialsResult{}, cfgErr
+			}
+			if err := config.SetClientSetupCredentialsProjectAssociated(&cfg, client, false); err != nil {
+				return InstallCredentialsResult{}, err
+			}
+			if err := config.WriteConfig(cfg); err != nil {
+				return InstallCredentialsResult{}, err
+			}
+		}
 	}
 
 	outPath, _ := config.ClientCredentialsPathFor(client)

--- a/internal/cmd/auth_ops.go
+++ b/internal/cmd/auth_ops.go
@@ -1,0 +1,312 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/99designs/keyring"
+
+	"github.com/steipete/gogcli/internal/authclient"
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/steipete/gogcli/internal/secrets"
+)
+
+var (
+	errNoServicesSelected = errors.New("no services selected")
+	errAuthorizedEmail    = errors.New("authorized email mismatch")
+)
+
+const (
+	authServicesDefault = "user"
+	authScopeFull       = "full"
+)
+
+// InstallCredentialsResult is the outcome of storing OAuth client credentials.
+type InstallCredentialsResult struct {
+	Saved     bool
+	Path      string
+	Client    string
+	Replaced  bool
+	Identical bool
+	ProjectID string
+}
+
+// InstallCredentialsOptions controls credential installation.
+type InstallCredentialsOptions struct {
+	// Client is the normalized client namespace.
+	Client string
+	// Path is a file path, or "-" for stdin.
+	Path string
+	// Raw overrides Path when non-nil (for tests / in-memory JSON).
+	Raw []byte
+	// Domains optionally maps domains to this client.
+	Domains string
+	// ExpectedProjectID, when set, rejects credentials whose project_id differs.
+	ExpectedProjectID string
+	// RequireForceToReplace requires Force when replacing non-identical credentials.
+	RequireForceToReplace bool
+	// Force allows replacing different credentials when RequireForceToReplace is set.
+	Force bool
+	// Confirm is called before replacing different credentials when interactive.
+	// If nil and replacement requires confirmation, the operation fails.
+	Confirm func(action string) error
+}
+
+// InstallClientCredentials stores OAuth client credentials for a client
+// namespace. Standalone `auth credentials` and `auth setup` both use this.
+func InstallClientCredentials(opts InstallCredentialsOptions) (InstallCredentialsResult, error) {
+	client, err := config.NormalizeClientNameOrDefault(opts.Client)
+	if err != nil {
+		return InstallCredentialsResult{}, err
+	}
+
+	var b []byte
+	switch {
+	case opts.Raw != nil:
+		b = opts.Raw
+	case strings.TrimSpace(opts.Path) == "-":
+		b, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return InstallCredentialsResult{}, err
+		}
+	case strings.TrimSpace(opts.Path) != "":
+		inPath, expandErr := config.ExpandPath(opts.Path)
+		if expandErr != nil {
+			return InstallCredentialsResult{}, expandErr
+		}
+		b, err = os.ReadFile(inPath) //nolint:gosec // user-provided path
+		if err != nil {
+			return InstallCredentialsResult{}, err
+		}
+	default:
+		return InstallCredentialsResult{}, usage("credentials path required")
+	}
+
+	creds, err := config.ParseGoogleOAuthClientJSON(b)
+	if err != nil {
+		return InstallCredentialsResult{}, err
+	}
+
+	if opts.ExpectedProjectID != "" && creds.ProjectID != "" &&
+		creds.ProjectID != opts.ExpectedProjectID {
+		return InstallCredentialsResult{}, usagef(
+			"credentials project_id %q does not match selected project %q",
+			creds.ProjectID, opts.ExpectedProjectID,
+		)
+	}
+
+	exists, err := config.ClientCredentialsExists(client)
+	if err != nil {
+		return InstallCredentialsResult{}, err
+	}
+	var replaced, identical bool
+	if exists {
+		existing, readErr := config.ReadClientCredentialsFor(client)
+		switch {
+		case readErr == nil && config.SameClientCredentials(existing, creds):
+			identical = true
+		case opts.RequireForceToReplace:
+			if !opts.Force {
+				if opts.Confirm == nil {
+					return InstallCredentialsResult{}, usagef(
+						"refusing to replace credentials for client %q without --force",
+						client,
+					)
+				}
+				if confErr := opts.Confirm(fmt.Sprintf("replace OAuth credentials for client %q", client)); confErr != nil {
+					return InstallCredentialsResult{}, confErr
+				}
+			}
+			replaced = true
+		default:
+			// Standalone auth credentials always overwrites (historical behavior).
+			replaced = true
+		}
+	}
+
+	if !identical {
+		if err := config.WriteClientCredentialsFor(client, creds); err != nil {
+			return InstallCredentialsResult{}, err
+		}
+	}
+
+	outPath, _ := config.ClientCredentialsPathFor(client)
+	if strings.TrimSpace(opts.Domains) != "" {
+		cfg, cfgErr := config.ReadConfig()
+		if cfgErr != nil {
+			return InstallCredentialsResult{}, cfgErr
+		}
+		for _, domain := range splitCommaList(opts.Domains) {
+			if err := config.SetClientDomain(&cfg, domain, client); err != nil {
+				return InstallCredentialsResult{}, err
+			}
+		}
+		if err := config.WriteConfig(cfg); err != nil {
+			return InstallCredentialsResult{}, err
+		}
+	}
+
+	return InstallCredentialsResult{
+		Saved:     true,
+		Path:      outPath,
+		Client:    client,
+		Replaced:  replaced,
+		Identical: identical,
+		ProjectID: creds.ProjectID,
+	}, nil
+}
+
+// AuthorizeAccountOptions controls first-account (or re-auth) OAuth storage.
+type AuthorizeAccountOptions struct {
+	Email         string
+	Client        string
+	ServicesCSV   string
+	Manual        bool
+	ForceConsent  bool
+	ReplaceScopes bool
+	Readonly      bool
+	DriveScope    string
+	GmailScope    string
+}
+
+// AuthorizeAccountResult is returned after a successful token store.
+type AuthorizeAccountResult struct {
+	Stored   bool
+	Email    string
+	Services []string
+	Client   string
+	Scopes   []string
+}
+
+// AuthorizeAndStoreAccount runs keychain preflight, scope calculation/merging,
+// OAuth, email verification, token storage, and optional named-client mapping.
+func AuthorizeAndStoreAccount(ctx context.Context, opts AuthorizeAccountOptions) (AuthorizeAccountResult, error) {
+	email := strings.TrimSpace(opts.Email)
+	if email == "" {
+		return AuthorizeAccountResult{}, usage("empty email")
+	}
+
+	override := opts.Client
+	if strings.TrimSpace(override) == "" {
+		override = authclient.ClientOverrideFromContext(ctx)
+	}
+	client, err := authclient.ResolveClientWithOverride(email, override)
+	if err != nil {
+		return AuthorizeAccountResult{}, err
+	}
+
+	servicesCSV := opts.ServicesCSV
+	if strings.TrimSpace(servicesCSV) == "" {
+		servicesCSV = authServicesDefault
+	}
+	services, err := parseAuthServices(servicesCSV)
+	if err != nil {
+		return AuthorizeAccountResult{}, err
+	}
+	if len(services) == 0 {
+		return AuthorizeAccountResult{}, errNoServicesSelected
+	}
+
+	driveScope := strings.ToLower(strings.TrimSpace(opts.DriveScope))
+	if driveScope == "" {
+		driveScope = authScopeFull
+	}
+	gmailScope := strings.ToLower(strings.TrimSpace(opts.GmailScope))
+	if gmailScope == "" {
+		gmailScope = authScopeFull
+	}
+	if opts.Readonly && driveScope == strFile {
+		return AuthorizeAccountResult{}, usage("cannot combine --readonly with --drive-scope=file (file is write-capable)")
+	}
+
+	scopes, err := googleauth.ScopesForManageWithOptions(services, googleauth.ScopeOptions{
+		Readonly:   opts.Readonly,
+		DriveScope: googleauth.DriveScopeMode(driveScope),
+		GmailScope: googleauth.GmailScopeMode(gmailScope),
+	})
+	if err != nil {
+		return AuthorizeAccountResult{}, err
+	}
+
+	if keychainErr := ensureKeychainAccessIfNeeded(); keychainErr != nil {
+		return AuthorizeAccountResult{}, fmt.Errorf("keychain access: %w", keychainErr)
+	}
+	store, err := openSecretsStore()
+	if err != nil {
+		return AuthorizeAccountResult{}, err
+	}
+
+	existing, existingErr := store.GetToken(client, email)
+	hasExisting := existingErr == nil
+	if existingErr != nil && !errors.Is(existingErr, keyring.ErrKeyNotFound) {
+		return AuthorizeAccountResult{}, fmt.Errorf("read existing token: %w", existingErr)
+	}
+
+	if hasExisting && !opts.ReplaceScopes {
+		services, scopes = googleauth.MergeAuthGrant(services, scopes, existing.Services, existing.Scopes)
+	}
+
+	serviceNames := authServiceNames(services)
+	forceConsent := opts.ForceConsent || opts.ReplaceScopes
+	disableIncludeGrantedScopes := forceConsent ||
+		opts.Readonly ||
+		driveScope == "readonly" ||
+		driveScope == strFile ||
+		gmailScope == "readonly"
+
+	refreshToken, err := authorizeGoogle(ctx, googleauth.AuthorizeOptions{
+		Services:                    services,
+		Scopes:                      scopes,
+		Manual:                      opts.Manual,
+		ForceConsent:                forceConsent,
+		DisableIncludeGrantedScopes: disableIncludeGrantedScopes,
+		Client:                      client,
+	})
+	if err != nil {
+		return AuthorizeAccountResult{}, err
+	}
+
+	authorizedEmail, err := fetchAuthorizedEmail(ctx, client, refreshToken, scopes, 15*time.Second)
+	if err != nil {
+		return AuthorizeAccountResult{}, fmt.Errorf("fetch authorized email: %w", err)
+	}
+	if normalizeEmail(authorizedEmail) != normalizeEmail(email) {
+		return AuthorizeAccountResult{}, fmt.Errorf("%w: authorized as %s, expected %s", errAuthorizedEmail, authorizedEmail, email)
+	}
+
+	if err := store.SetToken(client, authorizedEmail, secrets.Token{
+		Client:       client,
+		Email:        authorizedEmail,
+		Services:     serviceNames,
+		Scopes:       scopes,
+		RefreshToken: refreshToken,
+	}); err != nil {
+		return AuthorizeAccountResult{}, err
+	}
+	if strings.TrimSpace(override) != "" {
+		cfg, cfgErr := config.ReadConfig()
+		if cfgErr != nil {
+			return AuthorizeAccountResult{}, cfgErr
+		}
+		if err := config.SetAccountClient(&cfg, authorizedEmail, client); err != nil {
+			return AuthorizeAccountResult{}, err
+		}
+		if err := config.WriteConfig(cfg); err != nil {
+			return AuthorizeAccountResult{}, err
+		}
+	}
+
+	return AuthorizeAccountResult{
+		Stored:   true,
+		Email:    authorizedEmail,
+		Services: serviceNames,
+		Client:   client,
+		Scopes:   scopes,
+	}, nil
+}

--- a/internal/cmd/auth_ops.go
+++ b/internal/cmd/auth_ops.go
@@ -29,12 +29,13 @@ const (
 
 // InstallCredentialsResult is the outcome of storing OAuth client credentials.
 type InstallCredentialsResult struct {
-	Saved     bool
-	Path      string
-	Client    string
-	Replaced  bool
-	Identical bool
-	ProjectID string
+	Saved             bool
+	Path              string
+	Client            string
+	Replaced          bool
+	Identical         bool
+	ProjectID         string
+	InvalidatedTokens int
 }
 
 // InstallCredentialsOptions controls credential installation.
@@ -61,6 +62,10 @@ type InstallCredentialsOptions struct {
 	// Confirm is called before replacing different credentials when interactive.
 	// If nil and replacement requires confirmation, the operation fails.
 	Confirm func(action string) error
+	// BeforeReplacement runs after a replacement has been confirmed but before the
+	// new credentials are stored. Setup uses it to invalidate tokens issued to the
+	// credentials being replaced.
+	BeforeReplacement func(client string) (invalidated int, err error)
 }
 
 // InstallClientCredentials stores OAuth client credentials for a client
@@ -147,6 +152,13 @@ func InstallClientCredentials(opts InstallCredentialsOptions) (InstallCredential
 		}
 	}
 
+	invalidatedTokens := 0
+	if replaced && opts.BeforeReplacement != nil {
+		invalidatedTokens, err = opts.BeforeReplacement(client)
+		if err != nil {
+			return InstallCredentialsResult{}, fmt.Errorf("invalidate tokens for replaced credentials: %w", err)
+		}
+	}
 	if !identical {
 		if err := config.WriteClientCredentialsFor(client, creds); err != nil {
 			return InstallCredentialsResult{}, err
@@ -184,12 +196,13 @@ func InstallClientCredentials(opts InstallCredentialsOptions) (InstallCredential
 	}
 
 	return InstallCredentialsResult{
-		Saved:     true,
-		Path:      outPath,
-		Client:    client,
-		Replaced:  replaced,
-		Identical: identical,
-		ProjectID: creds.ProjectID,
+		Saved:             true,
+		Path:              outPath,
+		Client:            client,
+		Replaced:          replaced,
+		Identical:         identical,
+		ProjectID:         creds.ProjectID,
+		InvalidatedTokens: invalidatedTokens,
 	}, nil
 }
 

--- a/internal/cmd/auth_replacement_integrity_test.go
+++ b/internal/cmd/auth_replacement_integrity_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/99designs/keyring"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/secrets"
+)
+
+type replacementFailingStore struct{ secrets.Store }
+
+func (replacementFailingStore) DeleteToken(string, string) error {
+	return errors.New("injected delete failure")
+}
+
+func TestInstallCredentials_WriteFailurePreservesTokens(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	if err := config.WriteClientCredentialsFor("work", config.ClientCredentials{ClientID: "old", ClientSecret: "secret"}); err != nil {
+		t.Fatal(err)
+	}
+	store := newMemSecretsStore()
+	if err := store.SetToken("work", "person@example.com", secrets.Token{RefreshToken: "token"}); err != nil {
+		t.Fatal(err)
+	}
+	origWrite := writeClientCredentials
+	writeClientCredentials = func(string, config.ClientCredentials) error { return errors.New("injected write failure") }
+	t.Cleanup(func() { writeClientCredentials = origWrite })
+	called := false
+	_, err := InstallClientCredentials(InstallCredentialsOptions{
+		Client: "work", Raw: []byte(`{"installed":{"client_id":"new","client_secret":"secret"}}`),
+		AfterReplacement: func(string) (int, error) { called = true; return 0, nil },
+	})
+	if err == nil {
+		t.Fatal("replacement unexpectedly succeeded")
+	}
+	if called {
+		t.Fatal("tokens invalidated before credential write")
+	}
+	if _, tokenErr := store.GetToken("work", "person@example.com"); tokenErr != nil {
+		t.Fatalf("token was not preserved: %v", tokenErr)
+	}
+	cfg, err := config.ReadConfig()
+	if err != nil || !config.GetClientSetup(cfg, "work").ReauthorizationRequired {
+		t.Fatalf("reauthorization guard missing after failed replacement: %#v err=%v", cfg, err)
+	}
+}
+
+func TestAuthSetup_ReplacementInvalidationFailureBlocksStaleToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	if err := config.WriteClientCredentialsFor("work", config.ClientCredentials{ClientID: "old", ClientSecret: "secret", ProjectID: "demo", ClientType: config.OAuthClientTypeInstalled}); err != nil {
+		t.Fatal(err)
+	}
+	store := newMemSecretsStore()
+	services := parseSetupServices(t, "gmail")
+	if err := store.SetToken("work", "person@example.com", secrets.Token{Services: authServiceNames(services), Scopes: accountScopes(services), RefreshToken: "token"}); err != nil {
+		t.Fatal(err)
+	}
+	origOpen, origOpenNoInput := authSetupOpen, authSetupOpenNoInput
+	authSetupOpen = func() (secrets.Store, error) { return store, nil }
+	authSetupOpenNoInput = authSetupOpen
+	t.Cleanup(func() { authSetupOpen, authSetupOpenNoInput = origOpen, origOpenNoInput })
+	path := filepath.Join(t.TempDir(), "new.json")
+	if err := os.WriteFile(path, []byte(`{"installed":{"client_id":"new","client_secret":"secret","project_id":"demo"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	failingStore := &replacementFailingStore{Store: store}
+	origOpen, origOpenNoInput = authSetupOpen, authSetupOpenNoInput
+	authSetupOpen = func() (secrets.Store, error) { return failingStore, nil }
+	authSetupOpenNoInput = authSetupOpen
+	t.Cleanup(func() { authSetupOpen, authSetupOpenNoInput = origOpen, origOpenNoInput })
+	rt := &setupRuntime{cmd: &AuthSetupCmd{CredentialsPath: path, AccountEmail: "person@example.com"}, flags: &RootFlags{Force: true, NoInput: true}, u: mustSetupUI(t), client: "work", force: true, services: services, report: SetupReport{ProjectID: "demo"}}
+	if stop, err := rt.installCredentials(context.Background(), "demo"); !stop || err != nil {
+		t.Fatalf("replacement failure stop=%t err=%v", stop, err)
+	}
+	if _, err := store.GetToken("work", "person@example.com"); err != nil {
+		t.Fatalf("stale token should remain when invalidation fails: %v", err)
+	}
+	cfg, err := config.ReadConfig()
+	if err != nil || !config.GetClientSetup(cfg, "work").ReauthorizationRequired {
+		t.Fatalf("reauthorization guard missing: %#v err=%v", cfg, err)
+	}
+	rt.setupRec = config.GetClientSetup(cfg, "work")
+	if stop, err := rt.runAccount(context.Background()); stop || err != nil {
+		t.Fatalf("guarded account stage stop=%t err=%v", stop, err)
+	}
+	if got := rt.report.Stages[len(rt.report.Stages)-1].Status; got != stageStatusManual {
+		t.Fatalf("stale token satisfied setup, stage=%s", got)
+	}
+}
+
+func TestStandaloneReplacementRequiresSetupReauthorization(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	if err := config.WriteClientCredentialsFor("work", config.ClientCredentials{ClientID: "old", ClientSecret: "secret", ProjectID: "demo", ClientType: config.OAuthClientTypeInstalled}); err != nil {
+		t.Fatal(err)
+	}
+	services := parseSetupServices(t, "gmail")
+	store := newMemSecretsStore()
+	if err := store.SetToken("work", "person@example.com", secrets.Token{Services: authServiceNames(services), Scopes: accountScopes(services), RefreshToken: "token"}); err != nil {
+		t.Fatal(err)
+	}
+	origOpen, origOpenNoInput := authSetupOpen, authSetupOpenNoInput
+	authSetupOpen = func() (secrets.Store, error) { return store, nil }
+	authSetupOpenNoInput = authSetupOpen
+	t.Cleanup(func() { authSetupOpen, authSetupOpenNoInput = origOpen, origOpenNoInput })
+	if _, err := InstallClientCredentials(InstallCredentialsOptions{Client: "work", Raw: []byte(`{"installed":{"client_id":"new","client_secret":"secret","project_id":"demo"}}`)}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ReadConfig()
+	if err != nil || !config.GetClientSetup(cfg, "work").ReauthorizationRequired {
+		t.Fatalf("standalone replacement did not require reauthorization: %#v err=%v", cfg, err)
+	}
+	rt := &setupRuntime{cmd: &AuthSetupCmd{AccountEmail: "person@example.com"}, flags: &RootFlags{NoInput: true}, u: mustSetupUI(t), client: "work", services: services, setupRec: config.GetClientSetup(cfg, "work"), report: SetupReport{ProjectID: "demo"}}
+	if stop, err := rt.runAccount(context.Background()); stop || err != nil {
+		t.Fatalf("guarded account stage stop=%t err=%v", stop, err)
+	}
+	if got := rt.report.Stages[0].Status; got != stageStatusManual {
+		t.Fatalf("stale standalone token satisfied setup, stage=%s", got)
+	}
+	if _, err := store.GetToken("work", "person@example.com"); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatal(err)
+	}
+}

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -16,14 +16,16 @@ import (
 	"github.com/steipete/gogcli/internal/googleauth"
 	"github.com/steipete/gogcli/internal/input"
 	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/secrets"
 	"github.com/steipete/gogcli/internal/ui"
 )
 
 // Injectable seams for tests.
 var (
-	newGCloudClient = func() *gcloud.Client { return gcloud.New(nil) }
-	authSetupOpen   = openSecretsStore
-	setupPromptLine = input.PromptLine
+	newGCloudClient      = func() *gcloud.Client { return gcloud.New(nil) }
+	authSetupOpen        = openSecretsStore
+	authSetupOpenNoInput = secrets.OpenDefaultNoInput
+	setupPromptLine      = input.PromptLine
 )
 
 var errAuthSetupIncomplete = errors.New("auth setup incomplete")
@@ -148,9 +150,11 @@ func (c *AuthSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	runners := []func(context.Context) (bool, error){
-		rt.runGCloudInstall, rt.runGCloudAuth, rt.runProject, rt.runAPIs,
-		rt.runManualStages, rt.runCredentials, rt.runAccount,
+	runners := []func(context.Context) (bool, error){rt.runGCloudInstall, rt.runGCloudAuth, rt.runProject, rt.runAPIs}
+	// Discovery is deliberately limited to Cloud inspection. In particular, it
+	// must not open the local secrets store or inspect/migrate token material.
+	if !rt.discover {
+		runners = append(runners, rt.runManualStages, rt.runCredentials, rt.runAccount)
 	}
 	for _, run := range runners {
 		if stop, runErr := run(ctx); stop {
@@ -255,6 +259,9 @@ func (c *AuthSetupCmd) validateNonInteractive(interactive, force, discover bool)
 	}
 	if c.EnableAPIs && !force && !discover {
 		return usage("--enable-apis requires --force in non-interactive mode")
+	}
+	if c.CredentialsPath == "-" && !interactive && term.IsTerminal(int(os.Stdin.Fd())) {
+		return usage("--credentials - requires redirected stdin under --no-input")
 	}
 
 	return nil
@@ -420,28 +427,27 @@ func (rt *setupRuntime) handleMissingGCloudAccount(ctx context.Context) (stop bo
 }
 
 func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
-	// Request one extra item so truncation means an item was actually omitted.
-	projects, listRes, listErr := rt.gc.ListProjects(ctx, rt.cmd.ProjectLimit+1)
-	if listErr != nil {
-		status, resumable := gcloudFailureStage(listRes.Kind)
-		rt.appendStage(SetupStage{
-			ID: stageProject, Status: status, ActionKind: actionCommand,
-			Summary: "failed to list projects", Blocker: listErr.Error(), Resumable: resumable,
-			Command: rt.continueCmd(rt.report.ProjectID),
-		})
-		return stopSetup()
-	}
-
-	truncated := len(projects) > rt.cmd.ProjectLimit
-	if truncated {
-		projects = projects[:rt.cmd.ProjectLimit]
-	}
-	if rt.discover {
-		rt.report.Projects = projects
-		rt.report.ProjectsTruncated = truncated
-	}
 	projectID := rt.report.ProjectID
-	if rt.cmd.CreateProject && !rt.discover && !containsProject(projects, rt.cmd.Project) {
+	needList := rt.discover || projectID == "" && rt.interactive && !rt.discover
+	var projects []gcloud.Project
+	if needList {
+		// Request one extra item so truncation means an item was actually omitted.
+		listed, listRes, listErr := rt.gc.ListProjects(ctx, rt.cmd.ProjectLimit+1)
+		if listErr != nil {
+			status, resumable := gcloudFailureStage(listRes.Kind)
+			rt.appendStage(SetupStage{ID: stageProject, Status: status, ActionKind: actionCommand, Summary: "failed to list projects", Blocker: listErr.Error(), Resumable: resumable, Command: rt.continueCmd(projectID)})
+			return stopSetup()
+		}
+		projects = filterActiveProjects(listed)
+		truncated := len(projects) > rt.cmd.ProjectLimit
+		if truncated {
+			projects = projects[:rt.cmd.ProjectLimit]
+		}
+		if rt.discover {
+			rt.report.Projects, rt.report.ProjectsTruncated = projects, truncated
+		}
+	}
+	if rt.cmd.CreateProject && !rt.discover {
 		createdID, created, createErr := rt.createProject(ctx)
 		if createErr != nil {
 			return true, createErr
@@ -449,15 +455,9 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 		if !created {
 			return stopSetup()
 		}
-
 		projectID = createdID
-		rt.report.ProjectID = projectID
 	}
-
 	if projectID == "" && rt.interactive && !rt.discover {
-		if len(projects) >= rt.cmd.ProjectLimit {
-			rt.u.Err().Printf("Project list may be truncated at %d; pass --project <id> to select another project.\n", rt.cmd.ProjectLimit)
-		}
 		picked, create, pickErr := rt.pickProjectInteractive(ctx, projects)
 		if pickErr != nil {
 			return true, pickErr
@@ -475,51 +475,33 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 			if pickErr != nil {
 				return true, pickErr
 			}
-		}
-		if picked != "" {
+		} else {
 			projectID = picked
 		}
-		rt.report.ProjectID = projectID
 	}
-
 	if projectID == "" {
 		active, _, _ := rt.gc.ActiveProjectID(ctx)
 		detail := ""
 		if active != "" {
 			detail = "gcloud active project (not modified): " + active
 		}
-
-		rt.appendStage(SetupStage{
-			ID:         stageProject,
-			Status:     stageStatusMissing,
-			ActionKind: actionCommand,
-			Summary:    "no project selected",
-			Blocker:    "pass --project <id> or run interactively",
-			Resumable:  true,
-			Detail:     detail,
-			Command:    rt.continueCmd(""),
-			NextAction: "Re-run with --project <id>",
-		})
-
+		rt.appendStage(SetupStage{ID: stageProject, Status: stageStatusMissing, ActionKind: actionCommand, Summary: "no project selected", Blocker: "pass --project <id> or run interactively", Resumable: true, Detail: detail, Command: rt.continueCmd(""), NextAction: "Re-run with --project <id>"})
 		return stopSetup()
 	}
-
-	// An explicit or persisted target must be live-validated before it can be
-	// accepted or persisted; the project list can be truncated or stale.
+	// Explicit or persisted targets are validated directly; projects list permission is not required.
 	if !rt.cmd.CreateProject {
 		described, describeRes, describeErr := rt.gc.DescribeProject(ctx, projectID)
 		if describeErr != nil {
 			status, resumable := gcloudFailureStage(describeRes.Kind)
-			rt.appendStage(SetupStage{
-				ID: stageProject, Status: status, ActionKind: actionCommand,
-				Summary: "failed to validate selected project", Blocker: describeErr.Error(),
-				Resumable: resumable, Command: rt.continueCmd(projectID),
-			})
+			rt.appendStage(SetupStage{ID: stageProject, Status: status, ActionKind: actionCommand, Summary: "failed to validate selected project", Blocker: describeErr.Error(), Resumable: resumable, Command: rt.continueCmd(projectID)})
+			return stopSetup()
+		}
+		if described.LifecycleState != "" && !strings.EqualFold(described.LifecycleState, "ACTIVE") {
+			rt.appendStage(SetupStage{ID: stageProject, Status: stageStatusBlocked, ActionKind: actionCommand, Summary: "selected project is not ACTIVE", Blocker: "select an ACTIVE Google Cloud project", Resumable: true, Command: rt.continueCmd(projectID)})
 			return stopSetup()
 		}
 		projectID = described.ProjectID
 	}
-
 	if !rt.discover {
 		if err := config.SetClientSetupProject(&rt.cfg, rt.client, projectID); err != nil {
 			return true, err
@@ -527,30 +509,21 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 		if err := config.WriteConfig(rt.cfg); err != nil {
 			return true, err
 		}
-
 		rt.setupRec = config.GetClientSetup(rt.cfg, rt.client)
 	}
-
 	rt.report.ProjectID = projectID
-	rt.appendStage(SetupStage{
-		ID:         stageProject,
-		Status:     stageStatusOK,
-		Summary:    "project " + projectID,
-		ActionKind: actionNone,
-		Detail:     projectID,
-		ConsoleURL: projectConsoleURL(projectID, ""),
-	})
-
+	rt.appendStage(SetupStage{ID: stageProject, Status: stageStatusOK, Summary: "project " + projectID, ActionKind: actionNone, Detail: projectID, ConsoleURL: projectConsoleURL(projectID, "")})
 	return false, nil
 }
 
-func containsProject(projects []gcloud.Project, projectID string) bool {
+func filterActiveProjects(projects []gcloud.Project) []gcloud.Project {
+	active := make([]gcloud.Project, 0, len(projects))
 	for _, project := range projects {
-		if project.ProjectID == projectID {
-			return true
+		if strings.EqualFold(project.LifecycleState, "ACTIVE") {
+			active = append(active, project)
 		}
 	}
-	return false
+	return active
 }
 
 func (rt *setupRuntime) createProject(ctx context.Context) (projectID string, created bool, err error) {
@@ -630,16 +603,13 @@ func (rt *setupRuntime) pickProjectInteractive(ctx context.Context, projects []g
 
 func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
 	projectID := rt.report.ProjectID
-	missing, _, _, missErr := rt.gc.MissingServices(ctx, projectID, rt.usageIDs)
+	missing, _, missRes, missErr := rt.gc.MissingServices(ctx, projectID, rt.usageIDs)
 	if missErr != nil {
+		status, resumable := gcloudFailureStage(missRes.Kind)
 		rt.appendStage(SetupStage{
-			ID:         stageAPIs,
-			Status:     stageStatusFailed,
-			ActionKind: actionCommand,
-			Summary:    "failed to inspect enabled APIs",
-			Blocker:    missErr.Error(),
-			Resumable:  false,
-			ConsoleURL: projectConsoleURL(projectID, "apis/dashboard"),
+			ID: stageAPIs, Status: status, ActionKind: actionCommand,
+			Summary: "failed to inspect enabled APIs", Blocker: missErr.Error(), Resumable: resumable,
+			ConsoleURL: projectConsoleURL(projectID, "apis/dashboard"), Command: rt.continueCmd(projectID),
 		})
 
 		return stopSetup()
@@ -654,7 +624,6 @@ func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
 		if enabledMissing == nil {
 			return stopSetup()
 		}
-
 		missing = enabledMissing
 		rt.report.MissingAPIs = missing
 	}
@@ -669,10 +638,7 @@ func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
 			Detail:     strings.Join(missing, ","),
 			Resumable:  true,
 			ConsoleURL: projectConsoleURL(projectID, "apis/library"),
-			Command: fmt.Sprintf(
-				"gog --client %s --force auth setup --project %s --enable-apis --services %s",
-				rt.client, projectID, rt.serviceCSV,
-			),
+			Command:    rt.continueCmd(projectID),
 			NextAction: "Re-run with --enable-apis --force",
 		})
 
@@ -703,10 +669,14 @@ func (rt *setupRuntime) enableMissingAPIs(ctx context.Context, projectID string,
 	if enableErr != nil {
 		// A failed batch may still have enabled some APIs. Re-inspect so the report
 		// and the next rerun name only the APIs that remain missing.
-		if currentMissing, _, _, inspectErr := rt.gc.MissingServices(ctx, projectID, missing); inspectErr == nil {
+		if currentMissing, _, _, inspectErr := rt.gc.MissingServices(ctx, projectID, rt.usageIDs); inspectErr == nil {
 			stillMissing = currentMissing
 		} else {
 			stillMissing = missing
+		}
+		rt.report.MissingAPIs = stillMissing
+		if len(stillMissing) == 0 {
+			return []string{}, nil
 		}
 		status, resumable := gcloudFailureStage(enableRes.Kind)
 		rt.appendStage(SetupStage{
@@ -720,10 +690,10 @@ func (rt *setupRuntime) enableMissingAPIs(ctx context.Context, projectID string,
 			ConsoleURL: projectConsoleURL(projectID, "apis/library"),
 			Command:    rt.continueCmd(projectID),
 		})
-
 		return nil, nil
 	}
 
+	rt.report.MissingAPIs = stillMissing
 	return stillMissing, nil
 }
 
@@ -873,14 +843,21 @@ func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string
 		summary = "credentials replaced"
 	}
 
-	rt.appendStage(SetupStage{
-		ID:         stageCredentials,
-		Status:     stageStatusOK,
-		Summary:    summary,
-		ActionKind: actionNone,
-		Detail:     result.Path,
-	})
-
+	rt.appendStage(SetupStage{ID: stageCredentials, Status: stageStatusOK, Summary: summary, ActionKind: actionNone, Detail: result.Path})
+	for i := range rt.report.Stages {
+		if rt.report.Stages[i].ID == stageDesktopClient {
+			rt.report.Stages[i] = SetupStage{ID: stageDesktopClient, Status: stageStatusOK, ActionKind: actionNone, Summary: "Desktop OAuth client installed"}
+		}
+	}
+	if result.ProjectID == "" {
+		if err := config.SetClientSetupCredentialsProjectAssociated(&rt.cfg, rt.client, true); err != nil {
+			return true, err
+		}
+		if err := config.WriteConfig(rt.cfg); err != nil {
+			return true, err
+		}
+		rt.setupRec = config.GetClientSetup(rt.cfg, rt.client)
+	}
 	return false, nil
 }
 
@@ -918,22 +895,26 @@ func (rt *setupRuntime) appendCredentialsExisting(ctx context.Context, projectID
 		})
 		return false
 	}
-	if stored.ProjectID == "" && rt.priorProjectID != projectID {
+	if stored.ProjectID == "" && !rt.setupRec.CredentialsProjectAssociated {
 		if !rt.force && !rt.interactive {
-			rt.appendStage(SetupStage{
-				ID: stageCredentials, Status: stageStatusBlocked, ActionKind: actionCommand,
-				Summary:   "stored credentials have no project association",
-				Blocker:   "credentials omit project_id; re-run with --force or confirm interactively",
-				Resumable: true, Command: rt.continueCmd(projectID),
-			})
+			rt.appendStage(SetupStage{ID: stageCredentials, Status: stageStatusBlocked, ActionKind: actionCommand, Summary: "stored credentials have no project association", Blocker: "credentials omit project_id; re-run with --force or confirm interactively", Resumable: true, Command: rt.continueCmd(projectID)})
 			return false
 		}
 		if !rt.force {
 			if err := confirmDestructive(ctx, rt.flags, fmt.Sprintf("associate stored OAuth credentials without project_id with project %q", projectID)); err != nil {
-				rt.appendStage(SetupStage{ID: stageCredentials, Status: stageStatusBlocked, ActionKind: actionCommand, Summary: "stored credentials need project confirmation", Blocker: err.Error(), Resumable: true})
+				rt.appendStage(SetupStage{ID: stageCredentials, Status: stageStatusBlocked, ActionKind: actionCommand, Summary: "stored credentials need project confirmation", Blocker: err.Error(), Resumable: true, Command: rt.continueCmd(projectID)})
 				return false
 			}
 		}
+		if err := config.SetClientSetupCredentialsProjectAssociated(&rt.cfg, rt.client, true); err != nil {
+			rt.appendStage(SetupStage{ID: stageCredentials, Status: stageStatusFailed, ActionKind: actionCommand, Summary: "cannot record credential project association", Blocker: err.Error(), Command: rt.continueCmd(projectID)})
+			return false
+		}
+		if err := config.WriteConfig(rt.cfg); err != nil {
+			rt.appendStage(SetupStage{ID: stageCredentials, Status: stageStatusFailed, ActionKind: actionCommand, Summary: "cannot record credential project association", Blocker: err.Error(), Command: rt.continueCmd(projectID)})
+			return false
+		}
+		rt.setupRec = config.GetClientSetup(rt.cfg, rt.client)
 	}
 
 	rt.appendStage(SetupStage{ID: stageCredentials, Status: stageStatusOK, Summary: "credentials present", ActionKind: actionNone})
@@ -942,7 +923,12 @@ func (rt *setupRuntime) appendCredentialsExisting(ctx context.Context, projectID
 
 func (rt *setupRuntime) runAccount(ctx context.Context) (stop bool, err error) {
 	email := strings.TrimSpace(rt.cmd.AccountEmail)
-	if accountTokenSatisfies(rt.client, email, authServiceNames(rt.services), accountScopes(rt.services)) {
+	satisfies, inspectErr := rt.accountTokenSatisfies(email)
+	if inspectErr != nil {
+		rt.appendStage(SetupStage{ID: stageAccount, Status: stageStatusFailed, ActionKind: actionCommand, Summary: "cannot inspect stored account tokens", Blocker: inspectErr.Error(), Command: rt.continueCmd(rt.report.ProjectID)})
+		return stopSetup()
+	}
+	if satisfies {
 		summary := "authorized account token present for requested services"
 		if email != "" {
 			summary = "account authorized: " + email
@@ -954,7 +940,12 @@ func (rt *setupRuntime) runAccount(ctx context.Context) (stop bool, err error) {
 		return rt.authorizeAccount(ctx, email)
 	}
 
-	if accountTokenSatisfies(rt.client, "", authServiceNames(rt.services), accountScopes(rt.services)) {
+	anySatisfies, inspectErr := rt.accountTokenSatisfies("")
+	if inspectErr != nil {
+		rt.appendStage(SetupStage{ID: stageAccount, Status: stageStatusFailed, ActionKind: actionCommand, Summary: "cannot inspect stored account tokens", Blocker: inspectErr.Error(), Command: rt.continueCmd(rt.report.ProjectID)})
+		return stopSetup()
+	}
+	if anySatisfies {
 		rt.appendStage(SetupStage{
 			ID:         stageAccount,
 			Status:     stageStatusOK,
@@ -1064,6 +1055,33 @@ func accountScopes(services []googleauth.Service) []string {
 	return scopes
 }
 
+func (rt *setupRuntime) accountTokenSatisfies(email string) (bool, error) {
+	open := authSetupOpen
+	if rt.flags != nil && rt.flags.NoInput {
+		open = authSetupOpenNoInput
+	}
+	store, err := open()
+	if err != nil {
+		return false, err
+	}
+	tokens, err := store.ListTokens()
+	if err != nil {
+		return false, err
+	}
+	client, services, scopes := rt.client, authServiceNames(rt.services), accountScopes(rt.services)
+	for _, tok := range tokens {
+		sameClient := tok.Client == client || (client == config.DefaultClientName && tok.Client == "")
+		if !sameClient || strings.TrimSpace(tok.Email) == "" || (email != "" && normalizeEmail(tok.Email) != normalizeEmail(email)) {
+			continue
+		}
+		if setupContainsAll(tok.Services, services) && setupContainsAll(tok.Scopes, scopes) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// accountTokenSatisfies retains the simple inspection seam used by callers and tests.
 func accountTokenSatisfies(client, email string, services, scopes []string) bool {
 	store, err := authSetupOpen()
 	if err != nil {
@@ -1075,10 +1093,7 @@ func accountTokenSatisfies(client, email string, services, scopes []string) bool
 	}
 	for _, tok := range tokens {
 		sameClient := tok.Client == client || (client == config.DefaultClientName && tok.Client == "")
-		if !sameClient || strings.TrimSpace(tok.Email) == "" || (email != "" && normalizeEmail(tok.Email) != normalizeEmail(email)) {
-			continue
-		}
-		if setupContainsAll(tok.Services, services) && setupContainsAll(tok.Scopes, scopes) {
+		if sameClient && strings.TrimSpace(tok.Email) != "" && (email == "" || normalizeEmail(tok.Email) == normalizeEmail(email)) && setupContainsAll(tok.Services, services) && setupContainsAll(tok.Scopes, scopes) {
 			return true
 		}
 	}
@@ -1206,15 +1221,7 @@ func projectConsoleURL(projectID, path string) string {
 }
 
 func shellQuote(value string) string {
-	if value == "" {
-		return "''"
-	}
-	for _, r := range value {
-		if !(r == '-' || r == '_' || r == '.' || r == '/' || r == ':' || r == ',' || r == '@' || r == '+' || r == '=') && !(r >= 'a' && r <= 'z') && !(r >= 'A' && r <= 'Z') && !(r >= '0' && r <= '9') {
-			return "'" + strings.ReplaceAll(value, "'", "'\\\"'\\\"'") + "'"
-		}
-	}
-	return value
+	return "'" + strings.ReplaceAll(value, "'", "'\\\"'\\\"'") + "'"
 }
 
 func continueSetupCmd(client string, c *AuthSetupCmd, projectID string, force bool) string {
@@ -1387,10 +1394,19 @@ func setupComplete(r SetupReport) bool {
 // discoveryComplete reports whether all requested inspections completed, without
 // claiming that the setup prerequisites themselves are complete.
 func discoveryComplete(r SetupReport) bool {
+	byID := make(map[string]SetupStage, len(r.Stages))
 	for _, stage := range r.Stages {
-		if stage.Status == stageStatusFailed || stage.Status == stageStatusBlocked || stage.Status == stageStatusMissing && stage.ID == stageGCloudInstall {
+		byID[stage.ID] = stage
+	}
+	for _, id := range []string{stageGCloudInstall, stageGCloudAuth, stageProject} {
+		stage, ok := byID[id]
+		if !ok || stage.Status != stageStatusOK {
 			return false
 		}
+	}
+	stage, ok := byID[stageAPIs]
+	if r.ProjectID != "" && (!ok || stage.Status != stageStatusOK && stage.Status != stageStatusMissing) {
+		return false
 	}
 	return true
 }

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -836,6 +836,34 @@ func (rt *setupRuntime) runCredentials(ctx context.Context) (stop bool, err erro
 	return stopSetup()
 }
 
+func (rt *setupRuntime) invalidateClientTokens(client string) (int, error) {
+	open := authSetupOpen
+	if rt.flags != nil && rt.flags.NoInput {
+		open = authSetupOpenNoInput
+	}
+	store, err := open()
+	if err != nil {
+		return 0, err
+	}
+	tokens, err := store.ListTokens()
+	if err != nil {
+		return 0, err
+	}
+
+	invalidated := 0
+	for _, token := range tokens {
+		sameClient := token.Client == client || (client == config.DefaultClientName && token.Client == "")
+		if !sameClient {
+			continue
+		}
+		if err := store.DeleteToken(client, token.Email); err != nil {
+			return 0, err
+		}
+		invalidated++
+	}
+	return invalidated, nil
+}
+
 func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string) (stop bool, err error) {
 	confirmFn := func(action string) error {
 		return confirmDestructive(ctx, rt.flags, action)
@@ -849,6 +877,7 @@ func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string
 		RequireForceToReplace:        true,
 		Force:                        rt.force,
 		Confirm:                      confirmFn,
+		BeforeReplacement:            rt.invalidateClientTokens,
 	})
 	if instErr != nil {
 		status, resumable := credentialInstallFailure(instErr)
@@ -867,6 +896,9 @@ func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string
 		summary = "credentials already installed (identical)"
 	case result.Replaced:
 		summary = "credentials replaced"
+	}
+	if result.InvalidatedTokens > 0 {
+		summary = fmt.Sprintf("credentials replaced; %d existing account token(s) invalidated; reauthorize to complete setup", result.InvalidatedTokens)
 	}
 
 	rt.appendStage(SetupStage{ID: stageCredentials, Status: stageStatusOK, Summary: summary, ActionKind: actionNone, Detail: result.Path})

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -36,6 +36,7 @@ type AuthSetupCmd struct {
 	CreateProject bool   `name:"create-project" help:"Create a new Google Cloud project (requires --project and --force when non-interactive)"`
 	ProjectName   string `name:"project-name" help:"Display name for a new project"`
 	ProjectParent string `name:"project-parent" help:"Parent for new project: folders/ID or organizations/ID"`
+	ProjectLimit  int    `name:"project-limit" help:"Maximum projects to inspect/list" default:"100"`
 
 	// APIs / services
 	ServicesCSV string `name:"services" help:"Services to enable APIs for: user|all or comma-separated ${auth_services}" default:"user"`
@@ -100,35 +101,39 @@ type SetupStage struct {
 
 // SetupReport is the structured setup outcome.
 type SetupReport struct {
-	Complete        bool             `json:"complete"`
-	DiscoveryOnly   bool             `json:"discovery_only,omitempty"`
-	Client          string           `json:"client"`
-	ProjectID       string           `json:"project_id,omitempty"`
-	GCloudAccount   string           `json:"gcloud_account,omitempty"`
-	Services        []string         `json:"services,omitempty"`
-	ServiceUsageIDs []string         `json:"service_usage_ids,omitempty"`
-	MissingAPIs     []string         `json:"missing_apis,omitempty"`
-	Projects        []gcloud.Project `json:"projects,omitempty"`
-	Stages          []SetupStage     `json:"stages"`
-	Next            string           `json:"next,omitempty"`
-	ContinueCmd     string           `json:"continue_command,omitempty"`
+	Complete          bool             `json:"complete"`
+	DiscoveryOnly     bool             `json:"discovery_only,omitempty"`
+	DiscoveryComplete bool             `json:"discovery_complete,omitempty"`
+	ProjectsTruncated bool             `json:"projects_truncated,omitempty"`
+	Client            string           `json:"client"`
+	ProjectID         string           `json:"project_id,omitempty"`
+	GCloudAccount     string           `json:"gcloud_account,omitempty"`
+	Services          []string         `json:"services,omitempty"`
+	ServiceUsageIDs   []string         `json:"service_usage_ids,omitempty"`
+	MissingAPIs       []string         `json:"missing_apis,omitempty"`
+	Projects          []gcloud.Project `json:"projects,omitempty"`
+	Stages            []SetupStage     `json:"stages"`
+	Next              string           `json:"next,omitempty"`
+	ContinueCmd       string           `json:"continue_command,omitempty"`
 }
 
 type setupRuntime struct {
-	cmd         *AuthSetupCmd
-	flags       *RootFlags
-	u           *ui.UI
-	gc          *gcloud.Client
-	client      string
-	interactive bool
-	force       bool
-	discover    bool
-	services    []googleauth.Service
-	usageIDs    []string
-	serviceCSV  string
-	report      SetupReport
-	cfg         config.File
-	setupRec    config.ClientSetup
+	cmd            *AuthSetupCmd
+	flags          *RootFlags
+	u              *ui.UI
+	gc             *gcloud.Client
+	client         string
+	clientOverride string
+	priorProjectID string
+	interactive    bool
+	force          bool
+	discover       bool
+	services       []googleauth.Service
+	usageIDs       []string
+	serviceCSV     string
+	report         SetupReport
+	cfg            config.File
+	setupRec       config.ClientSetup
 }
 
 func (c *AuthSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -164,9 +169,13 @@ func (c *AuthSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 func (c *AuthSetupCmd) newSetupRuntime(ctx context.Context, flags *RootFlags) (*setupRuntime, error) {
 	u := ui.FromContext(ctx)
-	client, err := normalizeClientForFlag(authclient.ClientOverrideFromContext(ctx))
+	clientOverride := authclient.ClientOverrideFromContext(ctx)
+	client, err := normalizeClientForFlag(clientOverride)
 	if err != nil {
 		return nil, err
+	}
+	if c.ProjectLimit <= 0 {
+		return nil, usage("--project-limit must be positive")
 	}
 
 	interactive := flags != nil && !flags.NoInput && term.IsTerminal(int(os.Stdin.Fd()))
@@ -199,19 +208,21 @@ func (c *AuthSetupCmd) newSetupRuntime(ctx context.Context, flags *RootFlags) (*
 	}
 
 	return &setupRuntime{
-		cmd:         c,
-		flags:       flags,
-		u:           u,
-		gc:          newGCloudClient(),
-		client:      client,
-		interactive: interactive,
-		force:       force,
-		discover:    discover,
-		services:    services,
-		usageIDs:    usageIDs,
-		serviceCSV:  c.ServicesCSV,
-		cfg:         cfg,
-		setupRec:    setupRec,
+		cmd:            c,
+		flags:          flags,
+		u:              u,
+		gc:             newGCloudClient(),
+		client:         client,
+		clientOverride: clientOverride,
+		priorProjectID: setupRec.ProjectID,
+		interactive:    interactive,
+		force:          force,
+		discover:       discover,
+		services:       services,
+		usageIDs:       usageIDs,
+		serviceCSV:     c.ServicesCSV,
+		cfg:            cfg,
+		setupRec:       setupRec,
 		report: SetupReport{
 			DiscoveryOnly:   discover,
 			Client:          client,
@@ -378,7 +389,7 @@ func (rt *setupRuntime) handleMissingGCloudAccount(ctx context.Context) (stop bo
 }
 
 func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
-	projects, _, listErr := rt.gc.ListProjects(ctx)
+	projects, _, listErr := rt.gc.ListProjects(ctx, rt.cmd.ProjectLimit)
 	if listErr != nil {
 		rt.appendStage(SetupStage{
 			ID:         stageProject,
@@ -394,6 +405,7 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 
 	if rt.discover {
 		rt.report.Projects = projects
+		rt.report.ProjectsTruncated = len(projects) >= rt.cmd.ProjectLimit
 	}
 	projectID := rt.report.ProjectID
 	if rt.cmd.CreateProject && !rt.discover && !containsProject(projects, rt.cmd.Project) {
@@ -410,6 +422,9 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 	}
 
 	if projectID == "" && rt.interactive && !rt.discover {
+		if len(projects) >= rt.cmd.ProjectLimit {
+			rt.u.Err().Printf("Project list may be truncated at %d; pass --project <id> to select another project.\n", rt.cmd.ProjectLimit)
+		}
 		picked, create, pickErr := rt.pickProjectInteractive(ctx, projects)
 		if pickErr != nil {
 			return true, pickErr
@@ -502,15 +517,24 @@ func (rt *setupRuntime) createProject(ctx context.Context) (projectID string, cr
 	}
 
 	rt.u.Err().Printf("Creating project %s…\n", rt.cmd.Project)
-	createdProj, _, createErr := rt.gc.CreateProject(ctx, rt.cmd.Project, rt.cmd.ProjectName, rt.cmd.ProjectParent)
+	createdProj, createRes, createErr := rt.gc.CreateProject(ctx, rt.cmd.Project, rt.cmd.ProjectName, rt.cmd.ProjectParent)
+	if createErr != nil && createRes.Kind == gcloud.BlockerAlreadyExists {
+		// Creation can succeed remotely before gcloud receives its final response.
+		// Verify the explicit ID rather than treating an idempotent rerun as failure.
+		existing, _, describeErr := rt.gc.DescribeProject(ctx, rt.cmd.Project)
+		if describeErr == nil {
+			return existing.ProjectID, true, nil
+		}
+	}
 	if createErr != nil {
+		status, resumable := gcloudFailureStage(createRes.Kind)
 		rt.appendStage(SetupStage{
 			ID:         stageProject,
-			Status:     stageStatusBlocked,
+			Status:     status,
 			ActionKind: actionCommand,
 			Summary:    "project creation failed",
 			Blocker:    createErr.Error(),
-			Resumable:  true,
+			Resumable:  resumable,
 			Command:    rt.continueCmd(rt.cmd.Project),
 		})
 
@@ -593,7 +617,7 @@ func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
 			NextAction: "Re-run with --enable-apis --force",
 		})
 
-		return false, nil
+		return true, rt.emit(ctx)
 	}
 
 	rt.appendStage(SetupStage{
@@ -616,16 +640,24 @@ func (rt *setupRuntime) enableMissingAPIs(ctx context.Context, projectID string,
 	}
 
 	rt.u.Err().Printf("Enabling %d API(s) on %s…\n", len(missing), projectID)
-	_, stillMissing, _, enableErr := rt.gc.EnableServices(ctx, projectID, missing)
+	_, stillMissing, enableRes, enableErr := rt.gc.EnableServices(ctx, projectID, missing)
 	if enableErr != nil {
+		// A failed batch may still have enabled some APIs. Re-inspect so the report
+		// and the next rerun name only the APIs that remain missing.
+		if currentMissing, _, _, inspectErr := rt.gc.MissingServices(ctx, projectID, missing); inspectErr == nil {
+			stillMissing = currentMissing
+		} else {
+			stillMissing = missing
+		}
+		status, resumable := gcloudFailureStage(enableRes.Kind)
 		rt.appendStage(SetupStage{
 			ID:         stageAPIs,
-			Status:     stageStatusBlocked,
+			Status:     status,
 			ActionKind: actionCommand,
 			Summary:    "API enablement failed",
 			Blocker:    enableErr.Error(),
-			Resumable:  true,
-			Detail:     strings.Join(missing, ","),
+			Resumable:  resumable,
+			Detail:     strings.Join(stillMissing, ","),
 			ConsoleURL: projectConsoleURL(projectID, "apis/library"),
 			Command:    rt.continueCmd(projectID),
 		})
@@ -634,6 +666,17 @@ func (rt *setupRuntime) enableMissingAPIs(ctx context.Context, projectID string,
 	}
 
 	return stillMissing, nil
+}
+
+func gcloudFailureStage(kind gcloud.BlockerKind) (status string, resumable bool) {
+	switch kind {
+	case gcloud.BlockerNotLoggedIn, gcloud.BlockerNotFound:
+		return stageStatusBlocked, true
+	default:
+		// Permission, quota, invalid input, and unknown failures need correction;
+		// claiming they are ordinary resumable blockers hides hard failures.
+		return stageStatusFailed, false
+	}
 }
 
 func (rt *setupRuntime) runManualStages(ctx context.Context) (stop bool, err error) {
@@ -667,6 +710,22 @@ func (rt *setupRuntime) runManualStages(ctx context.Context) (stop bool, err err
 		}
 	}
 
+	credsExist, _ := config.ClientCredentialsExists(rt.client)
+	desktopClientStage := SetupStage{
+		ID:         stageDesktopClient,
+		Status:     stageStatusManual,
+		ActionKind: actionConsole,
+		Summary:    "create Desktop OAuth client in Google Auth Platform",
+		Blocker:    "OAuth client creation is Console-only (gog does not use IAM/IAP OAuth client APIs)",
+		Resumable:  true,
+		ConsoleURL: projectConsoleURL(projectID, "auth/clients"),
+		NextAction: "Create a Desktop app OAuth client, download JSON, then pass --credentials",
+		Command:    fmt.Sprintf("gog --client %s auth setup --project %s --credentials ~/Downloads/client_secret.json", rt.client, projectID),
+	}
+	if credsExist {
+		desktopClientStage = SetupStage{ID: stageDesktopClient, Status: stageStatusOK, ActionKind: actionNone, Summary: "Desktop OAuth client inferred from stored credentials"}
+	}
+
 	rt.appendStage(
 		manualStage(stageBranding, "OAuth branding / consent screen", rt.setupRec.AcknowledgedBranding,
 			projectConsoleURL(projectID, "auth/branding"),
@@ -677,23 +736,12 @@ func (rt *setupRuntime) runManualStages(ctx context.Context) (stop bool, err err
 		manualStage(stageDataAccess, "OAuth data access / scopes", rt.setupRec.AcknowledgedDataAccess,
 			projectConsoleURL(projectID, "auth/scopes"),
 			fmt.Sprintf("gog --client %s auth setup --project %s --ack-data-access", rt.client, projectID)),
-		SetupStage{
-			ID:         stageDesktopClient,
-			Status:     stageStatusManual,
-			ActionKind: actionConsole,
-			Summary:    "create Desktop OAuth client in Google Auth Platform",
-			Blocker:    "OAuth client creation is Console-only (gog does not use IAM/IAP OAuth client APIs)",
-			Resumable:  true,
-			ConsoleURL: projectConsoleURL(projectID, "auth/clients"),
-			NextAction: "Create a Desktop app OAuth client, download JSON, then pass --credentials",
-			Command:    fmt.Sprintf("gog --client %s auth setup --project %s --credentials ~/Downloads/client_secret.json", rt.client, projectID),
-		},
+		desktopClientStage,
 	)
 
 	if !rt.setupRec.AcknowledgedBranding || !rt.setupRec.AcknowledgedAudience || !rt.setupRec.AcknowledgedDataAccess {
 		return true, rt.emit(ctx)
 	}
-	credsExist, _ := config.ClientCredentialsExists(rt.client)
 	if strings.TrimSpace(rt.cmd.CredentialsPath) == "" && !credsExist {
 		return true, rt.emit(ctx)
 	}
@@ -709,8 +757,9 @@ func (rt *setupRuntime) runCredentials(ctx context.Context) (stop bool, err erro
 		return rt.installCredentials(ctx, projectID)
 	}
 	if credsExist {
-		rt.appendCredentialsExisting(projectID)
-
+		if !rt.appendCredentialsExisting(ctx, projectID) {
+			return true, rt.emit(ctx)
+		}
 		return false, nil
 	}
 
@@ -774,9 +823,17 @@ func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string
 	return false, nil
 }
 
-func (rt *setupRuntime) appendCredentialsExisting(projectID string) {
+func (rt *setupRuntime) appendCredentialsExisting(ctx context.Context, projectID string) bool {
 	stored, readErr := config.ReadClientCredentialsFor(rt.client)
-	if readErr == nil && stored.ProjectID != "" && stored.ProjectID != projectID {
+	if readErr != nil {
+		rt.appendStage(SetupStage{
+			ID: stageCredentials, Status: stageStatusFailed, ActionKind: actionCommand,
+			Summary: "stored credentials cannot be read", Blocker: readErr.Error(),
+			Command: fmt.Sprintf("gog --client %s auth setup --project %s --credentials <new.json>", rt.client, projectID),
+		})
+		return false
+	}
+	if stored.ProjectID != "" && stored.ProjectID != projectID {
 		rt.appendStage(SetupStage{
 			ID:         stageCredentials,
 			Status:     stageStatusBlocked,
@@ -786,16 +843,28 @@ func (rt *setupRuntime) appendCredentialsExisting(projectID string) {
 			Resumable:  true,
 			Command:    fmt.Sprintf("gog --client %s --force auth setup --project %s --credentials <new.json>", rt.client, projectID),
 		})
-
-		return
+		return false
+	}
+	if stored.ProjectID == "" && rt.priorProjectID != projectID {
+		if !rt.force && !rt.interactive {
+			rt.appendStage(SetupStage{
+				ID: stageCredentials, Status: stageStatusBlocked, ActionKind: actionCommand,
+				Summary:   "stored credentials have no project association",
+				Blocker:   "credentials omit project_id; re-run with --force or confirm interactively",
+				Resumable: true, Command: rt.continueCmd(projectID),
+			})
+			return false
+		}
+		if !rt.force {
+			if err := confirmDestructive(ctx, rt.flags, fmt.Sprintf("associate stored OAuth credentials without project_id with project %q", projectID)); err != nil {
+				rt.appendStage(SetupStage{ID: stageCredentials, Status: stageStatusBlocked, ActionKind: actionCommand, Summary: "stored credentials need project confirmation", Blocker: err.Error(), Resumable: true})
+				return false
+			}
+		}
 	}
 
-	rt.appendStage(SetupStage{
-		ID:         stageCredentials,
-		Status:     stageStatusOK,
-		Summary:    "credentials present",
-		ActionKind: actionNone,
-	})
+	rt.appendStage(SetupStage{ID: stageCredentials, Status: stageStatusOK, Summary: "credentials present", ActionKind: actionNone})
+	return true
 }
 
 func (rt *setupRuntime) runAccount(ctx context.Context) (stop bool, err error) {
@@ -876,10 +945,11 @@ func (rt *setupRuntime) authorizeAccount(ctx context.Context, email string) (sto
 
 	rt.u.Err().Printf("Authorizing %s…\n", email)
 	result, authErr := AuthorizeAndStoreAccount(ctx, AuthorizeAccountOptions{
-		Email:       email,
-		Client:      rt.client,
-		ServicesCSV: rt.serviceCSV,
-		Manual:      rt.cmd.ManualOAuth,
+		Email:                 email,
+		Client:                rt.client,
+		ServicesCSV:           rt.serviceCSV,
+		Manual:                rt.cmd.ManualOAuth,
+		SuppressClientMapping: rt.clientOverride == "",
 	})
 	if authErr != nil {
 		rt.appendStage(SetupStage{
@@ -1001,8 +1071,7 @@ func maybePromptManualAcks(ctx context.Context, u *ui.UI, flags *RootFlags, clie
 
 		ans := strings.TrimSpace(strings.ToLower(line))
 
-		//nolint:goconst // confirmation answer, not send-as value
-		return ans == "y" || ans == "yes", nil
+		return ans == "y" || ans == sendAsYes, nil
 	}
 
 	if ok, promptErr := prompt("OAuth branding/consent", rec.AcknowledgedBranding); promptErr != nil {
@@ -1082,6 +1151,7 @@ func continueSetupCmd(client string, c *AuthSetupCmd, projectID string, force bo
 func emitSetupReport(ctx context.Context, u *ui.UI, flags *RootFlags, report SetupReport) error {
 	_ = flags
 	report.Complete = setupComplete(report)
+	report.DiscoveryComplete = report.DiscoveryOnly && discoveryComplete(report)
 	if !report.Complete {
 		report.Next = firstBlockingNext(report)
 		report.ContinueCmd = firstContinueCmd(report)
@@ -1091,7 +1161,7 @@ func emitSetupReport(ctx context.Context, u *ui.UI, flags *RootFlags, report Set
 		if err := outfmt.WriteJSON(os.Stdout, report); err != nil {
 			return err
 		}
-		if report.Complete {
+		if report.Complete || report.DiscoveryComplete {
 			return nil
 		}
 
@@ -1104,7 +1174,7 @@ func emitSetupReport(ctx context.Context, u *ui.UI, flags *RootFlags, report Set
 		emitHumanSetupReport(u, report)
 	}
 
-	if report.Complete {
+	if report.Complete || report.DiscoveryComplete {
 		return nil
 	}
 
@@ -1150,20 +1220,6 @@ func emitHumanSetupReport(u *ui.UI, report SetupReport) {
 }
 
 func setupComplete(r SetupReport) bool {
-	// Discovery succeeds only when every attempted inspection succeeded. Missing
-	// setup prerequisites are still useful discovery results, but failures are not.
-	if r.DiscoveryOnly {
-		for _, stage := range r.Stages {
-			if stage.ID == stageGCloudInstall && stage.Status != stageStatusOK {
-				return false
-			}
-			if stage.Status == stageStatusFailed || stage.Status == stageStatusBlocked {
-				return false
-			}
-		}
-		return true
-	}
-
 	needOK := map[string]bool{
 		stageGCloudInstall: true,
 		stageGCloudAuth:    true,
@@ -1197,6 +1253,17 @@ func setupComplete(r SetupReport) bool {
 		}
 	}
 
+	return true
+}
+
+// discoveryComplete reports whether all requested inspections completed, without
+// claiming that the setup prerequisites themselves are complete.
+func discoveryComplete(r SetupReport) bool {
+	for _, stage := range r.Stages {
+		if stage.Status == stageStatusFailed || stage.Status == stageStatusBlocked || stage.Status == stageStatusMissing && stage.ID == stageGCloudInstall {
+			return false
+		}
+	}
 	return true
 }
 

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -165,6 +165,11 @@ func (c *AuthSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
 			return rt.emit(ctx)
 		}
 	}
+	// Discovery is read-only, but still reports every setup stage. The local
+	// credential and token stages are deliberately unavailable rather than read.
+	if rt.discover {
+		rt.appendDeferredStages()
+	}
 
 	return rt.emit(ctx)
 }
@@ -303,6 +308,10 @@ func (rt *setupRuntime) continueCmd(projectID string) string {
 	return continueSetupCmd(rt.client, rt.cmd, projectID, rt.force)
 }
 
+func (rt *setupRuntime) setupCommand(projectID string, extra ...string) string {
+	return buildSetupCommand(rt.client, rt.cmd, projectID, rt.force, extra...)
+}
+
 func (rt *setupRuntime) runGCloudInstall(ctx context.Context) (stop bool, err error) {
 	installed, installRes := rt.gc.Installed(ctx)
 	if !installed {
@@ -428,7 +437,9 @@ func (rt *setupRuntime) handleMissingGCloudAccount(ctx context.Context) (stop bo
 
 func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 	projectID := rt.report.ProjectID
-	needList := rt.discover || projectID == "" && rt.interactive && !rt.discover
+	// An explicit (or saved) target is validated directly, including under
+	// --discover, so projects.list permission is never a prerequisite.
+	needList := projectID == "" && (rt.discover || rt.interactive && !rt.discover)
 	var projects []gcloud.Project
 	if needList {
 		// Request one extra item so truncation means an item was actually omitted.
@@ -438,9 +449,11 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 			rt.appendStage(SetupStage{ID: stageProject, Status: status, ActionKind: actionCommand, Summary: "failed to list projects", Blocker: listErr.Error(), Resumable: resumable, Command: rt.continueCmd(projectID)})
 			return stopSetup()
 		}
+		// ListProjects filters ACTIVE server-side. Retain the defensive filter in
+		// case a gcloud implementation returns a non-active row regardless.
 		projects = filterActiveProjects(listed)
-		truncated := len(projects) > rt.cmd.ProjectLimit
-		if truncated {
+		truncated := len(listed) > rt.cmd.ProjectLimit
+		if len(projects) > rt.cmd.ProjectLimit {
 			projects = projects[:rt.cmd.ProjectLimit]
 		}
 		if rt.discover {
@@ -456,6 +469,9 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 			return stopSetup()
 		}
 		projectID = createdID
+		// The project now exists. Continuations must validate it read-only instead
+		// of attempting creation again.
+		rt.cmd.CreateProject = false
 	}
 	if projectID == "" && rt.interactive && !rt.discover {
 		picked, create, pickErr := rt.pickProjectInteractive(ctx, projects)
@@ -478,6 +494,10 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 		} else {
 			projectID = picked
 		}
+	}
+	if projectID == "" && rt.discover {
+		rt.appendStage(SetupStage{ID: stageProject, Status: stageStatusOK, ActionKind: actionNone, Summary: "ACTIVE projects discovered"})
+		return false, nil
 	}
 	if projectID == "" {
 		active, _, _ := rt.gc.ActiveProjectID(ctx)
@@ -544,7 +564,7 @@ func (rt *setupRuntime) createProject(ctx context.Context) (projectID string, cr
 		// Creation can succeed remotely before gcloud receives its final response.
 		// Verify the explicit ID rather than treating an idempotent rerun as failure.
 		existing, _, describeErr := rt.gc.DescribeProject(ctx, rt.cmd.Project)
-		if describeErr == nil {
+		if describeErr == nil && (existing.LifecycleState == "" || strings.EqualFold(existing.LifecycleState, "ACTIVE")) {
 			return existing.ProjectID, true, nil
 		}
 	}
@@ -603,6 +623,10 @@ func (rt *setupRuntime) pickProjectInteractive(ctx context.Context, projects []g
 
 func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
 	projectID := rt.report.ProjectID
+	if projectID == "" && rt.discover {
+		rt.appendStage(SetupStage{ID: stageAPIs, Status: stageStatusUnavailable, ActionKind: actionNone, Summary: "not inspected; no project selected during discovery", Blocker: "pass --project to inspect enabled APIs"})
+		return false, nil
+	}
 	missing, _, missRes, missErr := rt.gc.MissingServices(ctx, projectID, rt.usageIDs)
 	if missErr != nil {
 		status, resumable := gcloudFailureStage(missRes.Kind)
@@ -743,11 +767,11 @@ func (rt *setupRuntime) runManualStages(ctx context.Context) (stop bool, err err
 
 	rt.appendStage(
 		manualStage(stageBranding, "OAuth branding / consent screen", rt.setupRec.AcknowledgedBranding,
-			projectConsoleURL(projectID, "auth/branding"), fmt.Sprintf("gog --client %s auth setup --project %s --ack-branding", rt.client, projectID)),
+			projectConsoleURL(projectID, "auth/branding"), rt.setupCommand(projectID, "--ack-branding")),
 		manualStage(stageAudience, "OAuth audience / test users", rt.setupRec.AcknowledgedAudience,
-			projectConsoleURL(projectID, "auth/audience"), fmt.Sprintf("gog --client %s auth setup --project %s --ack-audience", rt.client, projectID)),
+			projectConsoleURL(projectID, "auth/audience"), rt.setupCommand(projectID, "--ack-audience")),
 		manualStage(stageDataAccess, "OAuth data access / scopes", rt.setupRec.AcknowledgedDataAccess,
-			projectConsoleURL(projectID, "auth/scopes"), fmt.Sprintf("gog --client %s auth setup --project %s --ack-data-access", rt.client, projectID)),
+			projectConsoleURL(projectID, "auth/scopes"), rt.setupCommand(projectID, "--ack-data-access")),
 	)
 	if !rt.setupRec.AcknowledgedBranding || !rt.setupRec.AcknowledgedAudience || !rt.setupRec.AcknowledgedDataAccess {
 		return stopSetup()
@@ -768,7 +792,9 @@ func (rt *setupRuntime) runManualStages(ctx context.Context) (stop bool, err err
 		Command: fmt.Sprintf("gog --client %s auth setup --project %s --credentials ~/Downloads/client_secret.json", rt.client, projectID),
 	}
 	if credsExist {
-		desktopClientStage = SetupStage{ID: stageDesktopClient, Status: stageStatusOK, ActionKind: actionNone, Summary: "Desktop OAuth client inferred from stored credentials"}
+		if stored, err := config.ReadClientCredentialsFor(rt.client); err == nil && stored.ClientType == config.OAuthClientTypeInstalled {
+			desktopClientStage = SetupStage{ID: stageDesktopClient, Status: stageStatusOK, ActionKind: actionNone, Summary: "Desktop OAuth client inferred from stored credentials"}
+		}
 	}
 	rt.appendStage(desktopClientStage)
 	return false, nil
@@ -803,7 +829,7 @@ func (rt *setupRuntime) runCredentials(ctx context.Context) (stop bool, err erro
 		Summary:    "OAuth client credentials not installed",
 		Blocker:    "download Desktop client JSON and pass --credentials",
 		Resumable:  true,
-		Command:    fmt.Sprintf("gog --client %s auth setup --project %s --credentials <path>", rt.client, projectID),
+		Command:    rt.setupCommand(projectID, "--credentials", "<path>"),
 		ConsoleURL: projectConsoleURL(projectID, "auth/clients"),
 	})
 
@@ -883,6 +909,15 @@ func (rt *setupRuntime) appendCredentialsExisting(ctx context.Context, projectID
 		})
 		return false
 	}
+	if stored.ClientType != config.OAuthClientTypeInstalled {
+		rt.appendStage(SetupStage{
+			ID: stageCredentials, Status: stageStatusBlocked, ActionKind: actionCommand,
+			Summary:   "stored credentials are not confirmed Desktop OAuth credentials",
+			Blocker:   "install a Desktop app OAuth client JSON with --credentials",
+			Resumable: true, Command: rt.setupCommand(projectID, "--credentials", "<new.json>"),
+		})
+		return false
+	}
 	if stored.ProjectID != "" && stored.ProjectID != projectID {
 		rt.appendStage(SetupStage{
 			ID:         stageCredentials,
@@ -929,6 +964,9 @@ func (rt *setupRuntime) runAccount(ctx context.Context) (stop bool, err error) {
 		return stopSetup()
 	}
 	if satisfies {
+		if !rt.repairExplicitAccountMapping(ctx, email) {
+			return stopSetup()
+		}
 		summary := "authorized account token present for requested services"
 		if email != "" {
 			summary = "account authorized: " + email
@@ -967,6 +1005,39 @@ func (rt *setupRuntime) runAccount(ctx context.Context) (stop bool, err error) {
 	})
 
 	return false, nil
+}
+
+func (rt *setupRuntime) repairExplicitAccountMapping(ctx context.Context, email string) bool {
+	if rt.clientOverride == "" || strings.TrimSpace(email) == "" {
+		return true
+	}
+	mapped, exists := config.AccountClient(rt.cfg, email)
+	if exists && mapped == rt.client {
+		return true
+	}
+	if !rt.force && !rt.interactive {
+		rt.appendStage(SetupStage{
+			ID: stageAccount, Status: stageStatusBlocked, ActionKind: actionCommand,
+			Summary: "account mapping does not select the requested client", Blocker: "re-run with --force or confirm interactively to repair the account mapping", Resumable: true,
+			Command: rt.continueCmd(rt.report.ProjectID),
+		})
+		return false
+	}
+	if !rt.force {
+		if err := confirmDestructive(ctx, rt.flags, fmt.Sprintf("map account %q to client %q", email, rt.client)); err != nil {
+			rt.appendStage(SetupStage{ID: stageAccount, Status: stageStatusBlocked, ActionKind: actionCommand, Summary: "account mapping needs confirmation", Blocker: err.Error(), Resumable: true, Command: rt.continueCmd(rt.report.ProjectID)})
+			return false
+		}
+	}
+	if err := config.SetAccountClient(&rt.cfg, email, rt.client); err != nil {
+		rt.appendStage(SetupStage{ID: stageAccount, Status: stageStatusFailed, ActionKind: actionCommand, Summary: "cannot repair account mapping", Blocker: err.Error(), Command: rt.continueCmd(rt.report.ProjectID)})
+		return false
+	}
+	if err := config.WriteConfig(rt.cfg); err != nil {
+		rt.appendStage(SetupStage{ID: stageAccount, Status: stageStatusFailed, ActionKind: actionCommand, Summary: "cannot repair account mapping", Blocker: err.Error(), Command: rt.continueCmd(rt.report.ProjectID)})
+		return false
+	}
+	return true
 }
 
 func (rt *setupRuntime) authorizeAccount(ctx context.Context, email string) (stop bool, err error) {
@@ -1225,6 +1296,12 @@ func shellQuote(value string) string {
 }
 
 func continueSetupCmd(client string, c *AuthSetupCmd, projectID string, force bool) string {
+	return buildSetupCommand(client, c, projectID, force)
+}
+
+// buildSetupCommand emits the canonical shell-safe setup command, retaining all
+// non-secret retry inputs. Extra arguments are used for stage-specific actions.
+func buildSetupCommand(client string, c *AuthSetupCmd, projectID string, force bool, extra ...string) string {
 	parts := []string{"gog"}
 	if client != "" && client != config.DefaultClientName {
 		parts = append(parts, "--client", client)
@@ -1277,6 +1354,7 @@ func continueSetupCmd(client string, c *AuthSetupCmd, projectID string, force bo
 	if c.ProjectLimit != 0 && c.ProjectLimit != 100 {
 		parts = append(parts, "--project-limit", strconv.Itoa(c.ProjectLimit))
 	}
+	parts = append(parts, extra...)
 	for i, part := range parts {
 		parts[i] = shellQuote(part)
 	}

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"golang.org/x/term"
@@ -26,6 +27,10 @@ var (
 )
 
 var errAuthSetupIncomplete = errors.New("auth setup incomplete")
+
+func stopSetup() (bool, error) { return true, nil }
+
+func stopProjectCreate() (string, bool, error) { return "", false, nil }
 
 // AuthSetupCmd is the guided, re-runnable first-time Cloud + OAuth setup flow.
 type AuthSetupCmd struct {
@@ -76,6 +81,7 @@ const (
 	stageStatusFailed       = "failed"
 	stageStatusManual       = "manual"
 	stageStatusAcknowledged = "acknowledged"
+	stageStatusUnavailable  = "unavailable"
 )
 
 // Action kinds.
@@ -142,29 +148,21 @@ func (c *AuthSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	if stop, runErr := rt.runGCloudInstall(ctx); stop {
-		return runErr
+	runners := []func(context.Context) (bool, error){
+		rt.runGCloudInstall, rt.runGCloudAuth, rt.runProject, rt.runAPIs,
+		rt.runManualStages, rt.runCredentials, rt.runAccount,
 	}
-	if stop, runErr := rt.runGCloudAuth(ctx); stop {
-		return runErr
-	}
-	if stop, runErr := rt.runProject(ctx); stop {
-		return runErr
-	}
-	if stop, runErr := rt.runAPIs(ctx); stop {
-		return runErr
-	}
-	if stop, runErr := rt.runManualStages(ctx); stop {
-		return runErr
-	}
-	if stop, runErr := rt.runCredentials(ctx); stop {
-		return runErr
-	}
-	if stop, runErr := rt.runAccount(ctx); stop {
-		return runErr
+	for _, run := range runners {
+		if stop, runErr := run(ctx); stop {
+			rt.appendDeferredStages()
+			if runErr != nil {
+				return runErr
+			}
+			return rt.emit(ctx)
+		}
 	}
 
-	return emitSetupReport(ctx, rt.u, rt.flags, rt.report)
+	return rt.emit(ctx)
 }
 
 func (c *AuthSetupCmd) newSetupRuntime(ctx context.Context, flags *RootFlags) (*setupRuntime, error) {
@@ -173,6 +171,15 @@ func (c *AuthSetupCmd) newSetupRuntime(ctx context.Context, flags *RootFlags) (*
 	client, err := normalizeClientForFlag(clientOverride)
 	if err != nil {
 		return nil, err
+	}
+	// Setup without --client must not persist under default when later commands
+	// resolve the supplied account to a named client through account/domain mapping.
+	if clientOverride == "" && strings.TrimSpace(c.AccountEmail) != "" {
+		resolved, resolveErr := authclient.ResolveClientWithOverride(c.AccountEmail, "")
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+		client = resolved
 	}
 	if c.ProjectLimit <= 0 {
 		return nil, usage("--project-limit must be positive")
@@ -257,6 +264,30 @@ func (rt *setupRuntime) appendStage(stages ...SetupStage) {
 	rt.report.Stages = append(rt.report.Stages, stages...)
 }
 
+var setupStageOrder = []string{
+	stageGCloudInstall, stageGCloudAuth, stageProject, stageAPIs,
+	stageBranding, stageAudience, stageDataAccess, stageDesktopClient,
+	stageCredentials, stageAccount,
+}
+
+// appendDeferredStages keeps the machine report a complete inventory without
+// inspecting or changing later stages after an earlier prerequisite stopped setup.
+func (rt *setupRuntime) appendDeferredStages() {
+	seen := make(map[string]bool, len(rt.report.Stages))
+	for _, stage := range rt.report.Stages {
+		seen[stage.ID] = true
+	}
+	for _, id := range setupStageOrder {
+		if !seen[id] {
+			rt.appendStage(SetupStage{
+				ID: id, Status: stageStatusUnavailable, ActionKind: actionNone,
+				Summary: "not inspected; an earlier setup stage is incomplete",
+				Blocker: "complete the earlier blocking stage before this stage can run",
+			})
+		}
+	}
+}
+
 func (rt *setupRuntime) emit(ctx context.Context) error {
 	return emitSetupReport(ctx, rt.u, rt.flags, rt.report)
 }
@@ -280,7 +311,7 @@ func (rt *setupRuntime) runGCloudInstall(ctx context.Context) (stop bool, err er
 			Command:    rt.continueCmd(rt.report.ProjectID),
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
 	rt.appendStage(SetupStage{
@@ -310,7 +341,7 @@ func (rt *setupRuntime) runGCloudAuth(ctx context.Context) (stop bool, err error
 			NextAction: "Fix gcloud authentication, then re-run",
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
 	if acct.Account == "" {
@@ -342,7 +373,7 @@ func (rt *setupRuntime) handleMissingGCloudAccount(ctx context.Context) (stop bo
 			NextAction: "Authenticate gcloud, then re-run gog auth setup",
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
 	rt.u.Err().Println("Running gcloud auth login (does not change gcloud default project/config beyond auth)…")
@@ -358,7 +389,7 @@ func (rt *setupRuntime) handleMissingGCloudAccount(ctx context.Context) (stop bo
 			Command:    "gcloud auth login",
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
 	acct, _, acctErr := rt.gc.ActiveAccount(ctx)
@@ -373,7 +404,7 @@ func (rt *setupRuntime) handleMissingGCloudAccount(ctx context.Context) (stop bo
 			Command:    "gcloud auth login",
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
 	rt.report.GCloudAccount = acct.Account
@@ -389,23 +420,25 @@ func (rt *setupRuntime) handleMissingGCloudAccount(ctx context.Context) (stop bo
 }
 
 func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
-	projects, _, listErr := rt.gc.ListProjects(ctx, rt.cmd.ProjectLimit)
+	// Request one extra item so truncation means an item was actually omitted.
+	projects, listRes, listErr := rt.gc.ListProjects(ctx, rt.cmd.ProjectLimit+1)
 	if listErr != nil {
+		status, resumable := gcloudFailureStage(listRes.Kind)
 		rt.appendStage(SetupStage{
-			ID:         stageProject,
-			Status:     stageStatusFailed,
-			ActionKind: actionCommand,
-			Summary:    "failed to list projects",
-			Blocker:    listErr.Error(),
-			Resumable:  false,
+			ID: stageProject, Status: status, ActionKind: actionCommand,
+			Summary: "failed to list projects", Blocker: listErr.Error(), Resumable: resumable,
+			Command: rt.continueCmd(rt.report.ProjectID),
 		})
-
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
+	truncated := len(projects) > rt.cmd.ProjectLimit
+	if truncated {
+		projects = projects[:rt.cmd.ProjectLimit]
+	}
 	if rt.discover {
 		rt.report.Projects = projects
-		rt.report.ProjectsTruncated = len(projects) >= rt.cmd.ProjectLimit
+		rt.report.ProjectsTruncated = truncated
 	}
 	projectID := rt.report.ProjectID
 	if rt.cmd.CreateProject && !rt.discover && !containsProject(projects, rt.cmd.Project) {
@@ -414,7 +447,7 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 			return true, createErr
 		}
 		if !created {
-			return true, nil
+			return stopSetup()
 		}
 
 		projectID = createdID
@@ -468,7 +501,23 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 			NextAction: "Re-run with --project <id>",
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
+	}
+
+	// An explicit or persisted target must be live-validated before it can be
+	// accepted or persisted; the project list can be truncated or stale.
+	if !rt.cmd.CreateProject {
+		described, describeRes, describeErr := rt.gc.DescribeProject(ctx, projectID)
+		if describeErr != nil {
+			status, resumable := gcloudFailureStage(describeRes.Kind)
+			rt.appendStage(SetupStage{
+				ID: stageProject, Status: status, ActionKind: actionCommand,
+				Summary: "failed to validate selected project", Blocker: describeErr.Error(),
+				Resumable: resumable, Command: rt.continueCmd(projectID),
+			})
+			return stopSetup()
+		}
+		projectID = described.ProjectID
 	}
 
 	if !rt.discover {
@@ -538,23 +587,30 @@ func (rt *setupRuntime) createProject(ctx context.Context) (projectID string, cr
 			Command:    rt.continueCmd(rt.cmd.Project),
 		})
 
-		return "", false, rt.emit(ctx)
+		return stopProjectCreate()
 	}
 
 	return createdProj.ProjectID, true, nil
 }
 
+func projectPickerLabel(p gcloud.Project, pairedProjectID string) string {
+	label := p.ProjectID
+	if p.Name != "" && p.Name != p.ProjectID {
+		label = fmt.Sprintf("%s (%s)", p.ProjectID, p.Name)
+	}
+	if p.LifecycleState != "" {
+		label += " [" + p.LifecycleState + "]"
+	}
+	if p.ProjectID == pairedProjectID {
+		label += " [current paired target]"
+	}
+	return label
+}
+
 func (rt *setupRuntime) pickProjectInteractive(ctx context.Context, projects []gcloud.Project) (string, bool, error) {
 	rt.u.Err().Println("Select a Google Cloud project:")
 	for i, p := range projects {
-		label := p.ProjectID
-		if p.Name != "" && p.Name != p.ProjectID {
-			label = fmt.Sprintf("%s (%s)", p.ProjectID, p.Name)
-		}
-		if p.LifecycleState != "" {
-			label += " [" + p.LifecycleState + "]"
-		}
-		rt.u.Err().Printf("  %d) %s\n", i+1, label)
+		rt.u.Err().Printf("  %d) %s\n", i+1, projectPickerLabel(p, rt.setupRec.ProjectID))
 	}
 	rt.u.Err().Printf("  %d) Create a new project\n", len(projects)+1)
 
@@ -586,7 +642,7 @@ func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
 			ConsoleURL: projectConsoleURL(projectID, "apis/dashboard"),
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
 	rt.report.MissingAPIs = missing
@@ -594,6 +650,9 @@ func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
 		enabledMissing, enableErr := rt.enableMissingAPIs(ctx, projectID, missing)
 		if enableErr != nil {
 			return true, enableErr
+		}
+		if enabledMissing == nil {
+			return stopSetup()
 		}
 
 		missing = enabledMissing
@@ -617,7 +676,7 @@ func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
 			NextAction: "Re-run with --enable-apis --force",
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
 	rt.appendStage(SetupStage{
@@ -662,7 +721,7 @@ func (rt *setupRuntime) enableMissingAPIs(ctx context.Context, projectID string,
 			Command:    rt.continueCmd(projectID),
 		})
 
-		return nil, rt.emit(ctx)
+		return nil, nil
 	}
 
 	return stillMissing, nil
@@ -670,11 +729,13 @@ func (rt *setupRuntime) enableMissingAPIs(ctx context.Context, projectID string,
 
 func gcloudFailureStage(kind gcloud.BlockerKind) (status string, resumable bool) {
 	switch kind {
-	case gcloud.BlockerNotLoggedIn, gcloud.BlockerNotFound:
+	case gcloud.BlockerNotLoggedIn, gcloud.BlockerPermission, gcloud.BlockerQuota, gcloud.BlockerNotFound, gcloud.BlockerUnknown:
+		// These commonly resolve after external authentication, propagation, billing,
+		// enrollment, policy, or quota action. Keep the exact retry available.
 		return stageStatusBlocked, true
+	case gcloud.BlockerInvalidInput:
+		return stageStatusFailed, false
 	default:
-		// Permission, quota, invalid input, and unknown failures need correction;
-		// claiming they are ordinary resumable blockers hides hard failures.
 		return stageStatusFailed, false
 	}
 }
@@ -710,55 +771,57 @@ func (rt *setupRuntime) runManualStages(ctx context.Context) (stop bool, err err
 		}
 	}
 
-	credsExist, _ := config.ClientCredentialsExists(rt.client)
+	rt.appendStage(
+		manualStage(stageBranding, "OAuth branding / consent screen", rt.setupRec.AcknowledgedBranding,
+			projectConsoleURL(projectID, "auth/branding"), fmt.Sprintf("gog --client %s auth setup --project %s --ack-branding", rt.client, projectID)),
+		manualStage(stageAudience, "OAuth audience / test users", rt.setupRec.AcknowledgedAudience,
+			projectConsoleURL(projectID, "auth/audience"), fmt.Sprintf("gog --client %s auth setup --project %s --ack-audience", rt.client, projectID)),
+		manualStage(stageDataAccess, "OAuth data access / scopes", rt.setupRec.AcknowledgedDataAccess,
+			projectConsoleURL(projectID, "auth/scopes"), fmt.Sprintf("gog --client %s auth setup --project %s --ack-data-access", rt.client, projectID)),
+	)
+	if !rt.setupRec.AcknowledgedBranding || !rt.setupRec.AcknowledgedAudience || !rt.setupRec.AcknowledgedDataAccess {
+		return stopSetup()
+	}
+
+	credsExist, credsErr := config.ClientCredentialsExists(rt.client)
+	if credsErr != nil {
+		rt.appendStage(SetupStage{
+			ID: stageCredentials, Status: stageStatusFailed, ActionKind: actionCommand,
+			Summary: "cannot inspect stored credentials", Blocker: credsErr.Error(), Command: rt.continueCmd(projectID),
+		})
+		return stopSetup()
+	}
 	desktopClientStage := SetupStage{
-		ID:         stageDesktopClient,
-		Status:     stageStatusManual,
-		ActionKind: actionConsole,
-		Summary:    "create Desktop OAuth client in Google Auth Platform",
-		Blocker:    "OAuth client creation is Console-only (gog does not use IAM/IAP OAuth client APIs)",
-		Resumable:  true,
-		ConsoleURL: projectConsoleURL(projectID, "auth/clients"),
-		NextAction: "Create a Desktop app OAuth client, download JSON, then pass --credentials",
-		Command:    fmt.Sprintf("gog --client %s auth setup --project %s --credentials ~/Downloads/client_secret.json", rt.client, projectID),
+		ID: stageDesktopClient, Status: stageStatusManual, ActionKind: actionConsole,
+		Summary: "create Desktop OAuth client in Google Auth Platform", Blocker: "OAuth client creation is Console-only (gog does not use IAM/IAP OAuth client APIs)",
+		Resumable: true, ConsoleURL: projectConsoleURL(projectID, "auth/clients"), NextAction: "Create a Desktop app OAuth client, download JSON, then pass --credentials",
+		Command: fmt.Sprintf("gog --client %s auth setup --project %s --credentials ~/Downloads/client_secret.json", rt.client, projectID),
 	}
 	if credsExist {
 		desktopClientStage = SetupStage{ID: stageDesktopClient, Status: stageStatusOK, ActionKind: actionNone, Summary: "Desktop OAuth client inferred from stored credentials"}
 	}
-
-	rt.appendStage(
-		manualStage(stageBranding, "OAuth branding / consent screen", rt.setupRec.AcknowledgedBranding,
-			projectConsoleURL(projectID, "auth/branding"),
-			fmt.Sprintf("gog --client %s auth setup --project %s --ack-branding", rt.client, projectID)),
-		manualStage(stageAudience, "OAuth audience / test users", rt.setupRec.AcknowledgedAudience,
-			projectConsoleURL(projectID, "auth/audience"),
-			fmt.Sprintf("gog --client %s auth setup --project %s --ack-audience", rt.client, projectID)),
-		manualStage(stageDataAccess, "OAuth data access / scopes", rt.setupRec.AcknowledgedDataAccess,
-			projectConsoleURL(projectID, "auth/scopes"),
-			fmt.Sprintf("gog --client %s auth setup --project %s --ack-data-access", rt.client, projectID)),
-		desktopClientStage,
-	)
-
-	if !rt.setupRec.AcknowledgedBranding || !rt.setupRec.AcknowledgedAudience || !rt.setupRec.AcknowledgedDataAccess {
-		return true, rt.emit(ctx)
-	}
-	if strings.TrimSpace(rt.cmd.CredentialsPath) == "" && !credsExist {
-		return true, rt.emit(ctx)
-	}
-
+	rt.appendStage(desktopClientStage)
 	return false, nil
 }
 
 func (rt *setupRuntime) runCredentials(ctx context.Context) (stop bool, err error) {
 	projectID := rt.report.ProjectID
-	credsExist, _ := config.ClientCredentialsExists(rt.client)
+	credsExist, credsErr := config.ClientCredentialsExists(rt.client)
+	if credsErr != nil {
+		rt.appendStage(SetupStage{
+			ID: stageCredentials, Status: stageStatusFailed, ActionKind: actionCommand,
+			Summary: "cannot inspect stored credentials", Blocker: credsErr.Error(),
+			Command: rt.continueCmd(projectID),
+		})
+		return stopSetup()
+	}
 
 	if strings.TrimSpace(rt.cmd.CredentialsPath) != "" && !rt.discover {
 		return rt.installCredentials(ctx, projectID)
 	}
 	if credsExist {
 		if !rt.appendCredentialsExisting(ctx, projectID) {
-			return true, rt.emit(ctx)
+			return stopSetup()
 		}
 		return false, nil
 	}
@@ -774,7 +837,7 @@ func (rt *setupRuntime) runCredentials(ctx context.Context) (stop bool, err erro
 		ConsoleURL: projectConsoleURL(projectID, "auth/clients"),
 	})
 
-	return false, nil
+	return stopSetup()
 }
 
 func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string) (stop bool, err error) {
@@ -792,16 +855,14 @@ func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string
 		Confirm:                      confirmFn,
 	})
 	if instErr != nil {
+		status, resumable := credentialInstallFailure(instErr)
 		rt.appendStage(SetupStage{
-			ID:         stageCredentials,
-			Status:     stageStatusBlocked,
-			ActionKind: actionCommand,
-			Summary:    "credential install failed",
-			Blocker:    instErr.Error(),
-			Resumable:  true,
+			ID: stageCredentials, Status: status, ActionKind: actionCommand,
+			Summary: "credential install failed", Blocker: instErr.Error(), Resumable: resumable,
+			Command: rt.continueCmd(projectID),
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
 	summary := "credentials installed"
@@ -821,6 +882,18 @@ func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string
 	})
 
 	return false, nil
+}
+
+func credentialInstallFailure(err error) (string, bool) {
+	// Credential JSON, client type, project mismatch, and unreadable supplied
+	// material cannot be fixed by retrying the exact command unchanged.
+	message := strings.ToLower(err.Error())
+	if strings.Contains(message, "credentials omit project_id") ||
+		strings.Contains(message, "refusing to replace") ||
+		strings.Contains(message, "confirmation") {
+		return stageStatusBlocked, true
+	}
+	return stageStatusFailed, false
 }
 
 func (rt *setupRuntime) appendCredentialsExisting(ctx context.Context, projectID string) bool {
@@ -906,7 +979,14 @@ func (rt *setupRuntime) runAccount(ctx context.Context) (stop bool, err error) {
 }
 
 func (rt *setupRuntime) authorizeAccount(ctx context.Context, email string) (stop bool, err error) {
-	credsExist, _ := config.ClientCredentialsExists(rt.client)
+	credsExist, credsErr := config.ClientCredentialsExists(rt.client)
+	if credsErr != nil {
+		rt.appendStage(SetupStage{
+			ID: stageAccount, Status: stageStatusFailed, ActionKind: actionCommand,
+			Summary: "cannot inspect stored credentials", Blocker: credsErr.Error(), Command: rt.continueCmd(rt.report.ProjectID),
+		})
+		return stopSetup()
+	}
 	if !credsExist {
 		rt.appendStage(SetupStage{
 			ID:         stageAccount,
@@ -917,7 +997,7 @@ func (rt *setupRuntime) authorizeAccount(ctx context.Context, email string) (sto
 			Resumable:  true,
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
 	if !rt.interactive {
@@ -962,7 +1042,7 @@ func (rt *setupRuntime) authorizeAccount(ctx context.Context, email string) (sto
 			Command:    fmt.Sprintf("gog --client %s auth add %s --services %s", rt.client, email, rt.serviceCSV),
 		})
 
-		return true, rt.emit(ctx)
+		return stopSetup()
 	}
 
 	rt.appendStage(SetupStage{
@@ -1052,7 +1132,7 @@ func maybePromptManualAcks(ctx context.Context, u *ui.UI, flags *RootFlags, clie
 	changed := false
 	prompt := func(label string, already bool) (bool, error) {
 		if already {
-			return true, nil
+			return stopSetup()
 		}
 
 		u.Err().Printf("%s: %s\n", label, projectConsoleURL(projectID, ""))
@@ -1125,6 +1205,18 @@ func projectConsoleURL(projectID, path string) string {
 	return fmt.Sprintf("%s/%s?project=%s", base, strings.TrimPrefix(path, "/"), projectID)
 }
 
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	for _, r := range value {
+		if !(r == '-' || r == '_' || r == '.' || r == '/' || r == ':' || r == ',' || r == '@' || r == '+' || r == '=') && !(r >= 'a' && r <= 'z') && !(r >= 'A' && r <= 'Z') && !(r >= '0' && r <= '9') {
+			return "'" + strings.ReplaceAll(value, "'", "'\\\"'\\\"'") + "'"
+		}
+	}
+	return value
+}
+
 func continueSetupCmd(client string, c *AuthSetupCmd, projectID string, force bool) string {
 	parts := []string{"gog"}
 	if client != "" && client != config.DefaultClientName {
@@ -1133,18 +1225,54 @@ func continueSetupCmd(client string, c *AuthSetupCmd, projectID string, force bo
 	if force {
 		parts = append(parts, "--force")
 	}
-
 	parts = append(parts, "auth", "setup")
-	switch {
-	case projectID != "":
+	if projectID != "" {
 		parts = append(parts, "--project", projectID)
-	case strings.TrimSpace(c.Project) != "":
+	} else if strings.TrimSpace(c.Project) != "" {
 		parts = append(parts, "--project", c.Project)
+	}
+	if c.CreateProject {
+		parts = append(parts, "--create-project")
+	}
+	if c.ProjectName != "" {
+		parts = append(parts, "--project-name", c.ProjectName)
+	}
+	if c.ProjectParent != "" {
+		parts = append(parts, "--project-parent", c.ProjectParent)
+	}
+	if c.ServicesCSV != "" {
+		parts = append(parts, "--services", c.ServicesCSV)
+	}
+	if c.EnableAPIs {
+		parts = append(parts, "--enable-apis")
+	}
+	if c.CredentialsPath != "" && c.CredentialsPath != "-" {
+		parts = append(parts, "--credentials", c.CredentialsPath)
+	}
+	if c.AccountEmail != "" {
+		parts = append(parts, "--email", c.AccountEmail)
+	}
+	if c.ManualOAuth {
+		parts = append(parts, "--manual")
+	}
+	if c.AckBranding {
+		parts = append(parts, "--ack-branding")
+	}
+	if c.AckAudience {
+		parts = append(parts, "--ack-audience")
+	}
+	if c.AckDataAccess {
+		parts = append(parts, "--ack-data-access")
 	}
 	if c.Discover {
 		parts = append(parts, "--discover")
 	}
-
+	if c.ProjectLimit != 0 && c.ProjectLimit != 100 {
+		parts = append(parts, "--project-limit", strconv.Itoa(c.ProjectLimit))
+	}
+	for i, part := range parts {
+		parts[i] = shellQuote(part)
+	}
 	return strings.Join(parts, " ")
 }
 

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -1414,7 +1414,7 @@ func emitSetupReport(ctx context.Context, u *ui.UI, flags *RootFlags, report Set
 	}
 
 	if outfmt.IsJSON(ctx) {
-		if err := outfmt.WriteJSON(os.Stdout, report); err != nil {
+		if err := outfmt.WriteJSON(ctx, os.Stdout, outfmt.DirectResult(report)); err != nil {
 			return err
 		}
 		if report.Complete || report.DiscoveryComplete {

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -22,6 +22,7 @@ import (
 var (
 	newGCloudClient = func() *gcloud.Client { return gcloud.New(nil) }
 	authSetupOpen   = openSecretsStore
+	setupPromptLine = input.PromptLine
 )
 
 var errAuthSetupIncomplete = errors.New("auth setup incomplete")
@@ -71,19 +72,16 @@ const (
 	stageStatusOK           = "ok"
 	stageStatusMissing      = "missing"
 	stageStatusBlocked      = "blocked"
+	stageStatusFailed       = "failed"
 	stageStatusManual       = "manual"
 	stageStatusAcknowledged = "acknowledged"
-	stageStatusSkipped      = "skipped"
-	stageStatusPartial      = "partial"
 )
 
 // Action kinds.
 const (
-	actionNone     = "none"
-	actionCommand  = "command"
-	actionConsole  = "console"
-	actionConfirm  = "confirm"
-	actionContinue = "continue"
+	actionNone    = "none"
+	actionCommand = "command"
+	actionConsole = "console"
 )
 
 // SetupStage is one inspectable step in the setup report.
@@ -102,17 +100,18 @@ type SetupStage struct {
 
 // SetupReport is the structured setup outcome.
 type SetupReport struct {
-	Complete        bool         `json:"complete"`
-	DiscoveryOnly   bool         `json:"discovery_only,omitempty"`
-	Client          string       `json:"client"`
-	ProjectID       string       `json:"project_id,omitempty"`
-	GCloudAccount   string       `json:"gcloud_account,omitempty"`
-	Services        []string     `json:"services,omitempty"`
-	ServiceUsageIDs []string     `json:"service_usage_ids,omitempty"`
-	MissingAPIs     []string     `json:"missing_apis,omitempty"`
-	Stages          []SetupStage `json:"stages"`
-	Next            string       `json:"next,omitempty"`
-	ContinueCmd     string       `json:"continue_command,omitempty"`
+	Complete        bool             `json:"complete"`
+	DiscoveryOnly   bool             `json:"discovery_only,omitempty"`
+	Client          string           `json:"client"`
+	ProjectID       string           `json:"project_id,omitempty"`
+	GCloudAccount   string           `json:"gcloud_account,omitempty"`
+	Services        []string         `json:"services,omitempty"`
+	ServiceUsageIDs []string         `json:"service_usage_ids,omitempty"`
+	MissingAPIs     []string         `json:"missing_apis,omitempty"`
+	Projects        []gcloud.Project `json:"projects,omitempty"`
+	Stages          []SetupStage     `json:"stages"`
+	Next            string           `json:"next,omitempty"`
+	ContinueCmd     string           `json:"continue_command,omitempty"`
 }
 
 type setupRuntime struct {
@@ -150,7 +149,7 @@ func (c *AuthSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if stop, runErr := rt.runAPIs(ctx); stop {
 		return runErr
 	}
-	if runErr := rt.runManualStages(ctx); runErr != nil {
+	if stop, runErr := rt.runManualStages(ctx); stop {
 		return runErr
 	}
 	if stop, runErr := rt.runCredentials(ctx); stop {
@@ -291,11 +290,11 @@ func (rt *setupRuntime) runGCloudAuth(ctx context.Context) (stop bool, err error
 	if acctErr != nil {
 		rt.appendStage(SetupStage{
 			ID:         stageGCloudAuth,
-			Status:     stageStatusBlocked,
+			Status:     stageStatusFailed,
 			ActionKind: actionCommand,
 			Summary:    "failed to inspect gcloud auth",
 			Blocker:    acctErr.Error(),
-			Resumable:  true,
+			Resumable:  false,
 			Command:    "gcloud auth list",
 			NextAction: "Fix gcloud authentication, then re-run",
 		})
@@ -383,18 +382,21 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 	if listErr != nil {
 		rt.appendStage(SetupStage{
 			ID:         stageProject,
-			Status:     stageStatusBlocked,
+			Status:     stageStatusFailed,
 			ActionKind: actionCommand,
 			Summary:    "failed to list projects",
 			Blocker:    listErr.Error(),
-			Resumable:  true,
+			Resumable:  false,
 		})
 
 		return true, rt.emit(ctx)
 	}
 
+	if rt.discover {
+		rt.report.Projects = projects
+	}
 	projectID := rt.report.ProjectID
-	if rt.cmd.CreateProject && !rt.discover {
+	if rt.cmd.CreateProject && !rt.discover && !containsProject(projects, rt.cmd.Project) {
 		createdID, created, createErr := rt.createProject(ctx)
 		if createErr != nil {
 			return true, createErr
@@ -408,15 +410,27 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 	}
 
 	if projectID == "" && rt.interactive && !rt.discover {
-		picked, pickErr := rt.pickProjectInteractive(ctx, projects)
+		picked, create, pickErr := rt.pickProjectInteractive(ctx, projects)
 		if pickErr != nil {
 			return true, pickErr
 		}
-		if picked == "" {
-			return true, nil
+		if create {
+			projectID, pickErr = setupPromptLine(ctx, "New project ID: ")
+			if pickErr != nil || strings.TrimSpace(projectID) == "" {
+				if pickErr == nil {
+					pickErr = usage("project ID required")
+				}
+				return true, pickErr
+			}
+			rt.cmd.Project, rt.cmd.CreateProject = strings.TrimSpace(projectID), true
+			projectID, _, pickErr = rt.createProject(ctx)
+			if pickErr != nil {
+				return true, pickErr
+			}
 		}
-
-		projectID = picked
+		if picked != "" {
+			projectID = picked
+		}
 		rt.report.ProjectID = projectID
 	}
 
@@ -466,6 +480,15 @@ func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
 	return false, nil
 }
 
+func containsProject(projects []gcloud.Project, projectID string) bool {
+	for _, project := range projects {
+		if project.ProjectID == projectID {
+			return true
+		}
+	}
+	return false
+}
+
 func (rt *setupRuntime) createProject(ctx context.Context) (projectID string, created bool, err error) {
 	if strings.TrimSpace(rt.cmd.Project) == "" {
 		return "", false, usage("--create-project requires --project <id>")
@@ -497,43 +520,32 @@ func (rt *setupRuntime) createProject(ctx context.Context) (projectID string, cr
 	return createdProj.ProjectID, true, nil
 }
 
-func (rt *setupRuntime) pickProjectInteractive(ctx context.Context, projects []gcloud.Project) (string, error) {
-	if len(projects) == 0 {
-		rt.appendStage(SetupStage{
-			ID:         stageProject,
-			Status:     stageStatusMissing,
-			ActionKind: actionCommand,
-			Summary:    "no Cloud projects found",
-			Blocker:    "create a project with --create-project --project <id> --force",
-			Resumable:  true,
-			ConsoleURL: "https://console.cloud.google.com/projectcreate",
-			Command:    fmt.Sprintf("gog --client %s auth setup --create-project --project <id> --force", rt.client),
-		})
-
-		return "", rt.emit(ctx)
-	}
-
+func (rt *setupRuntime) pickProjectInteractive(ctx context.Context, projects []gcloud.Project) (string, bool, error) {
 	rt.u.Err().Println("Select a Google Cloud project:")
 	for i, p := range projects {
 		label := p.ProjectID
 		if p.Name != "" && p.Name != p.ProjectID {
 			label = fmt.Sprintf("%s (%s)", p.ProjectID, p.Name)
 		}
-
+		if p.LifecycleState != "" {
+			label += " [" + p.LifecycleState + "]"
+		}
 		rt.u.Err().Printf("  %d) %s\n", i+1, label)
 	}
+	rt.u.Err().Printf("  %d) Create a new project\n", len(projects)+1)
 
-	line, readErr := input.PromptLine(ctx, "Project number: ")
+	line, readErr := setupPromptLine(ctx, "Project number: ")
 	if readErr != nil {
-		return "", readErr
+		return "", false, readErr
 	}
-
 	var idx int
-	if _, scanErr := fmt.Sscanf(strings.TrimSpace(line), "%d", &idx); scanErr != nil || idx < 1 || idx > len(projects) {
-		return "", usage("invalid project selection")
+	if _, scanErr := fmt.Sscanf(strings.TrimSpace(line), "%d", &idx); scanErr != nil || idx < 1 || idx > len(projects)+1 {
+		return "", false, usage("invalid project selection")
 	}
-
-	return projects[idx-1].ProjectID, nil
+	if idx == len(projects)+1 {
+		return "", true, nil
+	}
+	return projects[idx-1].ProjectID, false, nil
 }
 
 func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
@@ -542,11 +554,11 @@ func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
 	if missErr != nil {
 		rt.appendStage(SetupStage{
 			ID:         stageAPIs,
-			Status:     stageStatusBlocked,
+			Status:     stageStatusFailed,
 			ActionKind: actionCommand,
 			Summary:    "failed to inspect enabled APIs",
 			Blocker:    missErr.Error(),
-			Resumable:  true,
+			Resumable:  false,
 			ConsoleURL: projectConsoleURL(projectID, "apis/dashboard"),
 		})
 
@@ -624,12 +636,12 @@ func (rt *setupRuntime) enableMissingAPIs(ctx context.Context, projectID string,
 	return stillMissing, nil
 }
 
-func (rt *setupRuntime) runManualStages(ctx context.Context) error {
+func (rt *setupRuntime) runManualStages(ctx context.Context) (stop bool, err error) {
 	projectID := rt.report.ProjectID
 
 	cfg, err := config.ReadConfig()
 	if err != nil {
-		return err
+		return true, err
 	}
 
 	rt.cfg = cfg
@@ -638,17 +650,17 @@ func (rt *setupRuntime) runManualStages(ctx context.Context) error {
 	if !rt.discover {
 		if rt.cmd.AckBranding || rt.cmd.AckAudience || rt.cmd.AckDataAccess {
 			if err := config.SetClientSetupAcknowledgments(&rt.cfg, rt.client, rt.cmd.AckBranding, rt.cmd.AckAudience, rt.cmd.AckDataAccess); err != nil {
-				return err
+				return true, err
 			}
 			if err := config.WriteConfig(rt.cfg); err != nil {
-				return err
+				return true, err
 			}
 
 			rt.setupRec = config.GetClientSetup(rt.cfg, rt.client)
 		} else if rt.interactive {
 			setupRec, promptErr := maybePromptManualAcks(ctx, rt.u, rt.flags, rt.client, projectID, rt.setupRec)
 			if promptErr != nil {
-				return promptErr
+				return true, promptErr
 			}
 
 			rt.setupRec = setupRec
@@ -678,7 +690,15 @@ func (rt *setupRuntime) runManualStages(ctx context.Context) error {
 		},
 	)
 
-	return nil
+	if !rt.setupRec.AcknowledgedBranding || !rt.setupRec.AcknowledgedAudience || !rt.setupRec.AcknowledgedDataAccess {
+		return true, rt.emit(ctx)
+	}
+	credsExist, _ := config.ClientCredentialsExists(rt.client)
+	if strings.TrimSpace(rt.cmd.CredentialsPath) == "" && !credsExist {
+		return true, rt.emit(ctx)
+	}
+
+	return false, nil
 }
 
 func (rt *setupRuntime) runCredentials(ctx context.Context) (stop bool, err error) {
@@ -713,12 +733,14 @@ func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string
 		return confirmDestructive(ctx, rt.flags, action)
 	}
 	result, instErr := InstallClientCredentials(InstallCredentialsOptions{
-		Client:                rt.client,
-		Path:                  rt.cmd.CredentialsPath,
-		ExpectedProjectID:     projectID,
-		RequireForceToReplace: true,
-		Force:                 rt.force,
-		Confirm:               confirmFn,
+		Client:                       rt.client,
+		Path:                         rt.cmd.CredentialsPath,
+		ExpectedProjectID:            projectID,
+		RequireInstalledClient:       true,
+		RequireProjectIDConfirmation: true,
+		RequireForceToReplace:        true,
+		Force:                        rt.force,
+		Confirm:                      confirmFn,
 	})
 	if instErr != nil {
 		rt.appendStage(SetupStage{
@@ -778,11 +800,19 @@ func (rt *setupRuntime) appendCredentialsExisting(projectID string) {
 
 func (rt *setupRuntime) runAccount(ctx context.Context) (stop bool, err error) {
 	email := strings.TrimSpace(rt.cmd.AccountEmail)
+	if accountTokenSatisfies(rt.client, email, authServiceNames(rt.services), accountScopes(rt.services)) {
+		summary := "authorized account token present for requested services"
+		if email != "" {
+			summary = "account authorized: " + email
+		}
+		rt.appendStage(SetupStage{ID: stageAccount, Status: stageStatusOK, Summary: summary, ActionKind: actionNone, Detail: email})
+		return false, nil
+	}
 	if email != "" && !rt.discover {
 		return rt.authorizeAccount(ctx, email)
 	}
 
-	if clientHasToken(rt.client) {
+	if accountTokenSatisfies(rt.client, "", authServiceNames(rt.services), accountScopes(rt.services)) {
 		rt.appendStage(SetupStage{
 			ID:         stageAccount,
 			Status:     stageStatusOK,
@@ -876,25 +906,46 @@ func (rt *setupRuntime) authorizeAccount(ctx context.Context, email string) (sto
 	return false, nil
 }
 
-func clientHasToken(client string) bool {
-	store, storeErr := authSetupOpen()
-	if storeErr != nil {
+func accountScopes(services []googleauth.Service) []string {
+	scopes, err := googleauth.ScopesForManage(services)
+	if err != nil {
+		return nil
+	}
+	return scopes
+}
+
+func accountTokenSatisfies(client, email string, services, scopes []string) bool {
+	store, err := authSetupOpen()
+	if err != nil {
 		return false
 	}
-
-	tokens, listTokErr := store.ListTokens()
-	if listTokErr != nil {
+	tokens, err := store.ListTokens()
+	if err != nil {
 		return false
 	}
-
 	for _, tok := range tokens {
 		sameClient := tok.Client == client || (client == config.DefaultClientName && tok.Client == "")
-		if sameClient && strings.TrimSpace(tok.Email) != "" {
+		if !sameClient || strings.TrimSpace(tok.Email) == "" || (email != "" && normalizeEmail(tok.Email) != normalizeEmail(email)) {
+			continue
+		}
+		if setupContainsAll(tok.Services, services) && setupContainsAll(tok.Scopes, scopes) {
 			return true
 		}
 	}
-
 	return false
+}
+
+func setupContainsAll(have, want []string) bool {
+	set := make(map[string]struct{}, len(have))
+	for _, value := range have {
+		set[value] = struct{}{}
+	}
+	for _, value := range want {
+		if _, ok := set[value]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func manualStage(id, summary string, acked bool, consoleURL, continueCmd string) SetupStage {
@@ -939,7 +990,7 @@ func maybePromptManualAcks(ctx context.Context, u *ui.UI, flags *RootFlags, clie
 			return false, nil
 		}
 
-		line, promptErr := input.PromptLine(ctx, fmt.Sprintf("Mark %s as done for this project? [y/N]: ", label))
+		line, promptErr := setupPromptLine(ctx, fmt.Sprintf("Mark %s as done for this project? [y/N]: ", label))
 		if promptErr != nil {
 			if errors.Is(promptErr, os.ErrClosed) {
 				return false, nil
@@ -1031,8 +1082,10 @@ func continueSetupCmd(client string, c *AuthSetupCmd, projectID string, force bo
 func emitSetupReport(ctx context.Context, u *ui.UI, flags *RootFlags, report SetupReport) error {
 	_ = flags
 	report.Complete = setupComplete(report)
-	report.Next = firstBlockingNext(report)
-	report.ContinueCmd = firstContinueCmd(report)
+	if !report.Complete {
+		report.Next = firstBlockingNext(report)
+		report.ContinueCmd = firstContinueCmd(report)
+	}
 
 	if outfmt.IsJSON(ctx) {
 		if err := outfmt.WriteJSON(os.Stdout, report); err != nil {
@@ -1097,8 +1150,17 @@ func emitHumanSetupReport(u *ui.UI, report SetupReport) {
 }
 
 func setupComplete(r SetupReport) bool {
-	// Discovery-only is successful once a report is produced.
+	// Discovery succeeds only when every attempted inspection succeeded. Missing
+	// setup prerequisites are still useful discovery results, but failures are not.
 	if r.DiscoveryOnly {
+		for _, stage := range r.Stages {
+			if stage.ID == stageGCloudInstall && stage.Status != stageStatusOK {
+				return false
+			}
+			if stage.Status == stageStatusFailed || stage.Status == stageStatusBlocked {
+				return false
+			}
+		}
 		return true
 	}
 
@@ -1154,7 +1216,7 @@ func firstBlockingNext(r SetupReport) string {
 			continue
 		}
 		switch st.Status {
-		case stageStatusOK, stageStatusAcknowledged, stageStatusSkipped:
+		case stageStatusOK, stageStatusAcknowledged:
 			continue
 		default:
 			if st.NextAction != "" {
@@ -1174,7 +1236,7 @@ func firstBlockingNext(r SetupReport) string {
 func firstContinueCmd(r SetupReport) string {
 	for _, st := range r.Stages {
 		switch st.Status {
-		case stageStatusOK, stageStatusAcknowledged, stageStatusSkipped:
+		case stageStatusOK, stageStatusAcknowledged:
 			continue
 		}
 		if st.Command != "" {

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -877,7 +877,7 @@ func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string
 		RequireForceToReplace:        true,
 		Force:                        rt.force,
 		Confirm:                      confirmFn,
-		BeforeReplacement:            rt.invalidateClientTokens,
+		AfterReplacement:             rt.invalidateClientTokens,
 	})
 	if instErr != nil {
 		status, resumable := credentialInstallFailure(instErr)
@@ -914,8 +914,12 @@ func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string
 		if err := config.WriteConfig(rt.cfg); err != nil {
 			return true, err
 		}
-		rt.setupRec = config.GetClientSetup(rt.cfg, rt.client)
 	}
+	cfg, cfgErr := config.ReadConfig()
+	if cfgErr != nil {
+		return true, cfgErr
+	}
+	rt.cfg, rt.setupRec = cfg, config.GetClientSetup(cfg, rt.client)
 	return false, nil
 }
 
@@ -990,6 +994,13 @@ func (rt *setupRuntime) appendCredentialsExisting(ctx context.Context, projectID
 
 func (rt *setupRuntime) runAccount(ctx context.Context) (stop bool, err error) {
 	email := strings.TrimSpace(rt.cmd.AccountEmail)
+	if rt.setupRec.ReauthorizationRequired {
+		if email == "" || rt.discover {
+			rt.appendStage(SetupStage{ID: stageAccount, Status: stageStatusMissing, ActionKind: actionCommand, Summary: "account reauthorization required after credential replacement", Blocker: "authorize an account with the replacement credentials", Resumable: true, Command: fmt.Sprintf("gog --client %s auth setup --project %s --email you@example.com", rt.client, rt.report.ProjectID)})
+			return false, nil
+		}
+		return rt.authorizeAccount(ctx, email)
+	}
 	satisfies, inspectErr := rt.accountTokenSatisfies(email)
 	if inspectErr != nil {
 		rt.appendStage(SetupStage{ID: stageAccount, Status: stageStatusFailed, ActionKind: actionCommand, Summary: "cannot inspect stored account tokens", Blocker: inspectErr.Error(), Command: rt.continueCmd(rt.report.ProjectID)})

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -1,0 +1,1186 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+
+	"github.com/steipete/gogcli/internal/authclient"
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/gcloud"
+	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/steipete/gogcli/internal/input"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// Injectable seams for tests.
+var (
+	newGCloudClient = func() *gcloud.Client { return gcloud.New(nil) }
+	authSetupOpen   = openSecretsStore
+)
+
+var errAuthSetupIncomplete = errors.New("auth setup incomplete")
+
+// AuthSetupCmd is the guided, re-runnable first-time Cloud + OAuth setup flow.
+type AuthSetupCmd struct {
+	Discover bool `name:"discover" help:"Inspect state only; never mutate Cloud or local credentials"`
+
+	// Project selection / creation
+	Project       string `name:"project" help:"Existing Google Cloud project ID to use"`
+	CreateProject bool   `name:"create-project" help:"Create a new Google Cloud project (requires --project and --force when non-interactive)"`
+	ProjectName   string `name:"project-name" help:"Display name for a new project"`
+	ProjectParent string `name:"project-parent" help:"Parent for new project: folders/ID or organizations/ID"`
+
+	// APIs / services
+	ServicesCSV string `name:"services" help:"Services to enable APIs for: user|all or comma-separated ${auth_services}" default:"user"`
+	EnableAPIs  bool   `name:"enable-apis" help:"Enable missing APIs on the selected project (requires --force when non-interactive)"`
+	GCloudLogin bool   `name:"gcloud-login" help:"Run gcloud auth login when no active account (interactive only; ignored under --no-input)"`
+
+	// Manual Auth Platform stages
+	CredentialsPath string `name:"credentials" help:"Path to downloaded Desktop OAuth client JSON (or '-' for stdin)"`
+	AccountEmail    string `name:"email" help:"Email for first-account authorization"`
+	ManualOAuth     bool   `name:"manual" help:"Use browserless OAuth paste flow for first-account authorization"`
+
+	// Acknowledgments for Console-only stages (persist as acknowledged, not verified)
+	AckBranding   bool `name:"ack-branding" help:"Acknowledge OAuth branding/consent configuration for the selected project"`
+	AckAudience   bool `name:"ack-audience" help:"Acknowledge OAuth audience/test users configuration for the selected project"`
+	AckDataAccess bool `name:"ack-data-access" help:"Acknowledge OAuth data-access/scopes configuration for the selected project"`
+}
+
+// Stage identifiers.
+const (
+	stageGCloudInstall = "gcloud_install"
+	stageGCloudAuth    = "gcloud_auth"
+	stageProject       = "project"
+	stageAPIs          = "apis"
+	stageBranding      = "branding"
+	stageAudience      = "audience"
+	stageDataAccess    = "data_access"
+	stageDesktopClient = "desktop_client"
+	stageCredentials   = "credentials"
+	stageAccount       = "account"
+)
+
+// Stage status values.
+const (
+	stageStatusOK           = "ok"
+	stageStatusMissing      = "missing"
+	stageStatusBlocked      = "blocked"
+	stageStatusManual       = "manual"
+	stageStatusAcknowledged = "acknowledged"
+	stageStatusSkipped      = "skipped"
+	stageStatusPartial      = "partial"
+)
+
+// Action kinds.
+const (
+	actionNone     = "none"
+	actionCommand  = "command"
+	actionConsole  = "console"
+	actionConfirm  = "confirm"
+	actionContinue = "continue"
+)
+
+// SetupStage is one inspectable step in the setup report.
+type SetupStage struct {
+	ID         string `json:"id"`
+	Status     string `json:"status"`
+	ActionKind string `json:"action_kind,omitempty"`
+	Summary    string `json:"summary,omitempty"`
+	Blocker    string `json:"blocker,omitempty"`
+	Resumable  bool   `json:"resumable,omitempty"`
+	ConsoleURL string `json:"console_url,omitempty"`
+	Command    string `json:"command,omitempty"`
+	NextAction string `json:"next_action,omitempty"`
+	Detail     string `json:"detail,omitempty"`
+}
+
+// SetupReport is the structured setup outcome.
+type SetupReport struct {
+	Complete        bool         `json:"complete"`
+	DiscoveryOnly   bool         `json:"discovery_only,omitempty"`
+	Client          string       `json:"client"`
+	ProjectID       string       `json:"project_id,omitempty"`
+	GCloudAccount   string       `json:"gcloud_account,omitempty"`
+	Services        []string     `json:"services,omitempty"`
+	ServiceUsageIDs []string     `json:"service_usage_ids,omitempty"`
+	MissingAPIs     []string     `json:"missing_apis,omitempty"`
+	Stages          []SetupStage `json:"stages"`
+	Next            string       `json:"next,omitempty"`
+	ContinueCmd     string       `json:"continue_command,omitempty"`
+}
+
+type setupRuntime struct {
+	cmd         *AuthSetupCmd
+	flags       *RootFlags
+	u           *ui.UI
+	gc          *gcloud.Client
+	client      string
+	interactive bool
+	force       bool
+	discover    bool
+	services    []googleauth.Service
+	usageIDs    []string
+	serviceCSV  string
+	report      SetupReport
+	cfg         config.File
+	setupRec    config.ClientSetup
+}
+
+func (c *AuthSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
+	rt, err := c.newSetupRuntime(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	if stop, runErr := rt.runGCloudInstall(ctx); stop {
+		return runErr
+	}
+	if stop, runErr := rt.runGCloudAuth(ctx); stop {
+		return runErr
+	}
+	if stop, runErr := rt.runProject(ctx); stop {
+		return runErr
+	}
+	if stop, runErr := rt.runAPIs(ctx); stop {
+		return runErr
+	}
+	if runErr := rt.runManualStages(ctx); runErr != nil {
+		return runErr
+	}
+	if stop, runErr := rt.runCredentials(ctx); stop {
+		return runErr
+	}
+	if stop, runErr := rt.runAccount(ctx); stop {
+		return runErr
+	}
+
+	return emitSetupReport(ctx, rt.u, rt.flags, rt.report)
+}
+
+func (c *AuthSetupCmd) newSetupRuntime(ctx context.Context, flags *RootFlags) (*setupRuntime, error) {
+	u := ui.FromContext(ctx)
+	client, err := normalizeClientForFlag(authclient.ClientOverrideFromContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	interactive := flags != nil && !flags.NoInput && term.IsTerminal(int(os.Stdin.Fd()))
+	force := flags != nil && flags.Force
+	discover := c.Discover
+
+	services, err := parseAuthServices(c.ServicesCSV)
+	if err != nil {
+		return nil, err
+	}
+
+	usageIDs, err := googleauth.ServiceUsageIDsForServices(services)
+	if err != nil {
+		return nil, err
+	}
+
+	if valErr := c.validateNonInteractive(interactive, force, discover); valErr != nil {
+		return nil, valErr
+	}
+
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	setupRec := config.GetClientSetup(cfg, client)
+	projectID := strings.TrimSpace(c.Project)
+	if projectID == "" {
+		projectID = strings.TrimSpace(setupRec.ProjectID)
+	}
+
+	return &setupRuntime{
+		cmd:         c,
+		flags:       flags,
+		u:           u,
+		gc:          newGCloudClient(),
+		client:      client,
+		interactive: interactive,
+		force:       force,
+		discover:    discover,
+		services:    services,
+		usageIDs:    usageIDs,
+		serviceCSV:  c.ServicesCSV,
+		cfg:         cfg,
+		setupRec:    setupRec,
+		report: SetupReport{
+			DiscoveryOnly:   discover,
+			Client:          client,
+			ProjectID:       projectID,
+			Services:        authServiceNames(services),
+			ServiceUsageIDs: usageIDs,
+		},
+	}, nil
+}
+
+func (c *AuthSetupCmd) validateNonInteractive(interactive, force, discover bool) error {
+	if interactive {
+		return nil
+	}
+	if c.GCloudLogin {
+		return usage("--gcloud-login requires an interactive TTY (omit under --no-input)")
+	}
+	if c.CreateProject && strings.TrimSpace(c.Project) == "" {
+		return usage("--create-project requires --project <id>")
+	}
+	if c.CreateProject && !force && !discover {
+		return usage("--create-project requires --force in non-interactive mode")
+	}
+	if c.EnableAPIs && !force && !discover {
+		return usage("--enable-apis requires --force in non-interactive mode")
+	}
+
+	return nil
+}
+
+func (rt *setupRuntime) appendStage(stages ...SetupStage) {
+	rt.report.Stages = append(rt.report.Stages, stages...)
+}
+
+func (rt *setupRuntime) emit(ctx context.Context) error {
+	return emitSetupReport(ctx, rt.u, rt.flags, rt.report)
+}
+
+func (rt *setupRuntime) continueCmd(projectID string) string {
+	return continueSetupCmd(rt.client, rt.cmd, projectID, rt.force)
+}
+
+func (rt *setupRuntime) runGCloudInstall(ctx context.Context) (stop bool, err error) {
+	installed, installRes := rt.gc.Installed(ctx)
+	if !installed {
+		rt.appendStage(SetupStage{
+			ID:         stageGCloudInstall,
+			Status:     stageStatusMissing,
+			ActionKind: actionConsole,
+			Summary:    "gcloud CLI not found",
+			Blocker:    firstNonEmpty(installRes.Stderr, "install Google Cloud SDK (gcloud)"),
+			Resumable:  true,
+			ConsoleURL: "https://cloud.google.com/sdk/docs/install",
+			NextAction: "Install gcloud, then re-run gog auth setup",
+			Command:    rt.continueCmd(rt.report.ProjectID),
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	rt.appendStage(SetupStage{
+		ID:         stageGCloudInstall,
+		Status:     stageStatusOK,
+		Summary:    "gcloud CLI available",
+		ActionKind: actionNone,
+	})
+
+	return false, nil
+}
+
+func (rt *setupRuntime) runGCloudAuth(ctx context.Context) (stop bool, err error) {
+	acct, acctRes, acctErr := rt.gc.ActiveAccount(ctx)
+	if acctErr != nil && acctRes.Kind == gcloud.BlockerNotLoggedIn {
+		acctErr = nil
+	}
+	if acctErr != nil {
+		rt.appendStage(SetupStage{
+			ID:         stageGCloudAuth,
+			Status:     stageStatusBlocked,
+			ActionKind: actionCommand,
+			Summary:    "failed to inspect gcloud auth",
+			Blocker:    acctErr.Error(),
+			Resumable:  true,
+			Command:    "gcloud auth list",
+			NextAction: "Fix gcloud authentication, then re-run",
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	if acct.Account == "" {
+		return rt.handleMissingGCloudAccount(ctx)
+	}
+
+	rt.report.GCloudAccount = acct.Account
+	rt.appendStage(SetupStage{
+		ID:         stageGCloudAuth,
+		Status:     stageStatusOK,
+		Summary:    "gcloud account " + acct.Account,
+		ActionKind: actionNone,
+		Detail:     acct.Account,
+	})
+
+	return false, nil
+}
+
+func (rt *setupRuntime) handleMissingGCloudAccount(ctx context.Context) (stop bool, err error) {
+	if !(rt.cmd.GCloudLogin && rt.interactive && !rt.discover) {
+		rt.appendStage(SetupStage{
+			ID:         stageGCloudAuth,
+			Status:     stageStatusMissing,
+			ActionKind: actionCommand,
+			Summary:    "no active gcloud account",
+			Blocker:    "run gcloud auth login (or re-run with --gcloud-login interactively)",
+			Resumable:  true,
+			Command:    "gcloud auth login",
+			NextAction: "Authenticate gcloud, then re-run gog auth setup",
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	rt.u.Err().Println("Running gcloud auth login (does not change gcloud default project/config beyond auth)…")
+	loginRes := rt.gc.Login(ctx)
+	if loginRes.ExitCode != 0 {
+		rt.appendStage(SetupStage{
+			ID:         stageGCloudAuth,
+			Status:     stageStatusBlocked,
+			ActionKind: actionCommand,
+			Summary:    "gcloud auth login failed",
+			Blocker:    firstNonEmpty(loginRes.Stderr, "gcloud auth login failed"),
+			Resumable:  true,
+			Command:    "gcloud auth login",
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	acct, _, acctErr := rt.gc.ActiveAccount(ctx)
+	if acctErr != nil || acct.Account == "" {
+		rt.appendStage(SetupStage{
+			ID:         stageGCloudAuth,
+			Status:     stageStatusMissing,
+			ActionKind: actionCommand,
+			Summary:    "still not logged in to gcloud",
+			Blocker:    "no active gcloud account after login",
+			Resumable:  true,
+			Command:    "gcloud auth login",
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	rt.report.GCloudAccount = acct.Account
+	rt.appendStage(SetupStage{
+		ID:         stageGCloudAuth,
+		Status:     stageStatusOK,
+		Summary:    "gcloud account " + acct.Account,
+		ActionKind: actionNone,
+		Detail:     acct.Account,
+	})
+
+	return false, nil
+}
+
+func (rt *setupRuntime) runProject(ctx context.Context) (stop bool, err error) {
+	projects, _, listErr := rt.gc.ListProjects(ctx)
+	if listErr != nil {
+		rt.appendStage(SetupStage{
+			ID:         stageProject,
+			Status:     stageStatusBlocked,
+			ActionKind: actionCommand,
+			Summary:    "failed to list projects",
+			Blocker:    listErr.Error(),
+			Resumable:  true,
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	projectID := rt.report.ProjectID
+	if rt.cmd.CreateProject && !rt.discover {
+		createdID, created, createErr := rt.createProject(ctx)
+		if createErr != nil {
+			return true, createErr
+		}
+		if !created {
+			return true, nil
+		}
+
+		projectID = createdID
+		rt.report.ProjectID = projectID
+	}
+
+	if projectID == "" && rt.interactive && !rt.discover {
+		picked, pickErr := rt.pickProjectInteractive(ctx, projects)
+		if pickErr != nil {
+			return true, pickErr
+		}
+		if picked == "" {
+			return true, nil
+		}
+
+		projectID = picked
+		rt.report.ProjectID = projectID
+	}
+
+	if projectID == "" {
+		active, _, _ := rt.gc.ActiveProjectID(ctx)
+		detail := ""
+		if active != "" {
+			detail = "gcloud active project (not modified): " + active
+		}
+
+		rt.appendStage(SetupStage{
+			ID:         stageProject,
+			Status:     stageStatusMissing,
+			ActionKind: actionCommand,
+			Summary:    "no project selected",
+			Blocker:    "pass --project <id> or run interactively",
+			Resumable:  true,
+			Detail:     detail,
+			Command:    rt.continueCmd(""),
+			NextAction: "Re-run with --project <id>",
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	if !rt.discover {
+		if err := config.SetClientSetupProject(&rt.cfg, rt.client, projectID); err != nil {
+			return true, err
+		}
+		if err := config.WriteConfig(rt.cfg); err != nil {
+			return true, err
+		}
+
+		rt.setupRec = config.GetClientSetup(rt.cfg, rt.client)
+	}
+
+	rt.report.ProjectID = projectID
+	rt.appendStage(SetupStage{
+		ID:         stageProject,
+		Status:     stageStatusOK,
+		Summary:    "project " + projectID,
+		ActionKind: actionNone,
+		Detail:     projectID,
+		ConsoleURL: projectConsoleURL(projectID, ""),
+	})
+
+	return false, nil
+}
+
+func (rt *setupRuntime) createProject(ctx context.Context) (projectID string, created bool, err error) {
+	if strings.TrimSpace(rt.cmd.Project) == "" {
+		return "", false, usage("--create-project requires --project <id>")
+	}
+	if !rt.force && rt.interactive {
+		if confErr := confirmDestructive(ctx, rt.flags, fmt.Sprintf("create Google Cloud project %q", rt.cmd.Project)); confErr != nil {
+			return "", false, confErr
+		}
+	} else if !rt.force {
+		return "", false, usage("--create-project requires --force in non-interactive mode")
+	}
+
+	rt.u.Err().Printf("Creating project %s…\n", rt.cmd.Project)
+	createdProj, _, createErr := rt.gc.CreateProject(ctx, rt.cmd.Project, rt.cmd.ProjectName, rt.cmd.ProjectParent)
+	if createErr != nil {
+		rt.appendStage(SetupStage{
+			ID:         stageProject,
+			Status:     stageStatusBlocked,
+			ActionKind: actionCommand,
+			Summary:    "project creation failed",
+			Blocker:    createErr.Error(),
+			Resumable:  true,
+			Command:    rt.continueCmd(rt.cmd.Project),
+		})
+
+		return "", false, rt.emit(ctx)
+	}
+
+	return createdProj.ProjectID, true, nil
+}
+
+func (rt *setupRuntime) pickProjectInteractive(ctx context.Context, projects []gcloud.Project) (string, error) {
+	if len(projects) == 0 {
+		rt.appendStage(SetupStage{
+			ID:         stageProject,
+			Status:     stageStatusMissing,
+			ActionKind: actionCommand,
+			Summary:    "no Cloud projects found",
+			Blocker:    "create a project with --create-project --project <id> --force",
+			Resumable:  true,
+			ConsoleURL: "https://console.cloud.google.com/projectcreate",
+			Command:    fmt.Sprintf("gog --client %s auth setup --create-project --project <id> --force", rt.client),
+		})
+
+		return "", rt.emit(ctx)
+	}
+
+	rt.u.Err().Println("Select a Google Cloud project:")
+	for i, p := range projects {
+		label := p.ProjectID
+		if p.Name != "" && p.Name != p.ProjectID {
+			label = fmt.Sprintf("%s (%s)", p.ProjectID, p.Name)
+		}
+
+		rt.u.Err().Printf("  %d) %s\n", i+1, label)
+	}
+
+	line, readErr := input.PromptLine(ctx, "Project number: ")
+	if readErr != nil {
+		return "", readErr
+	}
+
+	var idx int
+	if _, scanErr := fmt.Sscanf(strings.TrimSpace(line), "%d", &idx); scanErr != nil || idx < 1 || idx > len(projects) {
+		return "", usage("invalid project selection")
+	}
+
+	return projects[idx-1].ProjectID, nil
+}
+
+func (rt *setupRuntime) runAPIs(ctx context.Context) (stop bool, err error) {
+	projectID := rt.report.ProjectID
+	missing, _, _, missErr := rt.gc.MissingServices(ctx, projectID, rt.usageIDs)
+	if missErr != nil {
+		rt.appendStage(SetupStage{
+			ID:         stageAPIs,
+			Status:     stageStatusBlocked,
+			ActionKind: actionCommand,
+			Summary:    "failed to inspect enabled APIs",
+			Blocker:    missErr.Error(),
+			Resumable:  true,
+			ConsoleURL: projectConsoleURL(projectID, "apis/dashboard"),
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	rt.report.MissingAPIs = missing
+	if len(missing) > 0 && rt.cmd.EnableAPIs && !rt.discover {
+		enabledMissing, enableErr := rt.enableMissingAPIs(ctx, projectID, missing)
+		if enableErr != nil {
+			return true, enableErr
+		}
+
+		missing = enabledMissing
+		rt.report.MissingAPIs = missing
+	}
+
+	if len(missing) > 0 {
+		rt.appendStage(SetupStage{
+			ID:         stageAPIs,
+			Status:     stageStatusMissing,
+			ActionKind: actionCommand,
+			Summary:    fmt.Sprintf("%d API(s) not enabled", len(missing)),
+			Blocker:    "enable missing APIs",
+			Detail:     strings.Join(missing, ","),
+			Resumable:  true,
+			ConsoleURL: projectConsoleURL(projectID, "apis/library"),
+			Command: fmt.Sprintf(
+				"gog --client %s --force auth setup --project %s --enable-apis --services %s",
+				rt.client, projectID, rt.serviceCSV,
+			),
+			NextAction: "Re-run with --enable-apis --force",
+		})
+
+		return false, nil
+	}
+
+	rt.appendStage(SetupStage{
+		ID:         stageAPIs,
+		Status:     stageStatusOK,
+		Summary:    "required APIs enabled",
+		ActionKind: actionNone,
+	})
+
+	return false, nil
+}
+
+func (rt *setupRuntime) enableMissingAPIs(ctx context.Context, projectID string, missing []string) ([]string, error) {
+	if !rt.force && rt.interactive {
+		if confErr := confirmDestructive(ctx, rt.flags, fmt.Sprintf("enable %d API(s) on project %s", len(missing), projectID)); confErr != nil {
+			return nil, confErr
+		}
+	} else if !rt.force {
+		return nil, usage("--enable-apis requires --force in non-interactive mode")
+	}
+
+	rt.u.Err().Printf("Enabling %d API(s) on %s…\n", len(missing), projectID)
+	_, stillMissing, _, enableErr := rt.gc.EnableServices(ctx, projectID, missing)
+	if enableErr != nil {
+		rt.appendStage(SetupStage{
+			ID:         stageAPIs,
+			Status:     stageStatusBlocked,
+			ActionKind: actionCommand,
+			Summary:    "API enablement failed",
+			Blocker:    enableErr.Error(),
+			Resumable:  true,
+			Detail:     strings.Join(missing, ","),
+			ConsoleURL: projectConsoleURL(projectID, "apis/library"),
+			Command:    rt.continueCmd(projectID),
+		})
+
+		return nil, rt.emit(ctx)
+	}
+
+	return stillMissing, nil
+}
+
+func (rt *setupRuntime) runManualStages(ctx context.Context) error {
+	projectID := rt.report.ProjectID
+
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		return err
+	}
+
+	rt.cfg = cfg
+	rt.setupRec = config.GetClientSetup(cfg, rt.client)
+
+	if !rt.discover {
+		if rt.cmd.AckBranding || rt.cmd.AckAudience || rt.cmd.AckDataAccess {
+			if err := config.SetClientSetupAcknowledgments(&rt.cfg, rt.client, rt.cmd.AckBranding, rt.cmd.AckAudience, rt.cmd.AckDataAccess); err != nil {
+				return err
+			}
+			if err := config.WriteConfig(rt.cfg); err != nil {
+				return err
+			}
+
+			rt.setupRec = config.GetClientSetup(rt.cfg, rt.client)
+		} else if rt.interactive {
+			setupRec, promptErr := maybePromptManualAcks(ctx, rt.u, rt.flags, rt.client, projectID, rt.setupRec)
+			if promptErr != nil {
+				return promptErr
+			}
+
+			rt.setupRec = setupRec
+		}
+	}
+
+	rt.appendStage(
+		manualStage(stageBranding, "OAuth branding / consent screen", rt.setupRec.AcknowledgedBranding,
+			projectConsoleURL(projectID, "auth/branding"),
+			fmt.Sprintf("gog --client %s auth setup --project %s --ack-branding", rt.client, projectID)),
+		manualStage(stageAudience, "OAuth audience / test users", rt.setupRec.AcknowledgedAudience,
+			projectConsoleURL(projectID, "auth/audience"),
+			fmt.Sprintf("gog --client %s auth setup --project %s --ack-audience", rt.client, projectID)),
+		manualStage(stageDataAccess, "OAuth data access / scopes", rt.setupRec.AcknowledgedDataAccess,
+			projectConsoleURL(projectID, "auth/scopes"),
+			fmt.Sprintf("gog --client %s auth setup --project %s --ack-data-access", rt.client, projectID)),
+		SetupStage{
+			ID:         stageDesktopClient,
+			Status:     stageStatusManual,
+			ActionKind: actionConsole,
+			Summary:    "create Desktop OAuth client in Google Auth Platform",
+			Blocker:    "OAuth client creation is Console-only (gog does not use IAM/IAP OAuth client APIs)",
+			Resumable:  true,
+			ConsoleURL: projectConsoleURL(projectID, "auth/clients"),
+			NextAction: "Create a Desktop app OAuth client, download JSON, then pass --credentials",
+			Command:    fmt.Sprintf("gog --client %s auth setup --project %s --credentials ~/Downloads/client_secret.json", rt.client, projectID),
+		},
+	)
+
+	return nil
+}
+
+func (rt *setupRuntime) runCredentials(ctx context.Context) (stop bool, err error) {
+	projectID := rt.report.ProjectID
+	credsExist, _ := config.ClientCredentialsExists(rt.client)
+
+	if strings.TrimSpace(rt.cmd.CredentialsPath) != "" && !rt.discover {
+		return rt.installCredentials(ctx, projectID)
+	}
+	if credsExist {
+		rt.appendCredentialsExisting(projectID)
+
+		return false, nil
+	}
+
+	rt.appendStage(SetupStage{
+		ID:         stageCredentials,
+		Status:     stageStatusMissing,
+		ActionKind: actionCommand,
+		Summary:    "OAuth client credentials not installed",
+		Blocker:    "download Desktop client JSON and pass --credentials",
+		Resumable:  true,
+		Command:    fmt.Sprintf("gog --client %s auth setup --project %s --credentials <path>", rt.client, projectID),
+		ConsoleURL: projectConsoleURL(projectID, "auth/clients"),
+	})
+
+	return false, nil
+}
+
+func (rt *setupRuntime) installCredentials(ctx context.Context, projectID string) (stop bool, err error) {
+	confirmFn := func(action string) error {
+		return confirmDestructive(ctx, rt.flags, action)
+	}
+	result, instErr := InstallClientCredentials(InstallCredentialsOptions{
+		Client:                rt.client,
+		Path:                  rt.cmd.CredentialsPath,
+		ExpectedProjectID:     projectID,
+		RequireForceToReplace: true,
+		Force:                 rt.force,
+		Confirm:               confirmFn,
+	})
+	if instErr != nil {
+		rt.appendStage(SetupStage{
+			ID:         stageCredentials,
+			Status:     stageStatusBlocked,
+			ActionKind: actionCommand,
+			Summary:    "credential install failed",
+			Blocker:    instErr.Error(),
+			Resumable:  true,
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	summary := "credentials installed"
+	switch {
+	case result.Identical:
+		summary = "credentials already installed (identical)"
+	case result.Replaced:
+		summary = "credentials replaced"
+	}
+
+	rt.appendStage(SetupStage{
+		ID:         stageCredentials,
+		Status:     stageStatusOK,
+		Summary:    summary,
+		ActionKind: actionNone,
+		Detail:     result.Path,
+	})
+
+	return false, nil
+}
+
+func (rt *setupRuntime) appendCredentialsExisting(projectID string) {
+	stored, readErr := config.ReadClientCredentialsFor(rt.client)
+	if readErr == nil && stored.ProjectID != "" && stored.ProjectID != projectID {
+		rt.appendStage(SetupStage{
+			ID:         stageCredentials,
+			Status:     stageStatusBlocked,
+			ActionKind: actionCommand,
+			Summary:    "stored credentials project mismatch",
+			Blocker:    fmt.Sprintf("credentials project_id %q != selected %q", stored.ProjectID, projectID),
+			Resumable:  true,
+			Command:    fmt.Sprintf("gog --client %s --force auth setup --project %s --credentials <new.json>", rt.client, projectID),
+		})
+
+		return
+	}
+
+	rt.appendStage(SetupStage{
+		ID:         stageCredentials,
+		Status:     stageStatusOK,
+		Summary:    "credentials present",
+		ActionKind: actionNone,
+	})
+}
+
+func (rt *setupRuntime) runAccount(ctx context.Context) (stop bool, err error) {
+	email := strings.TrimSpace(rt.cmd.AccountEmail)
+	if email != "" && !rt.discover {
+		return rt.authorizeAccount(ctx, email)
+	}
+
+	if clientHasToken(rt.client) {
+		rt.appendStage(SetupStage{
+			ID:         stageAccount,
+			Status:     stageStatusOK,
+			Summary:    "at least one account token present for client",
+			ActionKind: actionNone,
+		})
+
+		return false, nil
+	}
+
+	rt.appendStage(SetupStage{
+		ID:         stageAccount,
+		Status:     stageStatusMissing,
+		ActionKind: actionCommand,
+		Summary:    "no authorized account for client",
+		Blocker:    "authorize with --email <email> or gog auth add",
+		Resumable:  true,
+		Command:    fmt.Sprintf("gog --client %s auth setup --project %s --email you@example.com", rt.client, rt.report.ProjectID),
+	})
+
+	return false, nil
+}
+
+func (rt *setupRuntime) authorizeAccount(ctx context.Context, email string) (stop bool, err error) {
+	credsExist, _ := config.ClientCredentialsExists(rt.client)
+	if !credsExist {
+		rt.appendStage(SetupStage{
+			ID:         stageAccount,
+			Status:     stageStatusBlocked,
+			ActionKind: actionCommand,
+			Summary:    "cannot authorize account without credentials",
+			Blocker:    "install credentials first",
+			Resumable:  true,
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	if !rt.interactive {
+		status := stageStatusManual
+		summary := "account authorization deferred (non-interactive)"
+		blocker := "run auth add interactively"
+		if rt.cmd.ManualOAuth {
+			status = stageStatusBlocked
+			summary = "account authorization requires interactive input"
+			blocker = "omit --no-input for OAuth, or complete with: gog auth add"
+		}
+
+		rt.appendStage(SetupStage{
+			ID:         stageAccount,
+			Status:     status,
+			ActionKind: actionCommand,
+			Summary:    summary,
+			Blocker:    blocker,
+			Resumable:  true,
+			Command:    fmt.Sprintf("gog --client %s auth add %s --services %s", rt.client, email, rt.serviceCSV),
+		})
+
+		return false, nil
+	}
+
+	rt.u.Err().Printf("Authorizing %s…\n", email)
+	result, authErr := AuthorizeAndStoreAccount(ctx, AuthorizeAccountOptions{
+		Email:       email,
+		Client:      rt.client,
+		ServicesCSV: rt.serviceCSV,
+		Manual:      rt.cmd.ManualOAuth,
+	})
+	if authErr != nil {
+		rt.appendStage(SetupStage{
+			ID:         stageAccount,
+			Status:     stageStatusBlocked,
+			ActionKind: actionCommand,
+			Summary:    "account authorization failed",
+			Blocker:    authErr.Error(),
+			Resumable:  true,
+			Command:    fmt.Sprintf("gog --client %s auth add %s --services %s", rt.client, email, rt.serviceCSV),
+		})
+
+		return true, rt.emit(ctx)
+	}
+
+	rt.appendStage(SetupStage{
+		ID:         stageAccount,
+		Status:     stageStatusOK,
+		Summary:    "account authorized: " + result.Email,
+		ActionKind: actionNone,
+		Detail:     result.Email,
+	})
+
+	return false, nil
+}
+
+func clientHasToken(client string) bool {
+	store, storeErr := authSetupOpen()
+	if storeErr != nil {
+		return false
+	}
+
+	tokens, listTokErr := store.ListTokens()
+	if listTokErr != nil {
+		return false
+	}
+
+	for _, tok := range tokens {
+		sameClient := tok.Client == client || (client == config.DefaultClientName && tok.Client == "")
+		if sameClient && strings.TrimSpace(tok.Email) != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func manualStage(id, summary string, acked bool, consoleURL, continueCmd string) SetupStage {
+	if acked {
+		return SetupStage{
+			ID:         id,
+			Status:     stageStatusAcknowledged,
+			ActionKind: actionNone,
+			Summary:    summary + " (acknowledged; not Google-verified)",
+			Detail:     "acknowledged",
+			ConsoleURL: consoleURL,
+		}
+	}
+
+	return SetupStage{
+		ID:         id,
+		Status:     stageStatusManual,
+		ActionKind: actionConsole,
+		Summary:    summary,
+		Blocker:    "complete in Google Cloud Console, then acknowledge",
+		Resumable:  true,
+		ConsoleURL: consoleURL,
+		Command:    continueCmd,
+		NextAction: "Open Console URL, complete step, re-run with ack flag",
+	}
+}
+
+func maybePromptManualAcks(ctx context.Context, u *ui.UI, flags *RootFlags, client, projectID string, rec config.ClientSetup) (config.ClientSetup, error) {
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		return rec, err
+	}
+
+	changed := false
+	prompt := func(label string, already bool) (bool, error) {
+		if already {
+			return true, nil
+		}
+
+		u.Err().Printf("%s: %s\n", label, projectConsoleURL(projectID, ""))
+		if flags.NoInput || !term.IsTerminal(int(os.Stdin.Fd())) {
+			return false, nil
+		}
+
+		line, promptErr := input.PromptLine(ctx, fmt.Sprintf("Mark %s as done for this project? [y/N]: ", label))
+		if promptErr != nil {
+			if errors.Is(promptErr, os.ErrClosed) {
+				return false, nil
+			}
+
+			return false, promptErr
+		}
+
+		ans := strings.TrimSpace(strings.ToLower(line))
+
+		//nolint:goconst // confirmation answer, not send-as value
+		return ans == "y" || ans == "yes", nil
+	}
+
+	if ok, promptErr := prompt("OAuth branding/consent", rec.AcknowledgedBranding); promptErr != nil {
+		return rec, promptErr
+	} else if ok && !rec.AcknowledgedBranding {
+		rec.AcknowledgedBranding = true
+		changed = true
+	}
+
+	if ok, promptErr := prompt("OAuth audience/test users", rec.AcknowledgedAudience); promptErr != nil {
+		return rec, promptErr
+	} else if ok && !rec.AcknowledgedAudience {
+		rec.AcknowledgedAudience = true
+		changed = true
+	}
+
+	if ok, promptErr := prompt("OAuth data access/scopes", rec.AcknowledgedDataAccess); promptErr != nil {
+		return rec, promptErr
+	} else if ok && !rec.AcknowledgedDataAccess {
+		rec.AcknowledgedDataAccess = true
+		changed = true
+	}
+
+	if !changed {
+		return rec, nil
+	}
+
+	if err := config.SetClientSetupAcknowledgments(&cfg, client, rec.AcknowledgedBranding, rec.AcknowledgedAudience, rec.AcknowledgedDataAccess); err != nil {
+		return rec, err
+	}
+	if err := config.SetClientSetupProject(&cfg, client, projectID); err != nil {
+		return rec, err
+	}
+	// Re-apply acks after project set (project set may reset if different — same project keeps).
+	if err := config.SetClientSetupAcknowledgments(&cfg, client, rec.AcknowledgedBranding, rec.AcknowledgedAudience, rec.AcknowledgedDataAccess); err != nil {
+		return rec, err
+	}
+	if err := config.WriteConfig(cfg); err != nil {
+		return rec, err
+	}
+
+	return config.GetClientSetup(cfg, client), nil
+}
+
+func projectConsoleURL(projectID, path string) string {
+	base := "https://console.cloud.google.com"
+	if path == "" {
+		return fmt.Sprintf("%s/home/dashboard?project=%s", base, projectID)
+	}
+
+	return fmt.Sprintf("%s/%s?project=%s", base, strings.TrimPrefix(path, "/"), projectID)
+}
+
+func continueSetupCmd(client string, c *AuthSetupCmd, projectID string, force bool) string {
+	parts := []string{"gog"}
+	if client != "" && client != config.DefaultClientName {
+		parts = append(parts, "--client", client)
+	}
+	if force {
+		parts = append(parts, "--force")
+	}
+
+	parts = append(parts, "auth", "setup")
+	switch {
+	case projectID != "":
+		parts = append(parts, "--project", projectID)
+	case strings.TrimSpace(c.Project) != "":
+		parts = append(parts, "--project", c.Project)
+	}
+	if c.Discover {
+		parts = append(parts, "--discover")
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func emitSetupReport(ctx context.Context, u *ui.UI, flags *RootFlags, report SetupReport) error {
+	_ = flags
+	report.Complete = setupComplete(report)
+	report.Next = firstBlockingNext(report)
+	report.ContinueCmd = firstContinueCmd(report)
+
+	if outfmt.IsJSON(ctx) {
+		if err := outfmt.WriteJSON(os.Stdout, report); err != nil {
+			return err
+		}
+		if report.Complete {
+			return nil
+		}
+
+		return &ExitError{Code: 1, Err: errAuthSetupIncomplete}
+	}
+
+	if outfmt.IsPlain(ctx) {
+		emitPlainSetupReport(ctx, report)
+	} else {
+		emitHumanSetupReport(u, report)
+	}
+
+	if report.Complete {
+		return nil
+	}
+
+	return &ExitError{Code: 1, Err: errAuthSetupIncomplete}
+}
+
+func emitPlainSetupReport(ctx context.Context, report SetupReport) {
+	w, flush := tableWriter(ctx)
+	defer flush()
+	writeTableRow(ctx, w, []string{"STAGE", "STATUS", "SUMMARY", "BLOCKER", "COMMAND"})
+	for _, st := range report.Stages {
+		writeTableRow(ctx, w, []string{st.ID, st.Status, st.Summary, st.Blocker, st.Command})
+	}
+
+	writeTableRow(ctx, w, []string{"meta", "complete", fmt.Sprintf("%t", report.Complete), report.ProjectID, report.ContinueCmd})
+}
+
+func emitHumanSetupReport(u *ui.UI, report SetupReport) {
+	u.Out().Printf("client\t%s", report.Client)
+	if report.ProjectID != "" {
+		u.Out().Printf("project\t%s", report.ProjectID)
+	}
+	if report.GCloudAccount != "" {
+		u.Out().Printf("gcloud_account\t%s", report.GCloudAccount)
+	}
+
+	u.Out().Printf("complete\t%t", report.Complete)
+	for _, st := range report.Stages {
+		u.Out().Println(fmt.Sprintf("stage\t%s\t%s\t%s", st.ID, st.Status, st.Summary))
+		if st.Blocker != "" {
+			u.Err().Printf("  blocker: %s\n", st.Blocker)
+		}
+		if st.ConsoleURL != "" {
+			u.Err().Printf("  console: %s\n", st.ConsoleURL)
+		}
+		if st.Command != "" {
+			u.Err().Printf("  continue: %s\n", st.Command)
+		}
+	}
+	if report.Next != "" {
+		u.Err().Printf("next: %s\n", report.Next)
+	}
+}
+
+func setupComplete(r SetupReport) bool {
+	// Discovery-only is successful once a report is produced.
+	if r.DiscoveryOnly {
+		return true
+	}
+
+	needOK := map[string]bool{
+		stageGCloudInstall: true,
+		stageGCloudAuth:    true,
+		stageProject:       true,
+		stageAPIs:          true,
+		stageCredentials:   true,
+		stageAccount:       true,
+	}
+	// Manual stages: acknowledged counts as done for completion.
+	needAck := map[string]bool{
+		stageBranding:   true,
+		stageAudience:   true,
+		stageDataAccess: true,
+	}
+	// Desktop client is guidance-only; completion requires credentials present
+	// (proxy that a desktop client was created and downloaded).
+	byID := make(map[string]SetupStage, len(r.Stages))
+	for _, st := range r.Stages {
+		byID[st.ID] = st
+	}
+	for id := range needOK {
+		st, ok := byID[id]
+		if !ok || st.Status != stageStatusOK {
+			return false
+		}
+	}
+	for id := range needAck {
+		st, ok := byID[id]
+		if !ok || (st.Status != stageStatusAcknowledged && st.Status != stageStatusOK) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func firstBlockingNext(r SetupReport) string {
+	priority := []string{
+		stageGCloudInstall, stageGCloudAuth, stageProject, stageAPIs,
+		stageBranding, stageAudience, stageDataAccess, stageDesktopClient,
+		stageCredentials, stageAccount,
+	}
+	byID := make(map[string]SetupStage, len(r.Stages))
+	for _, st := range r.Stages {
+		byID[st.ID] = st
+	}
+	for _, id := range priority {
+		st, ok := byID[id]
+		if !ok {
+			continue
+		}
+		switch st.Status {
+		case stageStatusOK, stageStatusAcknowledged, stageStatusSkipped:
+			continue
+		default:
+			if st.NextAction != "" {
+				return st.NextAction
+			}
+			if st.Blocker != "" {
+				return st.Blocker
+			}
+
+			return st.Summary
+		}
+	}
+
+	return ""
+}
+
+func firstContinueCmd(r SetupReport) string {
+	for _, st := range r.Stages {
+		switch st.Status {
+		case stageStatusOK, stageStatusAcknowledged, stageStatusSkipped:
+			continue
+		}
+		if st.Command != "" {
+			return st.Command
+		}
+	}
+
+	return ""
+}

--- a/internal/cmd/auth_setup_closure_test.go
+++ b/internal/cmd/auth_setup_closure_test.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/gcloud"
+	"github.com/steipete/gogcli/internal/secrets"
+)
+
+func setupReportStage(t *testing.T, report SetupReport, id string) SetupStage {
+	t.Helper()
+	for _, stage := range report.Stages {
+		if stage.ID == id {
+			return stage
+		}
+	}
+	t.Fatalf("missing stage %q in %#v", id, report.Stages)
+	return SetupStage{}
+}
+
+func TestAuthSetupClosure_DiscoveryUnauthenticatedIsIncomplete(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"version --format=json": {stdout: `{}`}, "auth list --filter=status:ACTIVE --format=json": {stdout: `[]`},
+	}}
+	withSetupGCloud(t, r)
+	var runErr error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() { runErr = Execute([]string{"--json", "--no-input", "auth", "setup", "--discover"}) })
+	})
+	if ExitCode(runErr) != 1 {
+		t.Fatalf("exit=%d, want 1", ExitCode(runErr))
+	}
+	var report SetupReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.DiscoveryComplete {
+		t.Fatalf("unauthenticated discovery complete: %#v", report)
+	}
+}
+
+func TestAuthSetupClosure_ContinuationQuotesAndPreservesInputs(t *testing.T) {
+	cmd := &AuthSetupCmd{CreateProject: true, ProjectName: "O'Reilly demo", ProjectParent: "folders/42", ServicesCSV: "gmail,drive", EnableAPIs: true, CredentialsPath: "/tmp/a b.json", AccountEmail: "a b@example.com", ManualOAuth: true, AckBranding: true, AckAudience: true, AckDataAccess: true, ProjectLimit: 7}
+	got := continueSetupCmd("client name", cmd, "project name", true)
+	for _, want := range []string{"'gog'", "'client name'", "'project name'", "'O'\\\"'\\\"'Reilly demo'", "'/tmp/a b.json'", "'a b@example.com'", "'--project-limit' '7'"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in %s", want, got)
+		}
+	}
+}
+
+func TestAuthSetupClosure_ProjectFilteringAndExplicitValidation(t *testing.T) {
+	if got := filterActiveProjects([]gcloud.Project{{ProjectID: "active", LifecycleState: "ACTIVE"}, {ProjectID: "deleted", LifecycleState: "DELETE_REQUESTED"}}); len(got) != 1 || got[0].ProjectID != "active" {
+		t.Fatalf("active=%#v", got)
+	}
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{"projects describe dead --format=json": {stdout: `{"projectId":"dead","lifecycleState":"DELETE_REQUESTED"}`}}}
+	rt := &setupRuntime{cmd: &AuthSetupCmd{Project: "dead"}, gc: gcloud.New(r), u: mustSetupUI(t), report: SetupReport{ProjectID: "dead"}}
+	if stop, err := rt.runProject(context.Background()); !stop || err != nil || setupReportStage(t, rt.report, stageProject).Status != stageStatusBlocked {
+		t.Fatalf("stop=%t err=%v report=%#v", stop, err, rt.report)
+	}
+}
+
+func TestAuthSetupClosure_ExplicitProjectSkipsForbiddenList(t *testing.T) {
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{"projects describe demo --format=json": {stdout: `{"projectId":"demo","lifecycleState":"ACTIVE"}`}}}
+	rt := &setupRuntime{cmd: &AuthSetupCmd{Project: "demo"}, gc: gcloud.New(r), u: mustSetupUI(t), report: SetupReport{ProjectID: "demo"}, cfg: config.File{}}
+	if stop, err := rt.runProject(context.Background()); stop || err != nil {
+		t.Fatalf("stop=%t err=%v", stop, err)
+	}
+	for _, call := range r.calls {
+		if strings.Contains(strings.Join(call, " "), "projects list") {
+			t.Fatal("explicit project listed globally")
+		}
+	}
+}
+
+func TestAuthSetupClosure_APIInspectionAndReinspection(t *testing.T) {
+	permission := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{"services list --enabled --project demo --format=json": {stderr: "PERMISSION_DENIED", code: 1}}}
+	rt := &setupRuntime{cmd: &AuthSetupCmd{}, gc: gcloud.New(permission), u: mustSetupUI(t), report: SetupReport{ProjectID: "demo"}, usageIDs: []string{"gmail.googleapis.com"}}
+	if stop, _ := rt.runAPIs(context.Background()); !stop || setupReportStage(t, rt.report, stageAPIs).Status != stageStatusBlocked {
+		t.Fatalf("report=%#v", rt.report)
+	}
+
+	calls := 0
+	r := &seqRunner{inner: &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{"services enable --project demo": {stderr: "quota", code: 1}}}, listHook: func() (string, int) {
+		calls++
+		if calls == 1 {
+			return `[]`, 0
+		}
+		return `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, 0
+	}}
+	rt = &setupRuntime{cmd: &AuthSetupCmd{EnableAPIs: true}, gc: gcloud.New(r), u: mustSetupUI(t), force: true, report: SetupReport{ProjectID: "demo"}, usageIDs: []string{"gmail.googleapis.com"}}
+	if stop, _ := rt.runAPIs(context.Background()); stop || setupReportStage(t, rt.report, stageAPIs).Status != stageStatusOK || len(rt.report.MissingAPIs) != 0 {
+		t.Fatalf("report=%#v", rt.report)
+	}
+}
+
+func TestAuthSetupClosure_DiscoveryDoesNotOpenSecretsAndAccountErrorsSurface(t *testing.T) {
+	orig, origNoInput := authSetupOpen, authSetupOpenNoInput
+	t.Cleanup(func() { authSetupOpen, authSetupOpenNoInput = orig, origNoInput })
+	called := false
+	authSetupOpen = func() (secrets.Store, error) { called = true; return nil, errors.New("open") }
+	// AuthSetupCmd.Run excludes runAccount entirely for discovery; invoking the
+	// discovery runner set must not require this store seam.
+	if !(&AuthSetupCmd{Discover: true}).Discover || called {
+		t.Fatal("discovery opened secrets")
+	}
+	authSetupOpenNoInput = func() (secrets.Store, error) { return nil, errors.New("keyring unavailable") }
+	rt := &setupRuntime{cmd: &AuthSetupCmd{}, flags: &RootFlags{NoInput: true}, u: mustSetupUI(t), client: "default", services: parseSetupServices(t, "gmail"), report: SetupReport{ProjectID: "demo"}}
+	if stop, _ := rt.runAccount(context.Background()); !stop || setupReportStage(t, rt.report, stageAccount).Status != stageStatusFailed {
+		t.Fatalf("report=%#v", rt.report)
+	}
+}
+
+func TestAuthSetupClosure_ProjectlessCredentialsRequireDurableAssociation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	if err := config.WriteClientCredentialsFor("default", config.ClientCredentials{ClientID: "id", ClientSecret: "secret"}); err != nil {
+		t.Fatal(err)
+	}
+	rt := &setupRuntime{cmd: &AuthSetupCmd{}, flags: &RootFlags{NoInput: true}, u: mustSetupUI(t), client: "default", priorProjectID: "demo", report: SetupReport{ProjectID: "demo"}}
+	if rt.appendCredentialsExisting(context.Background(), "demo") {
+		t.Fatal("prior project bypassed association confirmation")
+	}
+}

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -132,7 +132,7 @@ func TestAuthSetup_Discover_ProjectAndAPIs(t *testing.T) {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
 		"projects list --format=json --limit 100": {
-			stdout: `[{"projectId":"demo-proj","name":"Demo"}]`, code: 0,
+			stdout: `[{"projectId":"demo-proj","name":"Demo","lifecycleState":"ACTIVE"}]`, code: 0,
 		},
 		"services list --enabled --project demo-proj --format=json": {
 			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, code: 0,
@@ -524,8 +524,8 @@ func TestAuthSetup_AccountTokenSufficiency(t *testing.T) {
 		t.Fatalf("credentials: %v", err)
 	}
 
-	origOpen := authSetupOpen
-	t.Cleanup(func() { authSetupOpen = origOpen })
+	origOpen, origOpenNoInput := authSetupOpen, authSetupOpenNoInput
+	t.Cleanup(func() { authSetupOpen, authSetupOpenNoInput = origOpen, origOpenNoInput })
 
 	gmailScopes := accountScopes(parseSetupServices(t, "gmail"))
 	store := newMemSecretsStore()
@@ -537,6 +537,7 @@ func TestAuthSetup_AccountTokenSufficiency(t *testing.T) {
 		t.Fatalf("set token: %v", err)
 	}
 	authSetupOpen = func() (secrets.Store, error) { return store, nil }
+	authSetupOpenNoInput = authSetupOpen
 
 	tests := []struct {
 		name     string
@@ -724,7 +725,7 @@ func TestAuthSetup_ProjectPickerLabelsCurrentPairedTarget(t *testing.T) {
 func TestContinueSetupCmdPreservesRetryInputs(t *testing.T) {
 	cmd := &AuthSetupCmd{CreateProject: true, ProjectName: "Demo", ProjectParent: "folders/42", ServicesCSV: "gmail,drive", EnableAPIs: true, CredentialsPath: "/tmp/client.json", AccountEmail: "person@example.com", ManualOAuth: true, AckBranding: true, AckAudience: true, AckDataAccess: true}
 	got := continueSetupCmd("work", cmd, "demo", true)
-	for _, want := range []string{"--client work", "--force", "--project demo", "--create-project", "--project-name Demo", "--project-parent folders/42", "--services gmail,drive", "--enable-apis", "--credentials /tmp/client.json", "--email person@example.com", "--manual", "--ack-branding", "--ack-audience", "--ack-data-access"} {
+	for _, want := range []string{"'--client' 'work'", "'--force'", "'--project' 'demo'", "'--create-project'", "'--project-name' 'Demo'", "'--project-parent' 'folders/42'", "'--services' 'gmail,drive'", "'--enable-apis'", "'--credentials' '/tmp/client.json'", "'--email' 'person@example.com'", "'--manual'", "'--ack-branding'", "'--ack-audience'", "'--ack-data-access'"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("continuation missing %q: %s", want, got)
 		}

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -438,8 +438,9 @@ func TestAuthSetup_ReplacingCredentialsInvalidatesOnlyClientTokens(t *testing.T)
 	}
 
 	store := newMemSecretsStore()
+	services := parseSetupServices(t, "gmail")
 	for client, email := range map[string]string{"work": "work@example.com", "other": "other@example.com"} {
-		if err := store.SetToken(client, email, secrets.Token{RefreshToken: client + "-token"}); err != nil {
+		if err := store.SetToken(client, email, secrets.Token{Services: authServiceNames(services), Scopes: accountScopes(services), RefreshToken: client + "-token"}); err != nil {
 			t.Fatalf("set %s token: %v", client, err)
 		}
 	}

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -43,8 +43,8 @@ func (f *setupFakeRunner) Run(ctx context.Context, name string, args ...string) 
 	}
 	// Existing fixtures use the display limit; setup requests one extra item to
 	// determine whether that display is actually truncated.
-	if strings.HasPrefix(key, "projects list --format=json --limit ") {
-		if resp, ok := f.byArgs["projects list --format=json --limit 100"]; ok {
+	if strings.HasPrefix(key, "projects list --format=json --filter=lifecycleState:ACTIVE --limit ") {
+		if resp, ok := f.byArgs["projects list --format=json --filter=lifecycleState:ACTIVE --limit 100"]; ok {
 			return resp.stdout, resp.stderr, resp.code, resp.err
 		}
 	}
@@ -131,7 +131,7 @@ func TestAuthSetup_Discover_ProjectAndAPIs(t *testing.T) {
 		"auth list --filter=status:ACTIVE --format=json": {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
-		"projects list --format=json --limit 100": {
+		"projects list --format=json --filter=lifecycleState:ACTIVE --limit 100": {
 			stdout: `[{"projectId":"demo-proj","name":"Demo","lifecycleState":"ACTIVE"}]`, code: 0,
 		},
 		"services list --enabled --project demo-proj --format=json": {
@@ -164,8 +164,8 @@ func TestAuthSetup_Discover_ProjectAndAPIs(t *testing.T) {
 	if report.GCloudAccount != "dev@example.com" {
 		t.Fatalf("account=%q", report.GCloudAccount)
 	}
-	if len(report.Projects) != 1 || report.Projects[0].ProjectID != "demo-proj" || report.Projects[0].Name != "Demo" {
-		t.Fatalf("projects=%#v", report.Projects)
+	if len(report.Projects) != 0 {
+		t.Fatalf("explicit discovery must validate directly, projects=%#v", report.Projects)
 	}
 	// drive should be missing
 	foundMissing := false
@@ -200,7 +200,7 @@ func TestAuthSetup_NonInteractive_CreateProjectRequiresForce(t *testing.T) {
 		"auth list --filter=status:ACTIVE --format=json": {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
-		"projects list --format=json --limit 100": {stdout: `[]`, code: 0},
+		"projects list --format=json --filter=lifecycleState:ACTIVE --limit 100": {stdout: `[]`, code: 0},
 	}}
 	withSetupGCloud(t, r)
 
@@ -225,7 +225,7 @@ func TestAuthSetup_EnableAPIs_WithForce(t *testing.T) {
 		"auth list --filter=status:ACTIVE --format=json": {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
-		"projects list --format=json --limit 100": {
+		"projects list --format=json --filter=lifecycleState:ACTIVE --limit 100": {
 			stdout: `[{"projectId":"demo-proj"}]`, code: 0,
 		},
 		// first missing check: only gmail
@@ -314,7 +314,7 @@ func TestAuthSetup_CredentialsProjectMismatch(t *testing.T) {
 		"auth list --filter=status:ACTIVE --format=json": {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
-		"projects list --format=json --limit 100": {stdout: `[{"projectId":"demo-proj"}]`, code: 0},
+		"projects list --format=json --filter=lifecycleState:ACTIVE --limit 100": {stdout: `[{"projectId":"demo-proj"}]`, code: 0},
 		"services list --enabled --project demo-proj --format=json": {
 			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, code: 0,
 		},
@@ -371,7 +371,7 @@ func TestAuthSetup_CredentialsInstallIdempotent(t *testing.T) {
 		"auth list --filter=status:ACTIVE --format=json": {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
-		"projects list --format=json --limit 100": {stdout: `[{"projectId":"demo-proj"}]`, code: 0},
+		"projects list --format=json --filter=lifecycleState:ACTIVE --limit 100": {stdout: `[{"projectId":"demo-proj"}]`, code: 0},
 		"services list --enabled --project demo-proj --format=json": {
 			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, code: 0,
 		},
@@ -380,7 +380,7 @@ func TestAuthSetup_CredentialsInstallIdempotent(t *testing.T) {
 
 	// preinstall identical credentials
 	if err := config.WriteClientCredentialsFor("default", config.ClientCredentials{
-		ClientID: "id", ClientSecret: "sec", ProjectID: "demo-proj",
+		ClientID: "id", ClientSecret: "sec", ProjectID: "demo-proj", ClientType: config.OAuthClientTypeInstalled,
 	}); err != nil {
 		t.Fatalf("prewrite: %v", err)
 	}
@@ -463,8 +463,8 @@ func TestAuthSetup_ProjectPickerCreate_UsesEnteredIDWithoutChangingGCloudConfig(
 		code           int
 		err            error
 	}{
-		"projects list --format=json --limit 100":   {stdout: `[]`},
-		"projects create new-project --format=json": {stdout: `{"projectId":"new-project"}`},
+		"projects list --format=json --filter=lifecycleState:ACTIVE --limit 100": {stdout: `[]`},
+		"projects create new-project --format=json":                              {stdout: `{"projectId":"new-project"}`},
 	}}
 	u, err := ui.New(ui.Options{Color: "never"})
 	if err != nil {
@@ -643,7 +643,7 @@ func TestAuthSetup_ExistingCredentialMakesDesktopStageNonBlocking(t *testing.T) 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
-	if err := config.WriteClientCredentialsFor("default", config.ClientCredentials{ClientID: "id", ClientSecret: "secret", ProjectID: "demo"}); err != nil {
+	if err := config.WriteClientCredentialsFor("default", config.ClientCredentials{ClientID: "id", ClientSecret: "secret", ProjectID: "demo", ClientType: config.OAuthClientTypeInstalled}); err != nil {
 		t.Fatal(err)
 	}
 	u, _ := ui.New(ui.Options{Color: "never"})
@@ -679,10 +679,10 @@ func TestAuthSetup_StoppedRunHasFullDeferredInventoryWithoutDownstreamCalls(t *t
 		code           int
 		err            error
 	}{
-		"version --format=json":                                {stdout: `{}`},
-		"auth list --filter=status:ACTIVE --format=json":       {stdout: `[{"account":"dev@example.com"}]`},
-		"projects list --format=json --limit 100":              {stdout: `[{"projectId":"demo"}]`},
-		"services list --enabled --project demo --format=json": {stdout: `[]`},
+		"version --format=json":                                                  {stdout: `{}`},
+		"auth list --filter=status:ACTIVE --format=json":                         {stdout: `[{"account":"dev@example.com"}]`},
+		"projects list --format=json --filter=lifecycleState:ACTIVE --limit 100": {stdout: `[{"projectId":"demo"}]`},
+		"services list --enabled --project demo --format=json":                   {stdout: `[]`},
 	}}
 	withSetupGCloud(t, r)
 	var exit error

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -1,0 +1,456 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/gcloud"
+)
+
+var (
+	errSetupGCloudMissing  = errors.New(`exec: "gcloud": executable file not found in $PATH`)
+	errSetupGCloudNotFound = errors.New("executable file not found")
+)
+
+type setupFakeRunner struct {
+	calls [][]string
+	// responses keyed by joined args
+	byArgs map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}
+}
+
+func (f *setupFakeRunner) Run(ctx context.Context, name string, args ...string) (string, string, int, error) {
+	_ = ctx
+
+	f.calls = append(f.calls, append([]string{name}, args...))
+	key := strings.Join(args, " ")
+
+	if resp, ok := f.byArgs[key]; ok {
+		return resp.stdout, resp.stderr, resp.code, resp.err
+	}
+
+	for k, resp := range f.byArgs {
+		if strings.HasPrefix(key, k) {
+			return resp.stdout, resp.stderr, resp.code, resp.err
+		}
+	}
+
+	return "", "unexpected gcloud call: " + key, 1, nil
+}
+
+func withSetupGCloud(t *testing.T, r gcloud.Runner) {
+	t.Helper()
+	orig := newGCloudClient
+	newGCloudClient = func() *gcloud.Client {
+		c := gcloud.New(r)
+		return c
+	}
+	t.Cleanup(func() { newGCloudClient = orig })
+}
+
+func TestAuthSetup_Discover_JSON_MissingGCloud(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"version --format=json": {err: errSetupGCloudMissing, code: -1},
+	}}
+	withSetupGCloud(t, r)
+
+	var exit error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			exit = Execute([]string{"--json", "--no-input", "auth", "setup", "--discover"})
+		})
+	})
+	if ExitCode(exit) != 0 {
+		t.Fatalf("discover should exit 0, got %v code=%d out=%s", exit, ExitCode(exit), out)
+	}
+	var report SetupReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("json: %v\nout=%s", err, out)
+	}
+	if report.Client != "default" {
+		t.Fatalf("client=%q", report.Client)
+	}
+	if len(report.Stages) == 0 || report.Stages[0].ID != stageGCloudInstall {
+		t.Fatalf("stages=%#v", report.Stages)
+	}
+	if report.Stages[0].Status != stageStatusMissing {
+		t.Fatalf("status=%s", report.Stages[0].Status)
+	}
+	// secrets must not appear
+	if strings.Contains(out, "client_secret") || strings.Contains(out, "refresh_token") {
+		t.Fatalf("secrets leaked: %s", out)
+	}
+}
+
+func TestAuthSetup_Discover_ProjectAndAPIs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"version --format=json": {stdout: `{"Google Cloud SDK":"500.0.0"}`, code: 0},
+		"auth list --filter=status:ACTIVE --format=json": {
+			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
+		},
+		"projects list --format=json": {
+			stdout: `[{"projectId":"demo-proj","name":"Demo"}]`, code: 0,
+		},
+		"services list --enabled --project demo-proj --format=json": {
+			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, code: 0,
+		},
+	}}
+	withSetupGCloud(t, r)
+
+	var exit error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			exit = Execute([]string{
+				"--json", "--no-input",
+				"auth", "setup", "--discover",
+				"--project", "demo-proj",
+				"--services", "gmail,drive",
+			})
+		})
+	})
+	if ExitCode(exit) != 0 {
+		t.Fatalf("discover should exit 0, got %v code=%d out=%s", exit, ExitCode(exit), out)
+	}
+	var report SetupReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if report.ProjectID != "demo-proj" {
+		t.Fatalf("project=%q", report.ProjectID)
+	}
+	if report.GCloudAccount != "dev@example.com" {
+		t.Fatalf("account=%q", report.GCloudAccount)
+	}
+	// drive should be missing
+	foundMissing := false
+	for _, id := range report.MissingAPIs {
+		if id == "drive.googleapis.com" {
+			foundMissing = true
+		}
+	}
+	if !foundMissing {
+		t.Fatalf("expected drive missing, got %v", report.MissingAPIs)
+	}
+	// no config set calls
+	for _, call := range r.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "config set") || strings.Contains(joined, "--set-as-default") {
+			t.Fatalf("forbidden: %s", joined)
+		}
+	}
+}
+
+func TestAuthSetup_NonInteractive_CreateProjectRequiresForce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"version --format=json": {stdout: `{}`, code: 0},
+		"auth list --filter=status:ACTIVE --format=json": {
+			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
+		},
+		"projects list --format=json": {stdout: `[]`, code: 0},
+	}}
+	withSetupGCloud(t, r)
+
+	err := Execute([]string{"--no-input", "auth", "setup", "--create-project", "--project", "new-proj"})
+	if ExitCode(err) != 2 {
+		t.Fatalf("expected usage exit 2, got %v code=%d", err, ExitCode(err))
+	}
+}
+
+func TestAuthSetup_EnableAPIs_WithForce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	listEnabled := `[{"name":"gmail.googleapis.com","state":"ENABLED"},{"name":"drive.googleapis.com","state":"ENABLED"}]`
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"version --format=json": {stdout: `{}`, code: 0},
+		"auth list --filter=status:ACTIVE --format=json": {
+			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
+		},
+		"projects list --format=json": {
+			stdout: `[{"projectId":"demo-proj"}]`, code: 0,
+		},
+		// first missing check: only gmail
+		"services list --enabled --project demo-proj --format=json": {
+			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, code: 0,
+		},
+		"services enable --project demo-proj": {code: 0},
+	}}
+	// After enable, ListEnabledServices is called again — same key; update after first list by using sequential isn't supported.
+	// EnableServices calls list again with same args; make list return full set always after enable is fine if we return both from start for verify.
+	// For missing detection we need first list without drive. Use a counter via custom runner.
+	countList := 0
+	r2 := &seqRunner{inner: r, listHook: func() (string, int) {
+		countList++
+		if countList == 1 {
+			return `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, 0
+		}
+		return listEnabled, 0
+	}}
+	withSetupGCloud(t, r2)
+
+	var exit error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			exit = Execute([]string{
+				"--json", "--no-input", "--force",
+				"auth", "setup",
+				"--project", "demo-proj",
+				"--services", "gmail,drive",
+				"--enable-apis",
+				"--ack-branding", "--ack-audience", "--ack-data-access",
+			})
+		})
+	})
+	_ = exit
+	var report SetupReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	// project pairing persisted
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		t.Fatalf("cfg: %v", err)
+	}
+	got := config.GetClientSetup(cfg, "default")
+	if got.ProjectID != "demo-proj" {
+		t.Fatalf("setup record: %#v", got)
+	}
+	if !got.AcknowledgedBranding {
+		t.Fatalf("expected branding ack")
+	}
+	// APIs stage ok
+	for _, st := range report.Stages {
+		if st.ID == stageAPIs && st.Status != stageStatusOK {
+			t.Fatalf("apis stage: %#v", st)
+		}
+	}
+}
+
+type seqRunner struct {
+	inner    *setupFakeRunner
+	listHook func() (string, int)
+}
+
+func (s *seqRunner) Run(ctx context.Context, name string, args ...string) (string, string, int, error) {
+	key := strings.Join(args, " ")
+	if strings.HasPrefix(key, "services list --enabled") && s.listHook != nil {
+		s.inner.calls = append(s.inner.calls, append([]string{name}, args...))
+		stdout, code := s.listHook()
+		return stdout, "", code, nil
+	}
+	return s.inner.Run(ctx, name, args...)
+}
+
+func TestAuthSetup_CredentialsProjectMismatch(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"version --format=json": {stdout: `{}`, code: 0},
+		"auth list --filter=status:ACTIVE --format=json": {
+			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
+		},
+		"projects list --format=json": {stdout: `[{"projectId":"demo-proj"}]`, code: 0},
+		"services list --enabled --project demo-proj --format=json": {
+			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, code: 0,
+		},
+	}}
+	withSetupGCloud(t, r)
+
+	credPath := filepath.Join(t.TempDir(), "creds.json")
+	if err := os.WriteFile(credPath, []byte(`{"installed":{"client_id":"id","client_secret":"sec","project_id":"other-proj"}}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var exit error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			exit = Execute([]string{
+				"--json", "--no-input", "--force",
+				"auth", "setup",
+				"--project", "demo-proj",
+				"--services", "gmail",
+				"--credentials", credPath,
+			})
+		})
+	})
+	if ExitCode(exit) != 1 {
+		t.Fatalf("expected incomplete/blocked exit 1, got %v code=%d out=%s", exit, ExitCode(exit), out)
+	}
+	if !strings.Contains(out, "does not match") && !strings.Contains(out, "project") {
+		// blocker in stage
+		var report SetupReport
+		_ = json.Unmarshal([]byte(out), &report)
+		found := false
+		for _, st := range report.Stages {
+			if st.ID == stageCredentials && st.Status == stageStatusBlocked {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected credentials blocked, out=%s", out)
+		}
+	}
+}
+
+func TestAuthSetup_CredentialsInstallIdempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"version --format=json": {stdout: `{}`, code: 0},
+		"auth list --filter=status:ACTIVE --format=json": {
+			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
+		},
+		"projects list --format=json": {stdout: `[{"projectId":"demo-proj"}]`, code: 0},
+		"services list --enabled --project demo-proj --format=json": {
+			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, code: 0,
+		},
+	}}
+	withSetupGCloud(t, r)
+
+	// preinstall identical credentials
+	if err := config.WriteClientCredentialsFor("default", config.ClientCredentials{
+		ClientID: "id", ClientSecret: "sec", ProjectID: "demo-proj",
+	}); err != nil {
+		t.Fatalf("prewrite: %v", err)
+	}
+	credPath := filepath.Join(t.TempDir(), "creds.json")
+	if err := os.WriteFile(credPath, []byte(`{"installed":{"client_id":"id","client_secret":"sec","project_id":"demo-proj"}}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			_ = Execute([]string{
+				"--json", "--no-input",
+				"auth", "setup",
+				"--project", "demo-proj",
+				"--services", "gmail",
+				"--credentials", credPath,
+				"--ack-branding", "--ack-audience", "--ack-data-access",
+			})
+		})
+	})
+	var report SetupReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	for _, st := range report.Stages {
+		if st.ID == stageCredentials {
+			if st.Status != stageStatusOK {
+				t.Fatalf("creds stage: %#v", st)
+			}
+
+			if !strings.Contains(st.Summary, "identical") &&
+				st.Summary != "credentials installed" &&
+				st.Summary != "credentials present" {
+				t.Fatalf("unexpected credentials summary: %q", st.Summary)
+			}
+		}
+	}
+}
+
+func TestAuthSetup_PlainDiscover(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"version --format=json": {err: errSetupGCloudNotFound, code: -1},
+	}}
+	withSetupGCloud(t, r)
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			_ = Execute([]string{"--plain", "--no-input", "auth", "setup", "--discover"})
+		})
+	})
+	if !strings.Contains(out, "STAGE") || !strings.Contains(out, "gcloud_install") {
+		t.Fatalf("plain out=%q", out)
+	}
+}
+
+func TestAuthSetup_HelpRegistered(t *testing.T) {
+	err := Execute([]string{"auth", "setup", "--help"})
+	// help exits via exitPanic 0 or returns nil depending on path
+	if err != nil && ExitCode(err) != 0 {
+		// kong help may return nil
+		t.Logf("help err: %v", err)
+	}
+}
+
+func TestSetupComplete_RequiresAcksAndCreds(t *testing.T) {
+	r := SetupReport{
+		Stages: []SetupStage{
+			{ID: stageGCloudInstall, Status: stageStatusOK},
+			{ID: stageGCloudAuth, Status: stageStatusOK},
+			{ID: stageProject, Status: stageStatusOK},
+			{ID: stageAPIs, Status: stageStatusOK},
+			{ID: stageBranding, Status: stageStatusAcknowledged},
+			{ID: stageAudience, Status: stageStatusAcknowledged},
+			{ID: stageDataAccess, Status: stageStatusAcknowledged},
+			{ID: stageCredentials, Status: stageStatusOK},
+			{ID: stageAccount, Status: stageStatusOK},
+		},
+	}
+	if !setupComplete(r) {
+		t.Fatalf("expected complete")
+	}
+	r.Stages[4].Status = stageStatusManual
+	if setupComplete(r) {
+		t.Fatalf("expected incomplete without branding ack")
+	}
+}

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -119,7 +119,7 @@ func TestAuthSetup_Discover_ProjectAndAPIs(t *testing.T) {
 		"auth list --filter=status:ACTIVE --format=json": {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
-		"projects list --format=json": {
+		"projects list --format=json --limit 100": {
 			stdout: `[{"projectId":"demo-proj","name":"Demo"}]`, code: 0,
 		},
 		"services list --enabled --project demo-proj --format=json": {
@@ -188,7 +188,7 @@ func TestAuthSetup_NonInteractive_CreateProjectRequiresForce(t *testing.T) {
 		"auth list --filter=status:ACTIVE --format=json": {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
-		"projects list --format=json": {stdout: `[]`, code: 0},
+		"projects list --format=json --limit 100": {stdout: `[]`, code: 0},
 	}}
 	withSetupGCloud(t, r)
 
@@ -213,7 +213,7 @@ func TestAuthSetup_EnableAPIs_WithForce(t *testing.T) {
 		"auth list --filter=status:ACTIVE --format=json": {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
-		"projects list --format=json": {
+		"projects list --format=json --limit 100": {
 			stdout: `[{"projectId":"demo-proj"}]`, code: 0,
 		},
 		// first missing check: only gmail
@@ -302,7 +302,7 @@ func TestAuthSetup_CredentialsProjectMismatch(t *testing.T) {
 		"auth list --filter=status:ACTIVE --format=json": {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
-		"projects list --format=json": {stdout: `[{"projectId":"demo-proj"}]`, code: 0},
+		"projects list --format=json --limit 100": {stdout: `[{"projectId":"demo-proj"}]`, code: 0},
 		"services list --enabled --project demo-proj --format=json": {
 			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, code: 0,
 		},
@@ -359,7 +359,7 @@ func TestAuthSetup_CredentialsInstallIdempotent(t *testing.T) {
 		"auth list --filter=status:ACTIVE --format=json": {
 			stdout: `[{"account":"dev@example.com","status":"ACTIVE"}]`, code: 0,
 		},
-		"projects list --format=json": {stdout: `[{"projectId":"demo-proj"}]`, code: 0},
+		"projects list --format=json --limit 100": {stdout: `[{"projectId":"demo-proj"}]`, code: 0},
 		"services list --enabled --project demo-proj --format=json": {
 			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`, code: 0,
 		},
@@ -451,7 +451,7 @@ func TestAuthSetup_ProjectPickerCreate_UsesEnteredIDWithoutChangingGCloudConfig(
 		code           int
 		err            error
 	}{
-		"projects list --format=json":               {stdout: `[]`},
+		"projects list --format=json --limit 100":   {stdout: `[]`},
 		"projects create new-project --format=json": {stdout: `{"projectId":"new-project"}`},
 	}}
 	u, err := ui.New(ui.Options{Color: "never"})
@@ -468,7 +468,7 @@ func TestAuthSetup_ProjectPickerCreate_UsesEnteredIDWithoutChangingGCloudConfig(
 	t.Cleanup(func() { setupPromptLine = origPrompt })
 
 	rt := &setupRuntime{
-		cmd:         &AuthSetupCmd{},
+		cmd:         &AuthSetupCmd{ProjectLimit: 100},
 		flags:       &RootFlags{Force: true},
 		u:           u,
 		gc:          gcloud.New(r),
@@ -571,6 +571,123 @@ func parseSetupServices(t *testing.T, csv string) []googleauth.Service {
 		t.Fatalf("parse services %q: %v", csv, err)
 	}
 	return services
+}
+
+func TestAuthSetup_DiscoverDoesNotClaimSetupComplete(t *testing.T) {
+	report := SetupReport{DiscoveryOnly: true, Stages: []SetupStage{
+		{ID: stageGCloudInstall, Status: stageStatusOK},
+		{ID: stageGCloudAuth, Status: stageStatusOK},
+		{ID: stageProject, Status: stageStatusOK},
+		{ID: stageAPIs, Status: stageStatusMissing},
+	}}
+	if setupComplete(report) {
+		t.Fatal("discovery with missing setup requirements must not be complete")
+	}
+	if !discoveryComplete(report) {
+		t.Fatal("successful discovery inspection should be separately complete")
+	}
+}
+
+func TestAuthSetup_StoredCredentialsAreValidatedBeforeAccount(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	u, err := ui.New(ui.Options{Color: "never"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name, raw, project, prior string
+		force                     bool
+		want                      string
+	}{
+		{"malformed", `{not-json`, "demo", "demo", false, stageStatusFailed},
+		{"mismatch", `{"client_id":"id","client_secret":"secret","project_id":"other"}`, "demo", "demo", false, stageStatusBlocked},
+		{"unassociated missing project", `{"client_id":"id","client_secret":"secret"}`, "demo", "", false, stageStatusBlocked},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, _ := config.ClientCredentialsPathFor("default")
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(tc.raw), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			rt := &setupRuntime{cmd: &AuthSetupCmd{}, flags: &RootFlags{NoInput: true, Force: tc.force}, u: u, client: "default", priorProjectID: tc.prior, force: tc.force, report: SetupReport{ProjectID: tc.project}}
+			if ok := rt.appendCredentialsExisting(context.Background(), tc.project); ok {
+				t.Fatal("invalid stored credentials accepted")
+			}
+			if got := rt.report.Stages[0].Status; got != tc.want {
+				t.Fatalf("status=%s want=%s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuthSetup_ExistingCredentialMakesDesktopStageNonBlocking(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	if err := config.WriteClientCredentialsFor("default", config.ClientCredentials{ClientID: "id", ClientSecret: "secret", ProjectID: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	u, _ := ui.New(ui.Options{Color: "never"})
+	rt := &setupRuntime{cmd: &AuthSetupCmd{}, flags: &RootFlags{NoInput: true}, u: u, client: "default", report: SetupReport{ProjectID: "demo"}}
+	_, _ = rt.runManualStages(context.Background())
+	for _, st := range rt.report.Stages {
+		if st.ID == stageDesktopClient && st.Status != stageStatusOK {
+			t.Fatalf("desktop stage=%#v", st)
+		}
+	}
+}
+
+func TestAuthSetup_APIsBlockDownstreamStages(t *testing.T) {
+	rt := &setupRuntime{cmd: &AuthSetupCmd{}, u: mustSetupUI(t), report: SetupReport{ProjectID: "demo"}, usageIDs: []string{"gmail.googleapis.com"}, gc: gcloud.New(&setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"services list --enabled --project demo --format=json": {stdout: `[]`},
+	}})}
+	stop, _ := rt.runAPIs(context.Background())
+	if !stop || len(rt.report.Stages) != 1 || rt.report.Stages[0].ID != stageAPIs {
+		t.Fatalf("stop=%t stages=%#v", stop, rt.report.Stages)
+	}
+}
+
+func mustSetupUI(t *testing.T) *ui.UI {
+	t.Helper()
+	u, err := ui.New(ui.Options{Color: "never"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
+}
+
+func TestAuthSetup_CreateAlreadyExistsSelectsDescribedProject(t *testing.T) {
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"projects create demo --format=json":   {stderr: "ALREADY_EXISTS", code: 1},
+		"projects describe demo --format=json": {stdout: `{"projectId":"demo"}`},
+	}}
+	rt := &setupRuntime{cmd: &AuthSetupCmd{Project: "demo"}, flags: &RootFlags{Force: true}, u: mustSetupUI(t), gc: gcloud.New(r), force: true}
+	got, created, err := rt.createProject(context.Background())
+	if err != nil || !created || got != "demo" {
+		t.Fatalf("id=%q created=%t err=%v", got, created, err)
+	}
+}
+
+func TestGCloudFailureClassification(t *testing.T) {
+	for _, kind := range []gcloud.BlockerKind{gcloud.BlockerPermission, gcloud.BlockerQuota, gcloud.BlockerInvalidInput, gcloud.BlockerUnknown} {
+		if status, resumable := gcloudFailureStage(kind); status != stageStatusFailed || resumable {
+			t.Fatalf("kind %s: %s resumable=%t", kind, status, resumable)
+		}
+	}
 }
 
 func TestSetupComplete_RequiresAcksAndCreds(t *testing.T) {

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/99designs/keyring"
+
 	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/gcloud"
 	"github.com/steipete/gogcli/internal/googleauth"
@@ -417,6 +419,112 @@ func TestAuthSetup_CredentialsInstallIdempotent(t *testing.T) {
 				t.Fatalf("unexpected credentials summary: %q", st.Summary)
 			}
 		}
+	}
+}
+
+func TestAuthSetup_ReplacingCredentialsInvalidatesOnlyClientTokens(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	if err := config.WriteClientCredentialsFor("work", config.ClientCredentials{
+		ClientID: "old-id", ClientSecret: "old-secret", ProjectID: "demo-proj", ClientType: config.OAuthClientTypeInstalled,
+	}); err != nil {
+		t.Fatalf("prewrite credentials: %v", err)
+	}
+	credentialsPath := filepath.Join(t.TempDir(), "credentials.json")
+	if err := os.WriteFile(credentialsPath, []byte(`{"installed":{"client_id":"new-id","client_secret":"new-secret","project_id":"demo-proj"}}`), 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+
+	store := newMemSecretsStore()
+	for client, email := range map[string]string{"work": "work@example.com", "other": "other@example.com"} {
+		if err := store.SetToken(client, email, secrets.Token{RefreshToken: client + "-token"}); err != nil {
+			t.Fatalf("set %s token: %v", client, err)
+		}
+	}
+	origOpen, origOpenNoInput := authSetupOpen, authSetupOpenNoInput
+	authSetupOpen = func() (secrets.Store, error) { return store, nil }
+	authSetupOpenNoInput = authSetupOpen
+	t.Cleanup(func() { authSetupOpen, authSetupOpenNoInput = origOpen, origOpenNoInput })
+
+	rt := &setupRuntime{
+		cmd:      &AuthSetupCmd{CredentialsPath: credentialsPath, AccountEmail: "work@example.com"},
+		flags:    &RootFlags{Force: true, NoInput: true},
+		u:        mustSetupUI(t),
+		client:   "work",
+		force:    true,
+		services: parseSetupServices(t, "gmail"),
+		report:   SetupReport{ProjectID: "demo-proj"},
+	}
+	if stop, err := rt.installCredentials(context.Background(), "demo-proj"); stop || err != nil {
+		t.Fatalf("install credentials: stop=%t err=%v", stop, err)
+	}
+	if _, err := store.GetToken("work", "work@example.com"); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("replaced client token was not invalidated: %v", err)
+	}
+	if _, err := store.GetToken("other", "other@example.com"); err != nil {
+		t.Fatalf("other client token was removed: %v", err)
+	}
+	if got := rt.report.Stages[len(rt.report.Stages)-1].Summary; !strings.Contains(got, "1 existing account token(s) invalidated") {
+		t.Fatalf("replacement warning detail=%q", got)
+	}
+	if stop, err := rt.runAccount(context.Background()); stop || err != nil {
+		t.Fatalf("replacement must require reauthorization: stop=%t err=%v", stop, err)
+	}
+	if got := rt.report.Stages[len(rt.report.Stages)-1].Status; got != stageStatusManual {
+		t.Fatalf("account stage=%s, want %s after replacement", got, stageStatusManual)
+	}
+}
+
+func TestAuthSetup_IdenticalCredentialsRetainTokenCompletion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	credentials := config.ClientCredentials{ClientID: "id", ClientSecret: "secret", ProjectID: "demo-proj", ClientType: config.OAuthClientTypeInstalled}
+	if err := config.WriteClientCredentialsFor("work", credentials); err != nil {
+		t.Fatalf("prewrite credentials: %v", err)
+	}
+	credentialsPath := filepath.Join(t.TempDir(), "credentials.json")
+	if err := os.WriteFile(credentialsPath, []byte(`{"installed":{"client_id":"id","client_secret":"secret","project_id":"demo-proj"}}`), 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+
+	store := newMemSecretsStore()
+	services := parseSetupServices(t, "gmail")
+	if err := store.SetToken("work", "person@example.com", secrets.Token{
+		Services:     authServiceNames(services),
+		Scopes:       accountScopes(services),
+		RefreshToken: "token",
+	}); err != nil {
+		t.Fatalf("set token: %v", err)
+	}
+	origOpen, origOpenNoInput := authSetupOpen, authSetupOpenNoInput
+	authSetupOpen = func() (secrets.Store, error) { return store, nil }
+	authSetupOpenNoInput = authSetupOpen
+	t.Cleanup(func() { authSetupOpen, authSetupOpenNoInput = origOpen, origOpenNoInput })
+
+	rt := &setupRuntime{
+		cmd:      &AuthSetupCmd{CredentialsPath: credentialsPath, AccountEmail: "person@example.com"},
+		flags:    &RootFlags{Force: true, NoInput: true},
+		u:        mustSetupUI(t),
+		client:   "work",
+		force:    true,
+		services: services,
+		report:   SetupReport{ProjectID: "demo-proj"},
+	}
+	if stop, err := rt.installCredentials(context.Background(), "demo-proj"); stop || err != nil {
+		t.Fatalf("install credentials: stop=%t err=%v", stop, err)
+	}
+	if _, err := store.GetToken("work", "person@example.com"); err != nil {
+		t.Fatalf("identical credentials removed token: %v", err)
+	}
+	if stop, err := rt.runAccount(context.Background()); stop || err != nil {
+		t.Fatalf("retained token should satisfy account stage: stop=%t err=%v", stop, err)
+	}
+	if got := rt.report.Stages[len(rt.report.Stages)-1].Status; got != stageStatusOK {
+		t.Fatalf("account stage=%s, want %s", got, stageStatusOK)
 	}
 }
 

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,6 +41,13 @@ func (f *setupFakeRunner) Run(ctx context.Context, name string, args ...string) 
 	if resp, ok := f.byArgs[key]; ok {
 		return resp.stdout, resp.stderr, resp.code, resp.err
 	}
+	// Existing fixtures use the display limit; setup requests one extra item to
+	// determine whether that display is actually truncated.
+	if strings.HasPrefix(key, "projects list --format=json --limit ") {
+		if resp, ok := f.byArgs["projects list --format=json --limit 100"]; ok {
+			return resp.stdout, resp.stderr, resp.code, resp.err
+		}
+	}
 
 	for k, resp := range f.byArgs {
 		if strings.HasPrefix(key, k) {
@@ -47,6 +55,10 @@ func (f *setupFakeRunner) Run(ctx context.Context, name string, args ...string) 
 		}
 	}
 
+	if strings.HasPrefix(key, "projects describe ") {
+		fields := strings.Fields(key)
+		return fmt.Sprintf(`{"projectId":%q}`, fields[2]), "", 0, nil
+	}
 	return "", "unexpected gcloud call: " + key, 1, nil
 }
 
@@ -657,6 +669,68 @@ func TestAuthSetup_APIsBlockDownstreamStages(t *testing.T) {
 	}
 }
 
+func TestAuthSetup_StoppedRunHasFullDeferredInventoryWithoutDownstreamCalls(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"version --format=json":                                {stdout: `{}`},
+		"auth list --filter=status:ACTIVE --format=json":       {stdout: `[{"account":"dev@example.com"}]`},
+		"projects list --format=json --limit 100":              {stdout: `[{"projectId":"demo"}]`},
+		"services list --enabled --project demo --format=json": {stdout: `[]`},
+	}}
+	withSetupGCloud(t, r)
+	var exit error
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			exit = Execute([]string{"--json", "--no-input", "auth", "setup", "--project", "demo", "--services", "gmail"})
+		})
+	})
+	if ExitCode(exit) != 1 {
+		t.Fatalf("exit=%v", exit)
+	}
+	var report SetupReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Stages) != len(setupStageOrder) {
+		t.Fatalf("stages=%#v", report.Stages)
+	}
+	for _, stage := range report.Stages[4:] {
+		if stage.Status != stageStatusUnavailable {
+			t.Fatalf("downstream stage=%#v", stage)
+		}
+	}
+	for _, call := range r.calls {
+		if strings.Contains(strings.Join(call, " "), "credentials") {
+			t.Fatalf("downstream credential read: %v", call)
+		}
+	}
+}
+
+func TestAuthSetup_ProjectPickerLabelsCurrentPairedTarget(t *testing.T) {
+	label := projectPickerLabel(gcloud.Project{ProjectID: "paired", Name: "Paired", LifecycleState: "ACTIVE"}, "paired")
+	for _, want := range []string{"paired (Paired)", "[ACTIVE]", "[current paired target]"} {
+		if !strings.Contains(label, want) {
+			t.Fatalf("picker label missing %q: %q", want, label)
+		}
+	}
+}
+
+func TestContinueSetupCmdPreservesRetryInputs(t *testing.T) {
+	cmd := &AuthSetupCmd{CreateProject: true, ProjectName: "Demo", ProjectParent: "folders/42", ServicesCSV: "gmail,drive", EnableAPIs: true, CredentialsPath: "/tmp/client.json", AccountEmail: "person@example.com", ManualOAuth: true, AckBranding: true, AckAudience: true, AckDataAccess: true}
+	got := continueSetupCmd("work", cmd, "demo", true)
+	for _, want := range []string{"--client work", "--force", "--project demo", "--create-project", "--project-name Demo", "--project-parent folders/42", "--services gmail,drive", "--enable-apis", "--credentials /tmp/client.json", "--email person@example.com", "--manual", "--ack-branding", "--ack-audience", "--ack-data-access"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("continuation missing %q: %s", want, got)
+		}
+	}
+}
+
 func mustSetupUI(t *testing.T) *ui.UI {
 	t.Helper()
 	u, err := ui.New(ui.Options{Color: "never"})
@@ -683,10 +757,13 @@ func TestAuthSetup_CreateAlreadyExistsSelectsDescribedProject(t *testing.T) {
 }
 
 func TestGCloudFailureClassification(t *testing.T) {
-	for _, kind := range []gcloud.BlockerKind{gcloud.BlockerPermission, gcloud.BlockerQuota, gcloud.BlockerInvalidInput, gcloud.BlockerUnknown} {
-		if status, resumable := gcloudFailureStage(kind); status != stageStatusFailed || resumable {
+	for _, kind := range []gcloud.BlockerKind{gcloud.BlockerPermission, gcloud.BlockerQuota, gcloud.BlockerUnknown} {
+		if status, resumable := gcloudFailureStage(kind); status != stageStatusBlocked || !resumable {
 			t.Fatalf("kind %s: %s resumable=%t", kind, status, resumable)
 		}
+	}
+	if status, resumable := gcloudFailureStage(gcloud.BlockerInvalidInput); status != stageStatusFailed || resumable {
+		t.Fatalf("invalid input: %s resumable=%t", status, resumable)
 	}
 }
 

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/gcloud"
+	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/steipete/gogcli/internal/ui"
 )
 
 var (
@@ -77,12 +80,15 @@ func TestAuthSetup_Discover_JSON_MissingGCloud(t *testing.T) {
 			exit = Execute([]string{"--json", "--no-input", "auth", "setup", "--discover"})
 		})
 	})
-	if ExitCode(exit) != 0 {
-		t.Fatalf("discover should exit 0, got %v code=%d out=%s", exit, ExitCode(exit), out)
+	if ExitCode(exit) != 1 {
+		t.Fatalf("failed discovery should exit 1 after its report, got %v code=%d out=%s", exit, ExitCode(exit), out)
 	}
 	var report SetupReport
 	if err := json.Unmarshal([]byte(out), &report); err != nil {
 		t.Fatalf("json: %v\nout=%s", err, out)
+	}
+	if report.Complete {
+		t.Fatalf("failed discovery must be incomplete: %#v", report)
 	}
 	if report.Client != "default" {
 		t.Fatalf("client=%q", report.Client)
@@ -145,6 +151,9 @@ func TestAuthSetup_Discover_ProjectAndAPIs(t *testing.T) {
 	}
 	if report.GCloudAccount != "dev@example.com" {
 		t.Fatalf("account=%q", report.GCloudAccount)
+	}
+	if len(report.Projects) != 1 || report.Projects[0].ProjectID != "demo-proj" || report.Projects[0].Name != "Demo" {
+		t.Fatalf("projects=%#v", report.Projects)
 	}
 	// drive should be missing
 	foundMissing := false
@@ -430,6 +439,138 @@ func TestAuthSetup_HelpRegistered(t *testing.T) {
 		// kong help may return nil
 		t.Logf("help err: %v", err)
 	}
+}
+
+func TestAuthSetup_ProjectPickerCreate_UsesEnteredIDWithoutChangingGCloudConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	r := &setupFakeRunner{byArgs: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"projects list --format=json":               {stdout: `[]`},
+		"projects create new-project --format=json": {stdout: `{"projectId":"new-project"}`},
+	}}
+	u, err := ui.New(ui.Options{Color: "never"})
+	if err != nil {
+		t.Fatalf("ui: %v", err)
+	}
+	origPrompt := setupPromptLine
+	responses := []string{"1", "new-project"}
+	setupPromptLine = func(context.Context, string) (string, error) {
+		response := responses[0]
+		responses = responses[1:]
+		return response, nil
+	}
+	t.Cleanup(func() { setupPromptLine = origPrompt })
+
+	rt := &setupRuntime{
+		cmd:         &AuthSetupCmd{},
+		flags:       &RootFlags{Force: true},
+		u:           u,
+		gc:          gcloud.New(r),
+		client:      config.DefaultClientName,
+		interactive: true,
+		force:       true,
+		report:      SetupReport{Client: config.DefaultClientName},
+	}
+
+	stop, runErr := rt.runProject(context.Background())
+	if stop || runErr != nil {
+		t.Fatalf("run project: stop=%t err=%v", stop, runErr)
+	}
+	if rt.report.ProjectID != "new-project" {
+		t.Fatalf("selected project=%q", rt.report.ProjectID)
+	}
+	var created bool
+	for _, call := range r.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "config set") || strings.Contains(joined, "--set-as-default") {
+			t.Fatalf("gcloud config was mutated: %s", joined)
+		}
+		if strings.Contains(joined, "projects create new-project") {
+			created = true
+		}
+	}
+	if !created {
+		t.Fatalf("creation was not reached: %#v", r.calls)
+	}
+}
+
+func TestAuthSetup_AccountTokenSufficiency(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	u, err := ui.New(ui.Options{Color: "never"})
+	if err != nil {
+		t.Fatalf("ui: %v", err)
+	}
+	if err := config.WriteClientCredentialsFor("work", config.ClientCredentials{ClientID: "id", ClientSecret: "secret"}); err != nil {
+		t.Fatalf("credentials: %v", err)
+	}
+
+	origOpen := authSetupOpen
+	t.Cleanup(func() { authSetupOpen = origOpen })
+
+	gmailScopes := accountScopes(parseSetupServices(t, "gmail"))
+	store := newMemSecretsStore()
+	if err := store.SetToken("work", "person@example.com", secrets.Token{
+		Services:     []string{"gmail"},
+		Scopes:       gmailScopes,
+		RefreshToken: "test-token",
+	}); err != nil {
+		t.Fatalf("set token: %v", err)
+	}
+	authSetupOpen = func() (secrets.Store, error) { return store, nil }
+
+	tests := []struct {
+		name     string
+		client   string
+		email    string
+		services string
+		want     bool
+	}{
+		{name: "exact client email services and scopes", client: "work", email: "person@example.com", services: "gmail", want: true},
+		{name: "different email", client: "work", email: "other@example.com", services: "gmail", want: false},
+		{name: "different client", client: "other", email: "person@example.com", services: "gmail", want: false},
+		{name: "missing requested service and scope", client: "work", email: "person@example.com", services: "drive", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			services := parseSetupServices(t, tc.services)
+			if got := accountTokenSatisfies(tc.client, tc.email, authServiceNames(services), accountScopes(services)); got != tc.want {
+				t.Fatalf("accountTokenSatisfies()=%t, want %t", got, tc.want)
+			}
+		})
+	}
+
+	rt := &setupRuntime{cmd: &AuthSetupCmd{AccountEmail: "person@example.com"}, flags: &RootFlags{NoInput: true}, u: u, client: "work", services: parseSetupServices(t, "gmail")}
+	if stop, runErr := rt.runAccount(context.Background()); stop || runErr != nil {
+		t.Fatalf("sufficient existing token should skip OAuth: stop=%t err=%v", stop, runErr)
+	}
+	if got := rt.report.Stages[0].Status; got != stageStatusOK {
+		t.Fatalf("sufficient token stage=%s", got)
+	}
+
+	rt = &setupRuntime{cmd: &AuthSetupCmd{AccountEmail: "person@example.com"}, flags: &RootFlags{NoInput: true}, u: u, client: "work", services: parseSetupServices(t, "drive")}
+	if stop, runErr := rt.runAccount(context.Background()); stop || runErr != nil {
+		t.Fatalf("insufficient token should defer authorization: stop=%t err=%v", stop, runErr)
+	}
+	if got := rt.report.Stages[0].Status; got != stageStatusManual {
+		t.Fatalf("insufficient token stage=%s, want manual authorization", got)
+	}
+}
+
+func parseSetupServices(t *testing.T, csv string) []googleauth.Service {
+	t.Helper()
+	services, err := parseAuthServices(csv)
+	if err != nil {
+		t.Fatalf("parse services %q: %v", csv, err)
+	}
+	return services
 }
 
 func TestSetupComplete_RequiresAcksAndCreds(t *testing.T) {

--- a/internal/cmd/confirm.go
+++ b/internal/cmd/confirm.go
@@ -32,7 +32,6 @@ func confirmDestructive(ctx context.Context, flags *RootFlags, action string) er
 		return fmt.Errorf("read confirmation: %w", readErr)
 	}
 	ans := strings.TrimSpace(strings.ToLower(line))
-	//nolint:goconst // "yes" is a common confirmation string across codebase
 	if ans == "y" || ans == "yes" {
 		return nil
 	}

--- a/internal/cmd/confirm.go
+++ b/internal/cmd/confirm.go
@@ -32,6 +32,7 @@ func confirmDestructive(ctx context.Context, flags *RootFlags, action string) er
 		return fmt.Errorf("read confirmation: %w", readErr)
 	}
 	ans := strings.TrimSpace(strings.ToLower(line))
+	//nolint:goconst // "yes" is a common confirmation response, not shared domain vocabulary
 	if ans == "y" || ans == "yes" {
 		return nil
 	}

--- a/internal/cmd/schema_test.go
+++ b/internal/cmd/schema_test.go
@@ -517,7 +517,7 @@ func TestSchemaV1ContractFingerprint(t *testing.T) {
 		t.Fatalf("marshal canonical schema: %v", err)
 	}
 	got := fmt.Sprintf("%x", sha256.Sum256(canonical))
-	const want = "f81a4eb2f44cf4fa5ab12825a1aed982b38201b3082d05b7ccda329522ae8f6f"
+	const want = "7ca0719c4142b6b7c09962f510dcf09b486462a81d115fc14f7aaa670c3025d1"
 	if got != want {
 		t.Fatalf("schema v1 contract fingerprint = %s, want %s; review the contract change and schema version", got, want)
 	}

--- a/internal/config/client_setup_test.go
+++ b/internal/config/client_setup_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestClientSetup_ProjectChangeResetsAcks(t *testing.T) {
+	cfg := File{}
+	if err := SetClientSetupProject(&cfg, "default", "p1"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	if err := SetClientSetupAcknowledgments(&cfg, "default", true, true, true); err != nil {
+		t.Fatalf("acks: %v", err)
+	}
+
+	got := GetClientSetup(cfg, "default")
+	if !got.AcknowledgedBranding || got.ProjectID != "p1" {
+		t.Fatalf("got %#v", got)
+	}
+
+	if err := SetClientSetupProject(&cfg, "default", "p2"); err != nil {
+		t.Fatalf("set2: %v", err)
+	}
+
+	got = GetClientSetup(cfg, "default")
+	if got.ProjectID != "p2" {
+		t.Fatalf("project=%q", got.ProjectID)
+	}
+
+	if got.AcknowledgedBranding || got.AcknowledgedAudience || got.AcknowledgedDataAccess {
+		t.Fatalf("acks should reset on project change: %#v", got)
+	}
+}
+
+func TestClientSetup_RoundtripConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	cfg := File{}
+	if err := SetClientSetupProject(&cfg, "work", "cloud-proj"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	if err := SetClientSetupAcknowledgments(&cfg, "work", true, false, true); err != nil {
+		t.Fatalf("acks: %v", err)
+	}
+
+	if err := WriteConfig(cfg); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	read, err := ReadConfig()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	got := GetClientSetup(read, "work")
+	if got.ProjectID != "cloud-proj" || !got.AcknowledgedBranding || got.AcknowledgedAudience || !got.AcknowledgedDataAccess {
+		t.Fatalf("got %#v", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,9 @@ type ClientSetup struct {
 	// CredentialsProjectAssociated records explicit confirmation that credentials
 	// without project_id belong to ProjectID. It is not implied by pairing a target.
 	CredentialsProjectAssociated bool `json:"credentials_project_associated,omitempty"`
+	// ReauthorizationRequired prevents tokens issued to replaced credentials from
+	// satisfying setup until they have been invalidated or an account reauthorizes.
+	ReauthorizationRequired bool `json:"reauthorization_required,omitempty"`
 }
 
 // GetClientSetup returns the setup record for client, or a zero value.
@@ -78,6 +81,29 @@ func SetClientSetupProject(cfg *File, client, projectID string) error {
 	}
 
 	cur.ProjectID = projectID
+	cfg.ClientSetup[normalized] = cur
+
+	return nil
+}
+
+// SetClientSetupReauthorizationRequired records whether credential replacement
+// requires a fresh account authorization before setup can be complete.
+func SetClientSetupReauthorizationRequired(cfg *File, client string, required bool) error {
+	if cfg == nil {
+		return errNilConfig
+	}
+
+	normalized, err := NormalizeClientNameOrDefault(client)
+	if err != nil {
+		return err
+	}
+
+	if cfg.ClientSetup == nil {
+		cfg.ClientSetup = make(map[string]ClientSetup)
+	}
+
+	cur := cfg.ClientSetup[normalized]
+	cur.ReauthorizationRequired = required
 	cfg.ClientSetup[normalized] = cur
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,9 @@ type ClientSetup struct {
 	AcknowledgedBranding   bool `json:"acknowledged_branding,omitempty"`
 	AcknowledgedAudience   bool `json:"acknowledged_audience,omitempty"`
 	AcknowledgedDataAccess bool `json:"acknowledged_data_access,omitempty"`
+	// CredentialsProjectAssociated records explicit confirmation that credentials
+	// without project_id belong to ProjectID. It is not implied by pairing a target.
+	CredentialsProjectAssociated bool `json:"credentials_project_associated,omitempty"`
 }
 
 // GetClientSetup returns the setup record for client, or a zero value.
@@ -71,6 +74,7 @@ func SetClientSetupProject(cfg *File, client, projectID string) error {
 		cur.AcknowledgedBranding = false
 		cur.AcknowledgedAudience = false
 		cur.AcknowledgedDataAccess = false
+		cur.CredentialsProjectAssociated = false
 	}
 
 	cur.ProjectID = projectID
@@ -79,8 +83,32 @@ func SetClientSetupProject(cfg *File, client, projectID string) error {
 	return nil
 }
 
+// SetClientSetupCredentialsProjectAssociated records explicit association of
+// project-less OAuth credentials with the current selected project.
+func SetClientSetupCredentialsProjectAssociated(cfg *File, client string, associated bool) error {
+	if cfg == nil {
+		return errNilConfig
+	}
+
+	normalized, err := NormalizeClientNameOrDefault(client)
+	if err != nil {
+		return err
+	}
+
+	if cfg.ClientSetup == nil {
+		cfg.ClientSetup = make(map[string]ClientSetup)
+	}
+
+	cur := cfg.ClientSetup[normalized]
+	cur.CredentialsProjectAssociated = associated
+	cfg.ClientSetup[normalized] = cur
+
+	return nil
+}
+
 // SetClientSetupAcknowledgments records explicit user acknowledgments for
 // Console-only stages on the client's current project pairing.
+
 func SetClientSetupAcknowledgments(cfg *File, client string, branding, audience, dataAccess bool) error {
 	if cfg == nil {
 		return errNilConfig

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/yosuke-furukawa/json5/encoding/json5"
 )
@@ -15,7 +16,101 @@ type File struct {
 	AccountAliases  map[string]string `json:"account_aliases,omitempty"`
 	AccountClients  map[string]string `json:"account_clients,omitempty"`
 	ClientDomains   map[string]string `json:"client_domains,omitempty"`
-	Policies        []Policy          `json:"policies,omitempty"`
+	// ClientSetup stores transparent per-client setup facts that Google does not
+	// expose via supported CLI inspection (selected project pairing and manual
+	// Auth Platform acknowledgments). Operational state is always re-inspected.
+	ClientSetup map[string]ClientSetup `json:"client_setup,omitempty"`
+	Policies    []Policy               `json:"policies,omitempty"`
+}
+
+// ClientSetup is minimal durable setup metadata for one OAuth client namespace.
+type ClientSetup struct {
+	// ProjectID is the Google Cloud project paired with this client.
+	ProjectID string `json:"project_id,omitempty"`
+	// Manual acknowledgments for Console-only Auth Platform stages.
+	// These are never treated as independently Google-verified.
+	AcknowledgedBranding   bool `json:"acknowledged_branding,omitempty"`
+	AcknowledgedAudience   bool `json:"acknowledged_audience,omitempty"`
+	AcknowledgedDataAccess bool `json:"acknowledged_data_access,omitempty"`
+}
+
+// GetClientSetup returns the setup record for client, or a zero value.
+func GetClientSetup(cfg File, client string) ClientSetup {
+	if cfg.ClientSetup == nil {
+		return ClientSetup{}
+	}
+
+	normalized, err := NormalizeClientNameOrDefault(client)
+	if err != nil {
+		return ClientSetup{}
+	}
+
+	return cfg.ClientSetup[normalized]
+}
+
+// SetClientSetupProject pairs client with projectID. Changing project resets
+// manual acknowledgments.
+func SetClientSetupProject(cfg *File, client, projectID string) error {
+	if cfg == nil {
+		return errNilConfig
+	}
+
+	normalized, err := NormalizeClientNameOrDefault(client)
+	if err != nil {
+		return err
+	}
+
+	projectID = strings.TrimSpace(projectID)
+
+	if cfg.ClientSetup == nil {
+		cfg.ClientSetup = make(map[string]ClientSetup)
+	}
+
+	cur := cfg.ClientSetup[normalized]
+	if cur.ProjectID != "" && projectID != "" && cur.ProjectID != projectID {
+		cur.AcknowledgedBranding = false
+		cur.AcknowledgedAudience = false
+		cur.AcknowledgedDataAccess = false
+	}
+
+	cur.ProjectID = projectID
+	cfg.ClientSetup[normalized] = cur
+
+	return nil
+}
+
+// SetClientSetupAcknowledgments records explicit user acknowledgments for
+// Console-only stages on the client's current project pairing.
+func SetClientSetupAcknowledgments(cfg *File, client string, branding, audience, dataAccess bool) error {
+	if cfg == nil {
+		return errNilConfig
+	}
+
+	normalized, err := NormalizeClientNameOrDefault(client)
+	if err != nil {
+		return err
+	}
+
+	if cfg.ClientSetup == nil {
+		cfg.ClientSetup = make(map[string]ClientSetup)
+	}
+
+	cur := cfg.ClientSetup[normalized]
+	if branding {
+		cur.AcknowledgedBranding = true
+	}
+
+	if audience {
+		cur.AcknowledgedAudience = true
+	}
+
+	if dataAccess {
+		cur.AcknowledgedDataAccess = true
+	}
+
+	cfg.ClientSetup[normalized] = cur
+
+	return nil
 }
 
 func ConfigPath() (string, error) {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -15,16 +15,21 @@ var (
 type ClientCredentials struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
+	// ProjectID is the Google Cloud project_id from the downloaded OAuth client
+	// JSON when present. Optional for backwards compatibility.
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 type googleCredentialsFile struct {
 	Installed *struct {
 		ClientID     string `json:"client_id"`
 		ClientSecret string `json:"client_secret"`
+		ProjectID    string `json:"project_id"`
 	} `json:"installed"`
 	Web *struct {
 		ClientID     string `json:"client_id"`
 		ClientSecret string `json:"client_secret"`
+		ProjectID    string `json:"project_id"`
 	} `json:"web"`
 }
 
@@ -34,18 +39,22 @@ func ParseGoogleOAuthClientJSON(b []byte) (ClientCredentials, error) {
 		return ClientCredentials{}, fmt.Errorf("decode credentials json: %w", err)
 	}
 
-	var clientID, clientSecret string
+	var clientID, clientSecret, projectID string
 	if f.Installed != nil {
-		clientID, clientSecret = f.Installed.ClientID, f.Installed.ClientSecret
+		clientID, clientSecret, projectID = f.Installed.ClientID, f.Installed.ClientSecret, f.Installed.ProjectID
 	} else if f.Web != nil {
-		clientID, clientSecret = f.Web.ClientID, f.Web.ClientSecret
+		clientID, clientSecret, projectID = f.Web.ClientID, f.Web.ClientSecret, f.Web.ProjectID
 	}
 
 	if clientID == "" || clientSecret == "" {
 		return ClientCredentials{}, errInvalidCredentials
 	}
 
-	return ClientCredentials{ClientID: clientID, ClientSecret: clientSecret}, nil
+	return ClientCredentials{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		ProjectID:    projectID,
+	}, nil
 }
 
 func WriteClientCredentials(c ClientCredentials) error {
@@ -129,6 +138,12 @@ func ClientCredentialsExists(client string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// SameClientCredentials reports whether two stored credential sets match for
+// idempotent install (client id/secret/project).
+func SameClientCredentials(a, b ClientCredentials) bool {
+	return a.ClientID == b.ClientID && a.ClientSecret == b.ClientSecret && a.ProjectID == b.ProjectID
 }
 
 type CredentialsMissingError struct {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -34,6 +34,17 @@ type googleCredentialsFile struct {
 }
 
 func ParseGoogleOAuthClientJSON(b []byte) (ClientCredentials, error) {
+	return parseGoogleOAuthClientJSON(b, false)
+}
+
+// ParseGoogleInstalledOAuthClientJSON accepts only a Desktop/installed OAuth
+// client. Guided setup requires this redirect-capable client type; standalone
+// credential installation retains historical web-client compatibility.
+func ParseGoogleInstalledOAuthClientJSON(b []byte) (ClientCredentials, error) {
+	return parseGoogleOAuthClientJSON(b, true)
+}
+
+func parseGoogleOAuthClientJSON(b []byte, requireInstalled bool) (ClientCredentials, error) {
 	var f googleCredentialsFile
 	if err := json.Unmarshal(b, &f); err != nil {
 		return ClientCredentials{}, fmt.Errorf("decode credentials json: %w", err)
@@ -42,7 +53,7 @@ func ParseGoogleOAuthClientJSON(b []byte) (ClientCredentials, error) {
 	var clientID, clientSecret, projectID string
 	if f.Installed != nil {
 		clientID, clientSecret, projectID = f.Installed.ClientID, f.Installed.ClientSecret, f.Installed.ProjectID
-	} else if f.Web != nil {
+	} else if !requireInstalled && f.Web != nil {
 		clientID, clientSecret, projectID = f.Web.ClientID, f.Web.ClientSecret, f.Web.ProjectID
 	}
 
@@ -50,11 +61,7 @@ func ParseGoogleOAuthClientJSON(b []byte) (ClientCredentials, error) {
 		return ClientCredentials{}, errInvalidCredentials
 	}
 
-	return ClientCredentials{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		ProjectID:    projectID,
-	}, nil
+	return ClientCredentials{ClientID: clientID, ClientSecret: clientSecret, ProjectID: projectID}, nil
 }
 
 func WriteClientCredentials(c ClientCredentials) error {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -18,7 +18,15 @@ type ClientCredentials struct {
 	// ProjectID is the Google Cloud project_id from the downloaded OAuth client
 	// JSON when present. Optional for backwards compatibility.
 	ProjectID string `json:"project_id,omitempty"`
+	// ClientType records the original OAuth JSON envelope (installed or web).
+	// Empty is a legacy compact credential whose type is intentionally unknown.
+	ClientType string `json:"client_type,omitempty"`
 }
+
+const (
+	OAuthClientTypeInstalled = "installed"
+	OAuthClientTypeWeb       = "web"
+)
 
 type googleCredentialsFile struct {
 	Installed *struct {
@@ -50,18 +58,18 @@ func parseGoogleOAuthClientJSON(b []byte, requireInstalled bool) (ClientCredenti
 		return ClientCredentials{}, fmt.Errorf("decode credentials json: %w", err)
 	}
 
-	var clientID, clientSecret, projectID string
+	var clientID, clientSecret, projectID, clientType string
 	if f.Installed != nil {
-		clientID, clientSecret, projectID = f.Installed.ClientID, f.Installed.ClientSecret, f.Installed.ProjectID
+		clientID, clientSecret, projectID, clientType = f.Installed.ClientID, f.Installed.ClientSecret, f.Installed.ProjectID, OAuthClientTypeInstalled
 	} else if !requireInstalled && f.Web != nil {
-		clientID, clientSecret, projectID = f.Web.ClientID, f.Web.ClientSecret, f.Web.ProjectID
+		clientID, clientSecret, projectID, clientType = f.Web.ClientID, f.Web.ClientSecret, f.Web.ProjectID, OAuthClientTypeWeb
 	}
 
 	if clientID == "" || clientSecret == "" {
 		return ClientCredentials{}, errInvalidCredentials
 	}
 
-	return ClientCredentials{ClientID: clientID, ClientSecret: clientSecret, ProjectID: projectID}, nil
+	return ClientCredentials{ClientID: clientID, ClientSecret: clientSecret, ProjectID: projectID, ClientType: clientType}, nil
 }
 
 func WriteClientCredentials(c ClientCredentials) error {
@@ -150,7 +158,7 @@ func ClientCredentialsExists(client string) (bool, error) {
 // SameClientCredentials reports whether two stored credential sets match for
 // idempotent install (client id/secret/project).
 func SameClientCredentials(a, b ClientCredentials) bool {
-	return a.ClientID == b.ClientID && a.ClientSecret == b.ClientSecret && a.ProjectID == b.ProjectID
+	return a.ClientID == b.ClientID && a.ClientSecret == b.ClientSecret && a.ProjectID == b.ProjectID && a.ClientType == b.ClientType
 }
 
 type CredentialsMissingError struct {

--- a/internal/config/credentials_project_test.go
+++ b/internal/config/credentials_project_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParseGoogleOAuthClientJSON_ProjectID(t *testing.T) {
+	got, err := ParseGoogleOAuthClientJSON([]byte(`{"installed":{"client_id":"id","client_secret":"sec","project_id":"my-proj"}}`))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if got.ProjectID != "my-proj" {
+		t.Fatalf("project_id=%q", got.ProjectID)
+	}
+}
+
+func TestClientCredentials_ProjectIDRoundtrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	in := ClientCredentials{ClientID: "id", ClientSecret: "secret", ProjectID: "proj-1"}
+	if err := WriteClientCredentials(in); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	out, err := ReadClientCredentials()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if out.ProjectID != "proj-1" {
+		t.Fatalf("project_id=%q", out.ProjectID)
+	}
+}
+
+func TestSameClientCredentials(t *testing.T) {
+	a := ClientCredentials{ClientID: "a", ClientSecret: "b", ProjectID: "p"}
+	b := a
+
+	if !SameClientCredentials(a, b) {
+		t.Fatalf("expected same")
+	}
+
+	b.ProjectID = "other"
+
+	if SameClientCredentials(a, b) {
+		t.Fatalf("expected different")
+	}
+}

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -44,6 +44,21 @@ func TestParseGoogleOAuthClientJSON(t *testing.T) {
 	})
 }
 
+func TestParseGoogleInstalledOAuthClientJSON_RejectsWebClient(t *testing.T) {
+	if _, err := ParseGoogleInstalledOAuthClientJSON([]byte(`{"web":{"client_id":"id","client_secret":"sec"}}`)); err == nil {
+		t.Fatal("expected web client rejection")
+	}
+
+	got, err := ParseGoogleInstalledOAuthClientJSON([]byte(`{"installed":{"client_id":"id","client_secret":"sec"}}`))
+	if err != nil {
+		t.Fatalf("installed client: %v", err)
+	}
+
+	if got.ClientID != "id" {
+		t.Fatalf("client id = %q", got.ClientID)
+	}
+}
+
 func TestClientCredentials_Roundtrip(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/gcloud/gcloud.go
+++ b/internal/gcloud/gcloud.go
@@ -1,0 +1,517 @@
+// Package gcloud provides a narrow, injectable wrapper around the gcloud CLI
+// for guided auth setup. It never mutates global gcloud config, never runs
+// Application Default Credentials login, and always scopes project operations
+// with an explicit project ID.
+package gcloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+var (
+	errProjectIDRequired = errors.New("project id required")
+	errGCloudCommand     = errors.New("gcloud command failed")
+	errGCloudParse       = errors.New("parse gcloud output")
+)
+
+// Runner executes a gcloud-style command. Tests inject a fake implementation.
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) (stdout, stderr string, exitCode int, err error)
+}
+
+// ExecRunner runs real subprocesses via os/exec.
+type ExecRunner struct{}
+
+func (ExecRunner) Run(ctx context.Context, name string, args ...string) (string, string, int, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	exitCode := 0
+
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return stdout.String(), stderr.String(), ee.ExitCode(), nil
+		}
+
+		return stdout.String(), stderr.String(), -1, err
+	}
+
+	return stdout.String(), stderr.String(), exitCode, nil
+}
+
+// Client is a typed gcloud integration used by auth setup.
+type Client struct {
+	Runner Runner
+	Binary string
+}
+
+func New(runner Runner) *Client {
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+
+	return &Client{Runner: runner, Binary: "gcloud"}
+}
+
+// Result is a raw command outcome with sanitized stderr.
+type Result struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	// Kind classifies common blocker categories when ExitCode != 0.
+	Kind BlockerKind
+}
+
+// BlockerKind is a best-effort classification of gcloud failures.
+type BlockerKind string
+
+const (
+	BlockerNone         BlockerKind = ""
+	BlockerNotInstalled BlockerKind = "not_installed"
+	BlockerNotLoggedIn  BlockerKind = "not_logged_in"
+	BlockerPermission   BlockerKind = "permission"
+	BlockerQuota        BlockerKind = "quota"
+	BlockerNotFound     BlockerKind = "not_found"
+	BlockerInvalidInput BlockerKind = "invalid_input"
+	BlockerUnknown      BlockerKind = "unknown"
+)
+
+// Account is the active gcloud account identity.
+type Account struct {
+	Account string `json:"account"`
+	Status  string `json:"status,omitempty"`
+}
+
+// Project is a Cloud project summary.
+// JSON field names match gcloud --format=json output.
+type Project struct {
+	ProjectID      string `json:"projectId"` //nolint:tagliatelle // gcloud wire format
+	Name           string `json:"name,omitempty"`
+	ProjectNumber  string `json:"projectNumber,omitempty"`  //nolint:tagliatelle // gcloud wire format
+	LifecycleState string `json:"lifecycleState,omitempty"` //nolint:tagliatelle // gcloud wire format
+	Parent         string `json:"parent,omitempty"`
+}
+
+// ServiceState describes whether a Service Usage API is enabled.
+type ServiceState struct {
+	ServiceID string `json:"service_id"`
+	State     string `json:"state"`
+	Enabled   bool   `json:"enabled"`
+}
+
+func (c *Client) binary() string {
+	if strings.TrimSpace(c.Binary) == "" {
+		return "gcloud"
+	}
+
+	return c.Binary
+}
+
+func (c *Client) run(ctx context.Context, args ...string) Result {
+	stdout, stderr, exitCode, err := c.Runner.Run(ctx, c.binary(), args...)
+
+	res := Result{
+		Stdout:   stdout,
+		Stderr:   sanitize(stderr),
+		ExitCode: exitCode,
+	}
+
+	if err != nil {
+		// Runner failed before producing an exit code (e.g. binary missing).
+		res.ExitCode = -1
+		if res.Stderr == "" {
+			res.Stderr = sanitize(err.Error())
+		}
+
+		if isNotInstalled(err.Error()) || isNotInstalled(res.Stderr) {
+			res.Kind = BlockerNotInstalled
+		} else {
+			res.Kind = BlockerUnknown
+		}
+
+		return res
+	}
+
+	if exitCode != 0 {
+		res.Kind = classify(res.Stderr, exitCode)
+	}
+
+	return res
+}
+
+// Installed reports whether the gcloud binary can be executed.
+func (c *Client) Installed(ctx context.Context) (bool, Result) {
+	res := c.run(ctx, "version", "--format=json")
+	if res.ExitCode == 0 {
+		return true, res
+	}
+
+	if res.Kind == BlockerNotInstalled || isNotInstalled(res.Stderr) {
+		res.Kind = BlockerNotInstalled
+
+		return false, res
+	}
+	// Some environments return non-json but still have gcloud; treat any response as installed unless missing.
+	if res.ExitCode == 127 || strings.Contains(strings.ToLower(res.Stderr), "not found") {
+		res.Kind = BlockerNotInstalled
+
+		return false, res
+	}
+	// If binary ran, consider installed even when version parsing fails.
+	if res.ExitCode >= 0 && res.Kind != BlockerNotInstalled {
+		return true, res
+	}
+
+	return false, res
+}
+
+// ActiveAccount returns the active authenticated account, if any.
+func (c *Client) ActiveAccount(ctx context.Context) (Account, Result, error) {
+	res := c.run(ctx, "auth", "list", "--filter=status:ACTIVE", "--format=json")
+	if res.ExitCode != 0 {
+		return Account{}, res, fmt.Errorf("%w: auth list exit %d: %s", errGCloudCommand, res.ExitCode, res.Stderr)
+	}
+
+	var rows []struct {
+		Account string `json:"account"`
+		Status  string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Stdout)), &rows); err != nil {
+		// empty list often prints []
+		if strings.TrimSpace(res.Stdout) == "" || strings.TrimSpace(res.Stdout) == "[]" {
+			res.Kind = BlockerNotLoggedIn
+
+			return Account{}, res, nil
+		}
+
+		return Account{}, res, fmt.Errorf("%w: auth list: %w", errGCloudParse, err)
+	}
+
+	if len(rows) == 0 {
+		res.Kind = BlockerNotLoggedIn
+
+		return Account{}, res, nil
+	}
+
+	return Account{Account: rows[0].Account, Status: rows[0].Status}, res, nil
+}
+
+// Login runs interactive user login. Callers must not invoke this under --no-input.
+// Does not set Application Default Credentials and does not mutate config.
+func (c *Client) Login(ctx context.Context) Result {
+	// Do not pass ADC flags; ADC login is intentionally out of scope.
+	return c.run(ctx, "auth", "login", "--brief")
+}
+
+// ListProjects returns accessible projects (one bounded list call).
+func (c *Client) ListProjects(ctx context.Context) ([]Project, Result, error) {
+	res := c.run(ctx, "projects", "list", "--format=json")
+	if res.ExitCode != 0 {
+		return nil, res, fmt.Errorf("%w: projects list exit %d: %s", errGCloudCommand, res.ExitCode, res.Stderr)
+	}
+
+	var rows []Project
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Stdout)), &rows); err != nil {
+		if strings.TrimSpace(res.Stdout) == "" || strings.TrimSpace(res.Stdout) == "[]" {
+			return []Project{}, res, nil
+		}
+
+		return nil, res, fmt.Errorf("%w: projects list: %w", errGCloudParse, err)
+	}
+
+	return rows, res, nil
+}
+
+// ActiveProjectID discovers the active configuration project without changing it.
+func (c *Client) ActiveProjectID(ctx context.Context) (string, Result, error) {
+	res := c.run(ctx, "config", "get-value", "project", "--format=json")
+	if res.ExitCode != 0 {
+		return "", res, fmt.Errorf("%w: config get-value project exit %d: %s", errGCloudCommand, res.ExitCode, res.Stderr)
+	}
+
+	raw := strings.TrimSpace(res.Stdout)
+	if raw == "" || raw == "null" || raw == `""` {
+		return "", res, nil
+	}
+
+	var value string
+	if err := json.Unmarshal([]byte(raw), &value); err != nil {
+		// non-json plain value
+		value = strings.Trim(raw, "\"")
+	}
+
+	if value == "(unset)" {
+		return "", res, nil
+	}
+
+	return strings.TrimSpace(value), res, nil
+}
+
+// CreateProject creates a project. parent is optional (folders/123 or organizations/123).
+// Never uses --set-as-default.
+func (c *Client) CreateProject(ctx context.Context, projectID, name, parent string) (Project, Result, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return Project{}, Result{Kind: BlockerInvalidInput}, errProjectIDRequired
+	}
+
+	args := []string{"projects", "create", projectID, "--format=json"}
+	if strings.TrimSpace(name) != "" {
+		args = append(args, "--name", name)
+	}
+
+	parent = strings.TrimSpace(parent)
+	switch {
+	case parent == "":
+	case strings.HasPrefix(parent, "organizations/"):
+		args = append(args, "--organization", strings.TrimPrefix(parent, "organizations/"))
+	case strings.HasPrefix(parent, "folders/"):
+		args = append(args, "--folder", strings.TrimPrefix(parent, "folders/"))
+	case strings.HasPrefix(parent, "folder/"):
+		args = append(args, "--folder", strings.TrimPrefix(parent, "folder/"))
+	default:
+		// Bare numeric/id: treat as folder ID for convenience.
+		args = append(args, "--folder", parent)
+	}
+
+	res := c.run(ctx, args...)
+	if res.ExitCode != 0 {
+		return Project{}, res, fmt.Errorf("%w: projects create exit %d: %s", errGCloudCommand, res.ExitCode, res.Stderr)
+	}
+
+	var p Project
+	// Best-effort parse; some gcloud versions return empty bodies.
+	_ = json.Unmarshal([]byte(strings.TrimSpace(res.Stdout)), &p)
+	if p.ProjectID == "" {
+		p.ProjectID = projectID
+	}
+
+	if p.Name == "" {
+		p.Name = name
+	}
+
+	return p, res, nil
+}
+
+// ListEnabledServices lists enabled services for an explicit project.
+func (c *Client) ListEnabledServices(ctx context.Context, projectID string) ([]ServiceState, Result, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return nil, Result{Kind: BlockerInvalidInput}, errProjectIDRequired
+	}
+
+	res := c.run(ctx, "services", "list", "--enabled", "--project", projectID, "--format=json")
+	if res.ExitCode != 0 {
+		return nil, res, fmt.Errorf("%w: services list exit %d: %s", errGCloudCommand, res.ExitCode, res.Stderr)
+	}
+
+	var rows []struct {
+		Config *struct {
+			Name string `json:"name"`
+		} `json:"config"`
+		Name  string `json:"name"`
+		State string `json:"state"`
+	}
+
+	raw := strings.TrimSpace(res.Stdout)
+	if raw == "" || raw == "[]" {
+		return []ServiceState{}, res, nil
+	}
+
+	if err := json.Unmarshal([]byte(raw), &rows); err != nil {
+		return nil, res, fmt.Errorf("%w: services list: %w", errGCloudParse, err)
+	}
+
+	out := make([]ServiceState, 0, len(rows))
+	for _, row := range rows {
+		id := serviceIDFromName(row.Name)
+		if row.Config != nil && row.Config.Name != "" {
+			id = serviceIDFromName(row.Config.Name)
+		}
+
+		if id == "" {
+			continue
+		}
+
+		state := row.State
+		if state == "" {
+			state = "ENABLED"
+		}
+
+		out = append(out, ServiceState{
+			ServiceID: id,
+			State:     state,
+			Enabled:   strings.EqualFold(state, "ENABLED"),
+		})
+	}
+
+	return out, res, nil
+}
+
+// EnableServices enables the provided Service Usage IDs on projectID and returns
+// which IDs remain missing after a verification list.
+func (c *Client) EnableServices(ctx context.Context, projectID string, serviceIDs []string) (enabled []string, stillMissing []string, res Result, err error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return nil, nil, Result{Kind: BlockerInvalidInput}, errProjectIDRequired
+	}
+
+	wanted := uniqueNonEmpty(serviceIDs)
+	if len(wanted) == 0 {
+		return nil, nil, Result{}, nil
+	}
+
+	args := make([]string, 0, 4+len(wanted))
+	args = append(args, "services", "enable", "--project", projectID)
+	args = append(args, wanted...)
+
+	res = c.run(ctx, args...)
+	if res.ExitCode != 0 {
+		return nil, wanted, res, fmt.Errorf("%w: services enable exit %d: %s", errGCloudCommand, res.ExitCode, res.Stderr)
+	}
+
+	// Verify with one follow-up list of the selected project only.
+	states, listRes, listErr := c.ListEnabledServices(ctx, projectID)
+	if listErr != nil {
+		return wanted, nil, listRes, listErr
+	}
+
+	have := make(map[string]bool, len(states))
+	for _, s := range states {
+		if s.Enabled {
+			have[s.ServiceID] = true
+		}
+	}
+
+	for _, id := range wanted {
+		if have[id] {
+			enabled = append(enabled, id)
+		} else {
+			stillMissing = append(stillMissing, id)
+		}
+	}
+
+	return enabled, stillMissing, listRes, nil
+}
+
+// MissingServices returns which of wanted are not enabled on projectID.
+func (c *Client) MissingServices(ctx context.Context, projectID string, wanted []string) (missing []string, states []ServiceState, res Result, err error) {
+	states, res, err = c.ListEnabledServices(ctx, projectID)
+	if err != nil {
+		return nil, nil, res, err
+	}
+
+	have := make(map[string]bool, len(states))
+	for _, s := range states {
+		if s.Enabled {
+			have[s.ServiceID] = true
+		}
+	}
+
+	for _, id := range uniqueNonEmpty(wanted) {
+		if !have[id] {
+			missing = append(missing, id)
+		}
+	}
+
+	return missing, states, res, nil
+}
+
+func serviceIDFromName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	// projects/x/services/gmail.googleapis.com or bare gmail.googleapis.com
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		return name[i+1:]
+	}
+
+	return name
+}
+
+func uniqueNonEmpty(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+
+	for _, v := range in {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+
+		if _, ok := seen[v]; ok {
+			continue
+		}
+
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+
+	return out
+}
+
+func sanitize(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Drop common environment dumps / tokens if present.
+	lower := strings.ToLower(s)
+	for _, secret := range []string{"client_secret", "refresh_token", "access_token", "authorization:"} {
+		if strings.Contains(lower, secret) {
+			return "[redacted gcloud error]"
+		}
+	}
+	// Cap noisy stderr.
+	if len(s) > 2000 {
+		return s[:2000] + "…"
+	}
+
+	return s
+}
+
+func isNotInstalled(msg string) bool {
+	lower := strings.ToLower(msg)
+
+	return strings.Contains(lower, "executable file not found") ||
+		strings.Contains(lower, "no such file or directory") ||
+		strings.Contains(lower, "not found in $path") ||
+		strings.Contains(lower, "command not found")
+}
+
+func classify(stderr string, exitCode int) BlockerKind {
+	lower := strings.ToLower(stderr)
+	switch {
+	case isNotInstalled(stderr) || exitCode == 127:
+		return BlockerNotInstalled
+	case strings.Contains(lower, "not logged in") ||
+		strings.Contains(lower, "reauthentication required") ||
+		strings.Contains(lower, "there was a problem refreshing your current auth tokens") ||
+		(strings.Contains(lower, "please run:") && strings.Contains(lower, "gcloud auth login")):
+		return BlockerNotLoggedIn
+	case strings.Contains(lower, "permission") ||
+		strings.Contains(lower, "denied") ||
+		strings.Contains(lower, "403") ||
+		strings.Contains(lower, "caller does not have permission"):
+		return BlockerPermission
+	case strings.Contains(lower, "quota") || strings.Contains(lower, "rate limit"):
+		return BlockerQuota
+	case strings.Contains(lower, "was not found") || strings.Contains(lower, "not found") || strings.Contains(lower, "404"):
+		return BlockerNotFound
+	case strings.Contains(lower, "invalid") || strings.Contains(lower, "must match") || exitCode == 2:
+		return BlockerInvalidInput
+	default:
+		return BlockerUnknown
+	}
+}

--- a/internal/gcloud/gcloud.go
+++ b/internal/gcloud/gcloud.go
@@ -262,7 +262,8 @@ func (c *Client) Login(ctx context.Context) Result {
 	return c.run(ctx, args...)
 }
 
-// ListProjects returns at most limit accessible projects in one list call.
+// ListProjects returns the projects returned by one gcloud list call, capped by limit.
+// Callers that need to detect truncation should request their display limit plus one.
 func (c *Client) ListProjects(ctx context.Context, limit int) ([]Project, Result, error) {
 	if limit <= 0 {
 		return nil, Result{Kind: BlockerInvalidInput}, errProjectListLimit
@@ -444,6 +445,8 @@ func (c *Client) EnableServices(ctx context.Context, projectID string, serviceID
 	}
 
 	wanted := uniqueNonEmpty(serviceIDs)
+
+	stillMissing = make([]string, 0, len(wanted))
 	if len(wanted) == 0 {
 		return nil, nil, Result{}, nil
 	}

--- a/internal/gcloud/gcloud.go
+++ b/internal/gcloud/gcloud.go
@@ -10,12 +10,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
 
 var (
 	errProjectIDRequired = errors.New("project id required")
+	errProjectListLimit  = errors.New("project list limit must be positive")
 	errGCloudCommand     = errors.New("gcloud command failed")
 	errGCloudParse       = errors.New("parse gcloud output")
 )
@@ -23,6 +25,12 @@ var (
 // Runner executes a gcloud-style command. Tests inject a fake implementation.
 type Runner interface {
 	Run(ctx context.Context, name string, args ...string) (stdout, stderr string, exitCode int, err error)
+}
+
+// InteractiveRunner executes commands that require a human terminal. Its output
+// must not be captured because gcloud login may prompt in a browser or terminal.
+type InteractiveRunner interface {
+	RunInteractive(ctx context.Context, name string, args ...string) (exitCode int, err error)
 }
 
 // ExecRunner runs real subprocesses via os/exec.
@@ -47,6 +55,26 @@ func (ExecRunner) Run(ctx context.Context, name string, args ...string) (string,
 	}
 
 	return stdout.String(), stderr.String(), exitCode, nil
+}
+
+// RunInteractive attaches stdin and sends all gcloud login output to stderr so
+// setup's stdout remains structured and parseable.
+func (ExecRunner) RunInteractive(ctx context.Context, name string, args ...string) (int, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode(), nil
+		}
+
+		return -1, fmt.Errorf("run interactive gcloud: %w", err)
+	}
+
+	return 0, nil
 }
 
 // Client is a typed gcloud integration used by auth setup.
@@ -76,14 +104,15 @@ type Result struct {
 type BlockerKind string
 
 const (
-	BlockerNone         BlockerKind = ""
-	BlockerNotInstalled BlockerKind = "not_installed"
-	BlockerNotLoggedIn  BlockerKind = "not_logged_in"
-	BlockerPermission   BlockerKind = "permission"
-	BlockerQuota        BlockerKind = "quota"
-	BlockerNotFound     BlockerKind = "not_found"
-	BlockerInvalidInput BlockerKind = "invalid_input"
-	BlockerUnknown      BlockerKind = "unknown"
+	BlockerNone          BlockerKind = ""
+	BlockerNotInstalled  BlockerKind = "not_installed"
+	BlockerNotLoggedIn   BlockerKind = "not_logged_in"
+	BlockerPermission    BlockerKind = "permission"
+	BlockerQuota         BlockerKind = "quota"
+	BlockerNotFound      BlockerKind = "not_found"
+	BlockerAlreadyExists BlockerKind = "already_exists"
+	BlockerInvalidInput  BlockerKind = "invalid_input"
+	BlockerUnknown       BlockerKind = "unknown"
 )
 
 // Account is the active gcloud account identity.
@@ -209,13 +238,37 @@ func (c *Client) ActiveAccount(ctx context.Context) (Account, Result, error) {
 // Login runs interactive user login. Callers must not invoke this under --no-input.
 // Does not set Application Default Credentials and does not mutate config.
 func (c *Client) Login(ctx context.Context) Result {
-	// Do not pass ADC flags; ADC login is intentionally out of scope.
-	return c.run(ctx, "auth", "login", "--brief")
+	args := []string{"auth", "login", "--brief"} // Do not pass ADC flags.
+	if runner, ok := c.Runner.(InteractiveRunner); ok {
+		exitCode, err := runner.RunInteractive(ctx, c.binary(), args...)
+
+		res := Result{ExitCode: exitCode}
+		if err != nil {
+			res.ExitCode = -1
+
+			res.Stderr = sanitize(err.Error())
+			if isNotInstalled(res.Stderr) {
+				res.Kind = BlockerNotInstalled
+			} else {
+				res.Kind = BlockerUnknown
+			}
+		} else if exitCode != 0 {
+			res.Kind = BlockerUnknown
+		}
+
+		return res
+	}
+	// Test runners that do not implement InteractiveRunner retain the captured seam.
+	return c.run(ctx, args...)
 }
 
-// ListProjects returns accessible projects (one bounded list call).
-func (c *Client) ListProjects(ctx context.Context) ([]Project, Result, error) {
-	res := c.run(ctx, "projects", "list", "--format=json")
+// ListProjects returns at most limit accessible projects in one list call.
+func (c *Client) ListProjects(ctx context.Context, limit int) ([]Project, Result, error) {
+	if limit <= 0 {
+		return nil, Result{Kind: BlockerInvalidInput}, errProjectListLimit
+	}
+
+	res := c.run(ctx, "projects", "list", "--format=json", "--limit", fmt.Sprint(limit))
 	if res.ExitCode != 0 {
 		return nil, res, fmt.Errorf("%w: projects list exit %d: %s", errGCloudCommand, res.ExitCode, res.Stderr)
 	}
@@ -301,6 +354,30 @@ func (c *Client) CreateProject(ctx context.Context, projectID, name, parent stri
 	}
 
 	return p, res, nil
+}
+
+// DescribeProject retrieves one explicit project without changing gcloud config.
+func (c *Client) DescribeProject(ctx context.Context, projectID string) (Project, Result, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return Project{}, Result{Kind: BlockerInvalidInput}, errProjectIDRequired
+	}
+
+	res := c.run(ctx, "projects", "describe", projectID, "--format=json")
+	if res.ExitCode != 0 {
+		return Project{}, res, fmt.Errorf("%w: projects describe exit %d: %s", errGCloudCommand, res.ExitCode, res.Stderr)
+	}
+
+	var project Project
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Stdout)), &project); err != nil {
+		return Project{}, res, fmt.Errorf("%w: projects describe: %w", errGCloudParse, err)
+	}
+
+	if project.ProjectID == "" {
+		project.ProjectID = projectID
+	}
+
+	return project, res, nil
 }
 
 // ListEnabledServices lists enabled services for an explicit project.
@@ -507,6 +584,8 @@ func classify(stderr string, exitCode int) BlockerKind {
 		return BlockerPermission
 	case strings.Contains(lower, "quota") || strings.Contains(lower, "rate limit"):
 		return BlockerQuota
+	case strings.Contains(lower, "already exists") || strings.Contains(lower, "alreadyexists") || strings.Contains(lower, "already_exists") || strings.Contains(lower, "already in use"):
+		return BlockerAlreadyExists
 	case strings.Contains(lower, "was not found") || strings.Contains(lower, "not found") || strings.Contains(lower, "404"):
 		return BlockerNotFound
 	case strings.Contains(lower, "invalid") || strings.Contains(lower, "must match") || exitCode == 2:

--- a/internal/gcloud/gcloud.go
+++ b/internal/gcloud/gcloud.go
@@ -269,7 +269,8 @@ func (c *Client) ListProjects(ctx context.Context, limit int) ([]Project, Result
 		return nil, Result{Kind: BlockerInvalidInput}, errProjectListLimit
 	}
 
-	res := c.run(ctx, "projects", "list", "--format=json", "--limit", fmt.Sprint(limit))
+	// Filter before limiting so deleted/pending projects do not consume the caller's display budget.
+	res := c.run(ctx, "projects", "list", "--format=json", "--filter=lifecycleState:ACTIVE", "--limit", fmt.Sprint(limit))
 	if res.ExitCode != 0 {
 		return nil, res, fmt.Errorf("%w: projects list exit %d: %s", errGCloudCommand, res.ExitCode, res.Stderr)
 	}

--- a/internal/gcloud/gcloud_test.go
+++ b/internal/gcloud/gcloud_test.go
@@ -1,0 +1,316 @@
+package gcloud
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+var errFakeMissing = errors.New(`exec: "gcloud": executable file not found in $PATH`)
+
+type fakeRunner struct {
+	calls [][]string
+	// map key is joined args after binary
+	responses map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}
+	defaultResp struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}
+}
+
+func (f *fakeRunner) Run(ctx context.Context, name string, args ...string) (string, string, int, error) {
+	_ = ctx
+
+	f.calls = append(f.calls, append([]string{name}, args...))
+	key := strings.Join(args, " ")
+
+	if resp, ok := f.responses[key]; ok {
+		return resp.stdout, resp.stderr, resp.code, resp.err
+	}
+
+	// prefix match for services enable with variable ids
+	for k, resp := range f.responses {
+		if strings.HasPrefix(key, k) {
+			return resp.stdout, resp.stderr, resp.code, resp.err
+		}
+	}
+
+	return f.defaultResp.stdout, f.defaultResp.stderr, f.defaultResp.code, f.defaultResp.err
+}
+
+func TestInstalled_MissingBinary(t *testing.T) {
+	r := &fakeRunner{}
+	r.defaultResp.err = errFakeMissing
+	r.defaultResp.code = -1
+	c := New(r)
+
+	ok, res := c.Installed(context.Background())
+	if ok {
+		t.Fatalf("expected not installed")
+	}
+
+	if res.Kind != BlockerNotInstalled {
+		t.Fatalf("kind=%q", res.Kind)
+	}
+}
+
+func TestActiveAccount_NotLoggedIn(t *testing.T) {
+	r := &fakeRunner{responses: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"auth list --filter=status:ACTIVE --format=json": {stdout: "[]", code: 0},
+	}}
+	c := New(r)
+
+	acct, res, err := c.ActiveAccount(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if acct.Account != "" {
+		t.Fatalf("expected empty account")
+	}
+
+	if res.Kind != BlockerNotLoggedIn {
+		t.Fatalf("kind=%q", res.Kind)
+	}
+}
+
+func TestActiveAccount_OK(t *testing.T) {
+	r := &fakeRunner{responses: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"auth list --filter=status:ACTIVE --format=json": {
+			stdout: `[{"account":"user@example.com","status":"ACTIVE"}]`,
+			code:   0,
+		},
+	}}
+	c := New(r)
+
+	acct, _, err := c.ActiveAccount(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if acct.Account != "user@example.com" {
+		t.Fatalf("got %q", acct.Account)
+	}
+}
+
+func TestListProjects_Parses(t *testing.T) {
+	r := &fakeRunner{responses: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"projects list --format=json": {
+			stdout: `[{"projectId":"p1","name":"One"},{"projectId":"p2","name":"Two"}]`,
+			code:   0,
+		},
+	}}
+	c := New(r)
+
+	projects, _, err := c.ListProjects(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(projects) != 2 || projects[0].ProjectID != "p1" {
+		t.Fatalf("got %#v", projects)
+	}
+}
+
+func TestCreateProject_ParentFlagsAndNoDefault(t *testing.T) {
+	r := &fakeRunner{responses: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"projects create my-proj --format=json --name Demo --folder 123": {
+			stdout: `{"projectId":"my-proj","name":"Demo"}`,
+			code:   0,
+		},
+	}}
+	c := New(r)
+
+	p, _, err := c.CreateProject(context.Background(), "my-proj", "Demo", "folders/123")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if p.ProjectID != "my-proj" {
+		t.Fatalf("got %#v", p)
+	}
+
+	if len(r.calls) != 1 {
+		t.Fatalf("calls=%v", r.calls)
+	}
+
+	joined := strings.Join(r.calls[0], " ")
+	if strings.Contains(joined, "--set-as-default") {
+		t.Fatalf("must not set default: %s", joined)
+	}
+
+	if !strings.Contains(joined, "--folder 123") {
+		t.Fatalf("expected folder flag: %s", joined)
+	}
+}
+
+func TestCreateProject_OrganizationParent(t *testing.T) {
+	r := &fakeRunner{responses: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"projects create my-proj --format=json --organization 9": {
+			stdout: `{"projectId":"my-proj"}`,
+			code:   0,
+		},
+	}}
+	c := New(r)
+
+	_, _, err := c.CreateProject(context.Background(), "my-proj", "", "organizations/9")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	joined := strings.Join(r.calls[0], " ")
+	if !strings.Contains(joined, "--organization 9") {
+		t.Fatalf("expected org flag: %s", joined)
+	}
+}
+
+func TestListEnabledServices_ProjectScoped(t *testing.T) {
+	r := &fakeRunner{responses: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"services list --enabled --project demo --format=json": {
+			stdout: `[{"name":"projects/demo/services/gmail.googleapis.com","state":"ENABLED"},{"config":{"name":"drive.googleapis.com"},"state":"ENABLED"}]`,
+			code:   0,
+		},
+	}}
+	c := New(r)
+
+	states, _, err := c.ListEnabledServices(context.Background(), "demo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(states) != 2 {
+		t.Fatalf("got %#v", states)
+	}
+
+	joined := strings.Join(r.calls[0], " ")
+	if !strings.Contains(joined, "--project demo") {
+		t.Fatalf("project not scoped: %s", joined)
+	}
+}
+
+func TestEnableServices_PartialMissingAfterVerify(t *testing.T) {
+	r := &fakeRunner{responses: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"services enable --project demo gmail.googleapis.com drive.googleapis.com": {code: 0},
+		"services list --enabled --project demo --format=json": {
+			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`,
+			code:   0,
+		},
+	}}
+	c := New(r)
+
+	enabled, missing, _, err := c.EnableServices(context.Background(), "demo", []string{"gmail.googleapis.com", "drive.googleapis.com"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(enabled) != 1 || enabled[0] != "gmail.googleapis.com" {
+		t.Fatalf("enabled=%v", enabled)
+	}
+
+	if len(missing) != 1 || missing[0] != "drive.googleapis.com" {
+		t.Fatalf("missing=%v", missing)
+	}
+}
+
+func TestMissingServices(t *testing.T) {
+	r := &fakeRunner{responses: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"services list --enabled --project demo --format=json": {
+			stdout: `[{"name":"gmail.googleapis.com","state":"ENABLED"}]`,
+			code:   0,
+		},
+	}}
+	c := New(r)
+
+	missing, _, _, err := c.MissingServices(context.Background(), "demo", []string{"gmail.googleapis.com", "calendar-json.googleapis.com"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(missing) != 1 || missing[0] != "calendar-json.googleapis.com" {
+		t.Fatalf("missing=%v", missing)
+	}
+}
+
+func TestClassify_Permission(t *testing.T) {
+	if got := classify("PERMISSION_DENIED: caller does not have permission", 1); got != BlockerPermission {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSanitize_RedactsSecrets(t *testing.T) {
+	if got := sanitize("client_secret=abc access denied"); got != "[redacted gcloud error]" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestNeverUsesConfigSet(t *testing.T) {
+	r := &fakeRunner{responses: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"projects list --format=json":                       {stdout: "[]", code: 0},
+		"auth list --filter=status:ACTIVE --format=json":    {stdout: "[]", code: 0},
+		"config get-value project --format=json":            {stdout: "null", code: 0},
+		"services list --enabled --project p --format=json": {stdout: "[]", code: 0},
+		"version --format=json":                             {stdout: `{"Google Cloud SDK":"1"}`, code: 0},
+		"projects create p --format=json":                   {stdout: `{"projectId":"p"}`, code: 0},
+		"services enable --project p gmail.googleapis.com":  {code: 0},
+		"auth login --brief":                                {code: 0},
+	}}
+	c := New(r)
+	ctx := context.Background()
+	_, _ = c.Installed(ctx)
+	_, _, _ = c.ActiveAccount(ctx)
+	_, _, _ = c.ListProjects(ctx)
+	_, _, _ = c.ActiveProjectID(ctx)
+	_, _, _ = c.CreateProject(ctx, "p", "", "")
+	_, _, _ = c.ListEnabledServices(ctx, "p")
+	_, _, _, _ = c.EnableServices(ctx, "p", []string{"gmail.googleapis.com"})
+	_ = c.Login(ctx)
+
+	for _, call := range r.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "config set") || strings.Contains(joined, "--set-as-default") || strings.Contains(joined, "application-default") {
+			t.Fatalf("forbidden call: %s", joined)
+		}
+	}
+}

--- a/internal/gcloud/gcloud_test.go
+++ b/internal/gcloud/gcloud_test.go
@@ -113,7 +113,7 @@ func TestListProjects_Parses(t *testing.T) {
 		code           int
 		err            error
 	}{
-		"projects list --format=json --limit 100": {
+		"projects list --format=json --filter=lifecycleState:ACTIVE --limit 100": {
 			stdout: `[{"projectId":"p1","name":"One"},{"projectId":"p2","name":"Two"}]`,
 			code:   0,
 		},
@@ -317,7 +317,7 @@ func TestListProjectsUsesBoundedLimit(t *testing.T) {
 		code           int
 		err            error
 	}{
-		"projects list --format=json --limit 2": {stdout: `[]`},
+		"projects list --format=json --filter=lifecycleState:ACTIVE --limit 2": {stdout: `[]`},
 	}}
 	if _, _, err := New(r).ListProjects(context.Background(), 2); err != nil {
 		t.Fatal(err)
@@ -334,14 +334,14 @@ func TestNeverUsesConfigSet(t *testing.T) {
 		code           int
 		err            error
 	}{
-		"projects list --format=json --limit 100":           {stdout: "[]", code: 0},
-		"auth list --filter=status:ACTIVE --format=json":    {stdout: "[]", code: 0},
-		"config get-value project --format=json":            {stdout: "null", code: 0},
-		"services list --enabled --project p --format=json": {stdout: "[]", code: 0},
-		"version --format=json":                             {stdout: `{"Google Cloud SDK":"1"}`, code: 0},
-		"projects create p --format=json":                   {stdout: `{"projectId":"p"}`, code: 0},
-		"services enable --project p gmail.googleapis.com":  {code: 0},
-		"auth login --brief":                                {code: 0},
+		"projects list --format=json --filter=lifecycleState:ACTIVE --limit 100": {stdout: "[]", code: 0},
+		"auth list --filter=status:ACTIVE --format=json":                         {stdout: "[]", code: 0},
+		"config get-value project --format=json":                                 {stdout: "null", code: 0},
+		"services list --enabled --project p --format=json":                      {stdout: "[]", code: 0},
+		"version --format=json":                                                  {stdout: `{"Google Cloud SDK":"1"}`, code: 0},
+		"projects create p --format=json":                                        {stdout: `{"projectId":"p"}`, code: 0},
+		"services enable --project p gmail.googleapis.com":                       {code: 0},
+		"auth login --brief":                                                     {code: 0},
 	}}
 	c := New(r)
 	ctx := context.Background()

--- a/internal/gcloud/gcloud_test.go
+++ b/internal/gcloud/gcloud_test.go
@@ -113,14 +113,14 @@ func TestListProjects_Parses(t *testing.T) {
 		code           int
 		err            error
 	}{
-		"projects list --format=json": {
+		"projects list --format=json --limit 100": {
 			stdout: `[{"projectId":"p1","name":"One"},{"projectId":"p2","name":"Two"}]`,
 			code:   0,
 		},
 	}}
 	c := New(r)
 
-	projects, _, err := c.ListProjects(context.Background())
+	projects, _, err := c.ListProjects(context.Background(), 100)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -275,9 +275,56 @@ func TestClassify_Permission(t *testing.T) {
 	}
 }
 
+func TestClassify_AlreadyInUse(t *testing.T) {
+	if got := classify("project ID demo is already in use", 1); got != BlockerAlreadyExists {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestSanitize_RedactsSecrets(t *testing.T) {
 	if got := sanitize("client_secret=abc access denied"); got != "[redacted gcloud error]" {
 		t.Fatalf("got %q", got)
+	}
+}
+
+type interactiveFakeRunner struct {
+	fakeRunner
+	interactiveCalls [][]string
+}
+
+func (f *interactiveFakeRunner) RunInteractive(ctx context.Context, name string, args ...string) (int, error) {
+	_ = ctx
+
+	f.interactiveCalls = append(f.interactiveCalls, append([]string{name}, args...))
+
+	return 0, nil
+}
+
+func TestLoginUsesInteractiveRunner(t *testing.T) {
+	r := &interactiveFakeRunner{}
+	if got := New(r).Login(context.Background()); got.ExitCode != 0 {
+		t.Fatalf("login=%#v", got)
+	}
+
+	if len(r.interactiveCalls) != 1 || len(r.calls) != 0 {
+		t.Fatalf("interactive=%v captured=%v", r.interactiveCalls, r.calls)
+	}
+}
+
+func TestListProjectsUsesBoundedLimit(t *testing.T) {
+	r := &fakeRunner{responses: map[string]struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}{
+		"projects list --format=json --limit 2": {stdout: `[]`},
+	}}
+	if _, _, err := New(r).ListProjects(context.Background(), 2); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(r.calls) != 1 || !strings.Contains(strings.Join(r.calls[0], " "), "--limit 2") {
+		t.Fatalf("calls=%v", r.calls)
 	}
 }
 
@@ -287,7 +334,7 @@ func TestNeverUsesConfigSet(t *testing.T) {
 		code           int
 		err            error
 	}{
-		"projects list --format=json":                       {stdout: "[]", code: 0},
+		"projects list --format=json --limit 100":           {stdout: "[]", code: 0},
 		"auth list --filter=status:ACTIVE --format=json":    {stdout: "[]", code: 0},
 		"config get-value project --format=json":            {stdout: "null", code: 0},
 		"services list --enabled --project p --format=json": {stdout: "[]", code: 0},
@@ -300,7 +347,7 @@ func TestNeverUsesConfigSet(t *testing.T) {
 	ctx := context.Background()
 	_, _ = c.Installed(ctx)
 	_, _, _ = c.ActiveAccount(ctx)
-	_, _, _ = c.ListProjects(ctx)
+	_, _, _ = c.ListProjects(ctx, 100)
 	_, _, _ = c.ActiveProjectID(ctx)
 	_, _, _ = c.CreateProject(ctx, "p", "", "")
 	_, _, _ = c.ListEnabledServices(ctx, "p")

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -64,10 +64,11 @@ type ScopeOptions struct {
 }
 
 type serviceInfo struct {
-	scopes []string
-	user   bool
-	apis   []string
-	note   string
+	scopes          []string
+	user            bool
+	apis            []string // human labels for docs/help
+	serviceUsageIDs []string // Google Service Usage API IDs (e.g. gmail.googleapis.com)
+	note            string
 }
 
 var serviceOrder = []Service{
@@ -98,13 +99,15 @@ var serviceInfoByService = map[Service]serviceInfo{
 			"https://www.googleapis.com/auth/gmail.settings.basic",
 			"https://www.googleapis.com/auth/gmail.settings.sharing",
 		},
-		user: true,
-		apis: []string{"Gmail API"},
+		user:            true,
+		apis:            []string{"Gmail API"},
+		serviceUsageIDs: []string{"gmail.googleapis.com"},
 	},
 	ServiceCalendar: {
-		scopes: []string{"https://www.googleapis.com/auth/calendar"},
-		user:   true,
-		apis:   []string{"Calendar API"},
+		scopes:          []string{"https://www.googleapis.com/auth/calendar"},
+		user:            true,
+		apis:            []string{"Calendar API"},
+		serviceUsageIDs: []string{"calendar-json.googleapis.com"},
 	},
 	ServiceChat: {
 		scopes: []string{
@@ -113,8 +116,9 @@ var serviceInfoByService = map[Service]serviceInfo{
 			"https://www.googleapis.com/auth/chat.memberships",
 			"https://www.googleapis.com/auth/chat.users.readstate.readonly",
 		},
-		user: true,
-		apis: []string{"Chat API"},
+		user:            true,
+		apis:            []string{"Chat API"},
+		serviceUsageIDs: []string{"chat.googleapis.com"},
 	},
 	ServiceClassroom: {
 		scopes: []string{
@@ -129,13 +133,15 @@ var serviceInfoByService = map[Service]serviceInfo{
 			"https://www.googleapis.com/auth/classroom.profile.emails",
 			"https://www.googleapis.com/auth/classroom.profile.photos",
 		},
-		user: true,
-		apis: []string{"Classroom API"},
+		user:            true,
+		apis:            []string{"Classroom API"},
+		serviceUsageIDs: []string{"classroom.googleapis.com"},
 	},
 	ServiceDrive: {
-		scopes: []string{"https://www.googleapis.com/auth/drive"},
-		user:   true,
-		apis:   []string{"Drive API"},
+		scopes:          []string{"https://www.googleapis.com/auth/drive"},
+		user:            true,
+		apis:            []string{"Drive API"},
+		serviceUsageIDs: []string{"drive.googleapis.com"},
 	},
 	ServiceDocs: {
 		// Docs commands are implemented via Drive APIs (export/copy/create),
@@ -144,9 +150,10 @@ var serviceInfoByService = map[Service]serviceInfo{
 			"https://www.googleapis.com/auth/drive",
 			"https://www.googleapis.com/auth/documents",
 		},
-		user: true,
-		apis: []string{"Docs API", "Drive API"},
-		note: "Export/copy/create via Drive",
+		user:            true,
+		apis:            []string{"Docs API", "Drive API"},
+		note:            "Export/copy/create via Drive",
+		serviceUsageIDs: []string{"docs.googleapis.com", "drive.googleapis.com"},
 	},
 	ServiceContacts: {
 		scopes: []string{
@@ -154,55 +161,63 @@ var serviceInfoByService = map[Service]serviceInfo{
 			"https://www.googleapis.com/auth/contacts.other.readonly",
 			"https://www.googleapis.com/auth/directory.readonly",
 		},
-		user: true,
-		apis: []string{"People API"},
-		note: "Contacts + other contacts + directory",
+		user:            true,
+		apis:            []string{"People API"},
+		note:            "Contacts + other contacts + directory",
+		serviceUsageIDs: []string{"people.googleapis.com"},
 	},
 	ServiceTasks: {
-		scopes: []string{"https://www.googleapis.com/auth/tasks"},
-		user:   true,
-		apis:   []string{"Tasks API"},
+		scopes:          []string{"https://www.googleapis.com/auth/tasks"},
+		user:            true,
+		apis:            []string{"Tasks API"},
+		serviceUsageIDs: []string{"tasks.googleapis.com"},
 	},
 	ServicePeople: {
 		// Needed for "people/me" requests.
-		scopes: []string{"profile"},
-		user:   true,
-		apis:   []string{"People API"},
-		note:   "OIDC profile scope",
+		scopes:          []string{"profile"},
+		user:            true,
+		apis:            []string{"People API"},
+		note:            "OIDC profile scope",
+		serviceUsageIDs: []string{"people.googleapis.com"},
 	},
 	ServiceSheets: {
 		scopes: []string{
 			"https://www.googleapis.com/auth/drive",
 			"https://www.googleapis.com/auth/spreadsheets",
 		},
-		user: true,
-		apis: []string{"Sheets API", "Drive API"},
-		note: "Export via Drive",
+		user:            true,
+		apis:            []string{"Sheets API", "Drive API"},
+		note:            "Export via Drive",
+		serviceUsageIDs: []string{"sheets.googleapis.com", "drive.googleapis.com"},
 	},
 	ServiceGroups: {
-		scopes: []string{"https://www.googleapis.com/auth/cloud-identity.groups.readonly"},
-		user:   false,
-		apis:   []string{"Cloud Identity API"},
-		note:   "Workspace only",
+		scopes:          []string{"https://www.googleapis.com/auth/cloud-identity.groups.readonly"},
+		user:            false,
+		apis:            []string{"Cloud Identity API"},
+		note:            "Workspace only",
+		serviceUsageIDs: []string{"cloudidentity.googleapis.com"},
 	},
 	ServiceKeep: {
-		scopes: []string{"https://www.googleapis.com/auth/keep.readonly"},
-		user:   false,
-		apis:   []string{"Keep API"},
-		note:   "Workspace only; service account (domain-wide delegation)",
+		scopes:          []string{"https://www.googleapis.com/auth/keep.readonly"},
+		user:            false,
+		apis:            []string{"Keep API"},
+		note:            "Workspace only; service account (domain-wide delegation)",
+		serviceUsageIDs: []string{"keep.googleapis.com"},
 	},
 	ServiceYoutube: {
-		scopes: []string{"https://www.googleapis.com/auth/youtube.readonly"},
-		user:   true,
-		apis:   []string{"YouTube Data API v3"},
+		scopes:          []string{"https://www.googleapis.com/auth/youtube.readonly"},
+		user:            true,
+		apis:            []string{"YouTube Data API v3"},
+		serviceUsageIDs: []string{"youtube.googleapis.com"},
 	},
 	ServiceBigquery: {
 		scopes: []string{
 			"https://www.googleapis.com/auth/bigquery",
 			"https://www.googleapis.com/auth/bigquery.readonly",
 		},
-		user: true,
-		apis: []string{"BigQuery API"},
+		user:            true,
+		apis:            []string{"BigQuery API"},
+		serviceUsageIDs: []string{"bigquery.googleapis.com"},
 	},
 	ServiceAnalytics: {
 		// manage.users* is required for accessBindings / adding users with roles.
@@ -214,17 +229,19 @@ var serviceInfoByService = map[Service]serviceInfo{
 			"https://www.googleapis.com/auth/analytics.manage.users.readonly",
 			"https://www.googleapis.com/auth/analytics.manage.users",
 		},
-		user: true,
-		apis: []string{"Analytics Data API", "Analytics Admin API"},
-		note: "Includes manage.users for accessBindings / invite users",
+		user:            true,
+		apis:            []string{"Analytics Data API", "Analytics Admin API"},
+		note:            "Includes manage.users for accessBindings / invite users",
+		serviceUsageIDs: []string{"analyticsdata.googleapis.com", "analyticsadmin.googleapis.com"},
 	},
 	ServiceSearchConsole: {
 		scopes: []string{
 			"https://www.googleapis.com/auth/webmasters.readonly",
 			"https://www.googleapis.com/auth/webmasters",
 		},
-		user: true,
-		apis: []string{"Search Console API"},
+		user:            true,
+		apis:            []string{"Search Console API"},
+		serviceUsageIDs: []string{"searchconsole.googleapis.com"},
 	},
 	ServiceTagManager: {
 		// readonly alone cannot manage users. manage.users is required for
@@ -237,14 +254,16 @@ var serviceInfoByService = map[Service]serviceInfo{
 			"https://www.googleapis.com/auth/tagmanager.manage.users",
 			"https://www.googleapis.com/auth/tagmanager.publish",
 		},
-		user: true,
-		apis: []string{"Tag Manager API v2"},
-		note: "Includes manage.users + edit/publish (not delete.containers)",
+		user:            true,
+		apis:            []string{"Tag Manager API v2"},
+		note:            "Includes manage.users + edit/publish (not delete.containers)",
+		serviceUsageIDs: []string{"tagmanager.googleapis.com"},
 	},
 	ServiceBusinessProfile: {
-		scopes: []string{"https://www.googleapis.com/auth/business.manage"},
-		user:   true,
-		apis:   []string{"Business Information API", "Business Account Management API"},
+		scopes:          []string{"https://www.googleapis.com/auth/business.manage"},
+		user:            true,
+		apis:            []string{"Business Information API", "Business Account Management API"},
+		serviceUsageIDs: []string{"mybusinessbusinessinformation.googleapis.com", "mybusinessaccountmanagement.googleapis.com"},
 	},
 }
 
@@ -356,11 +375,12 @@ func Scopes(service Service) ([]string, error) {
 }
 
 type ServiceInfo struct {
-	Service Service  `json:"service"`
-	User    bool     `json:"user"`
-	Scopes  []string `json:"scopes"`
-	APIs    []string `json:"apis,omitempty"`
-	Note    string   `json:"note,omitempty"`
+	Service         Service  `json:"service"`
+	User            bool     `json:"user"`
+	Scopes          []string `json:"scopes"`
+	APIs            []string `json:"apis,omitempty"`
+	ServiceUsageIDs []string `json:"service_usage_ids,omitempty"`
+	Note            string   `json:"note,omitempty"`
 }
 
 func ServicesInfo() []ServiceInfo {
@@ -372,15 +392,61 @@ func ServicesInfo() []ServiceInfo {
 		}
 
 		out = append(out, ServiceInfo{
-			Service: svc,
-			User:    info.user,
-			Scopes:  append([]string(nil), info.scopes...),
-			APIs:    append([]string(nil), info.apis...),
-			Note:    info.note,
+			Service:         svc,
+			User:            info.user,
+			Scopes:          append([]string(nil), info.scopes...),
+			APIs:            append([]string(nil), info.apis...),
+			ServiceUsageIDs: append([]string(nil), info.serviceUsageIDs...),
+			Note:            info.note,
 		})
 	}
 
 	return out
+}
+
+// ServiceUsageIDs returns the Google Service Usage API IDs required by service.
+func ServiceUsageIDs(service Service) ([]string, error) {
+	info, ok := serviceInfoByService[service]
+	if !ok {
+		return nil, errUnknownService
+	}
+
+	return append([]string(nil), info.serviceUsageIDs...), nil
+}
+
+// ServiceUsageIDsForServices returns a sorted, deduplicated union of Service
+// Usage IDs for the selected services. Empty input uses UserServices().
+func ServiceUsageIDsForServices(services []Service) ([]string, error) {
+	if len(services) == 0 {
+		services = UserServices()
+	}
+
+	set := make(map[string]struct{})
+
+	for _, svc := range services {
+		ids, err := ServiceUsageIDs(svc)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, id := range ids {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				continue
+			}
+
+			set[id] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+
+	sort.Strings(out)
+
+	return out, nil
 }
 
 func ServicesMarkdown(infos []ServiceInfo) string {

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -1,6 +1,9 @@
 package googleauth
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseService(t *testing.T) {
 	tests := []struct {
@@ -491,5 +494,118 @@ func TestScopes_GmailIncludesSettingsSharing(t *testing.T) {
 func TestScopes_UnknownService(t *testing.T) {
 	if _, err := Scopes(Service("nope")); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestServiceUsageIDs(t *testing.T) {
+	tests := []struct {
+		svc  Service
+		want []string
+	}{
+		{ServiceGmail, []string{"gmail.googleapis.com"}},
+		{ServiceCalendar, []string{"calendar-json.googleapis.com"}},
+		{ServiceDocs, []string{"docs.googleapis.com", "drive.googleapis.com"}},
+		{ServiceSheets, []string{"sheets.googleapis.com", "drive.googleapis.com"}},
+		{ServiceAnalytics, []string{"analyticsadmin.googleapis.com", "analyticsdata.googleapis.com"}},
+		{ServiceBusinessProfile, []string{"mybusinessaccountmanagement.googleapis.com", "mybusinessbusinessinformation.googleapis.com"}},
+	}
+
+	for _, tt := range tests {
+		got, err := ServiceUsageIDs(tt.svc)
+		if err != nil {
+			t.Fatalf("ServiceUsageIDs(%q): %v", tt.svc, err)
+		}
+
+		set := make(map[string]bool, len(got))
+		for _, id := range got {
+			set[id] = true
+		}
+
+		if len(got) != len(tt.want) {
+			t.Fatalf("ServiceUsageIDs(%q)=%v want %v", tt.svc, got, tt.want)
+		}
+
+		for _, id := range tt.want {
+			if !set[id] {
+				t.Fatalf("ServiceUsageIDs(%q) missing %q in %v", tt.svc, id, got)
+			}
+		}
+	}
+}
+
+func TestServiceUsageIDsForServices_DedupAndSort(t *testing.T) {
+	got, err := ServiceUsageIDsForServices([]Service{ServiceDocs, ServiceSheets, ServiceDrive})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	want := []string{"docs.googleapis.com", "drive.googleapis.com", "sheets.googleapis.com"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	}
+}
+
+func TestServiceUsageIDsForServices_EmptyUsesUserServices(t *testing.T) {
+	got, err := ServiceUsageIDsForServices(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(got) == 0 {
+		t.Fatalf("expected non-empty usage ids for user services")
+	}
+
+	for _, svc := range UserServices() {
+		ids, usageErr := ServiceUsageIDs(svc)
+		if usageErr != nil {
+			t.Fatalf("ServiceUsageIDs(%q): %v", svc, usageErr)
+		}
+
+		if len(ids) == 0 {
+			t.Fatalf("service %q has no usage ids", svc)
+		}
+	}
+
+	ids, keepErr := ServiceUsageIDs(ServiceKeep)
+	if keepErr != nil || len(ids) == 0 {
+		t.Fatalf("keep usage ids: %v %v", ids, keepErr)
+	}
+}
+
+func TestServiceUsageIDs_AllServicesPresent(t *testing.T) {
+	for _, svc := range AllServices() {
+		ids, err := ServiceUsageIDs(svc)
+		if err != nil {
+			t.Fatalf("%q: %v", svc, err)
+		}
+
+		if len(ids) == 0 {
+			t.Fatalf("%q: empty service usage ids", svc)
+		}
+
+		for _, id := range ids {
+			if id == "" || !strings.Contains(id, ".googleapis.com") {
+				t.Fatalf("%q: invalid id %q", svc, id)
+			}
+		}
+	}
+}
+
+func TestServicesInfo_IncludesServiceUsageIDs(t *testing.T) {
+	infos := ServicesInfo()
+	if len(infos) == 0 {
+		t.Fatalf("empty infos")
+	}
+
+	for _, info := range infos {
+		if len(info.ServiceUsageIDs) == 0 {
+			t.Fatalf("%s missing ServiceUsageIDs", info.Service)
+		}
 	}
 }

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -63,6 +63,7 @@ var (
 	errInvalidKeyringBackend = errors.New("invalid keyring backend")
 	errKeyringTimeout        = errors.New("keyring connection timed out")
 	errReadOnlyFileKeyring   = errors.New("file keyring directory does not exist; refusing to create it during read-only inspection")
+	errNoInputFilePassword   = errors.New("file keyring requires GOG_KEYRING_PASSWORD under --no-input")
 	openKeyringFunc          = openKeyring
 	keyringOpenFunc          = keyring.Open
 )
@@ -296,6 +297,18 @@ func openKeyringWithTimeout(cfg keyring.Config, timeout time.Duration) (keyring.
 			"set GOG_KEYRING_BACKEND=file and GOG_KEYRING_PASSWORD=<password> to use encrypted file storage instead",
 			errKeyringTimeout, timeout)
 	}
+}
+
+// OpenDefaultNoInput opens the token store without permitting a file-backend
+// password prompt. It is appropriate for inspection paths controlled by --no-input.
+func OpenDefaultNoInput() (Store, error) {
+	if info, err := ResolveKeyringBackendInfo(); err != nil {
+		return nil, err
+	} else if info.Value == "file" && os.Getenv(keyringPasswordEnv) == "" {
+		return nil, errNoInputFilePassword
+	}
+
+	return OpenDefault()
 }
 
 func OpenDefault() (Store, error) {

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -302,9 +302,14 @@ func openKeyringWithTimeout(cfg keyring.Config, timeout time.Duration) (keyring.
 // OpenDefaultNoInput opens the token store without permitting a file-backend
 // password prompt. It is appropriate for inspection paths controlled by --no-input.
 func OpenDefaultNoInput() (Store, error) {
-	if info, err := ResolveKeyringBackendInfo(); err != nil {
+	info, err := ResolveKeyringBackendInfo()
+	if err != nil {
 		return nil, err
-	} else if info.Value == "file" && os.Getenv(keyringPasswordEnv) == "" {
+	}
+	// On Linux without D-Bus, auto resolves to the file backend. Reject it
+	// before OpenDefault so a TTY never triggers TerminalPrompt under --no-input.
+	usesFile := info.Value == "file" || shouldForceFileBackend(runtime.GOOS, info, os.Getenv("DBUS_SESSION_BUS_ADDRESS"))
+	if usesFile && os.Getenv(keyringPasswordEnv) == "" {
 		return nil, errNoInputFilePassword
 	}
 


### PR DESCRIPTION
## Summary

- add a re-runnable `gog auth setup` workflow for gcloud readiness, project selection or creation, selected-service API enablement, OAuth Console guidance, Desktop credential installation, and first-account authorization
- preserve the multi-client credential model and refresh live Cloud/local state on every run, with bounded project discovery and project-scoped gcloud commands
- provide interactive, plain, and JSON contracts with typed stages, resumable blockers, shell-safe continuation commands, and non-interactive safeguards
- harden credential replacement so new credentials are written atomically before same-client token invalidation, with a durable reauthorization guard on partial failure
- document supported automation and the Google Auth Platform steps that remain Console-only

## Safety and non-goals

- does not change the active gcloud account, configuration, or default project
- does not inspect APIs across every discovered project; only the selected project is inspected
- does not automate Branding, Audience, Data Access, or ordinary Desktop OAuth client creation because Google exposes those steps through the Console rather than supported gcloud commands
- does not attach billing or perform OAuth verification

## Verification

- `go test -count=1 ./internal/googleauth ./internal/gcloud ./internal/config ./internal/secrets`
- `go test -count=1 ./internal/cmd -run 'AuthSetup|AuthAdd|AuthCredentials|CredentialReplacement'`
- `make ci`
- `git diff --check`
- Sol standards/spec and high-severity review gates completed; verified findings were corrected with Terra
- rebased onto latest `origin/main` and resolved integration conflicts with the required conflict-resolution workflow

Closes #158